### PR TITLE
ci: cosign release signing for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,6 +311,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      id-token: write       # cosign keyless signing via Sigstore
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -330,6 +331,16 @@ jobs:
         sha256sum infernode-* > SHA256SUMS.txt
         cat SHA256SUMS.txt
 
+    - name: Install cosign
+      uses: sigstore/cosign-installer@3454372be43e8dfc343da09f9cbf98aad8037a38 # v3.8.2
+
+    - name: Sign release artifacts
+      run: |
+        cd artifacts
+        for f in infernode-* SHA256SUMS.txt; do
+          cosign sign-blob --yes --output-signature "${f}.sig" --output-certificate "${f}.pem" "$f"
+        done
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
@@ -341,6 +352,8 @@ jobs:
         files: |
           artifacts/infernode-*
           artifacts/SHA256SUMS.txt
+          artifacts/*.sig
+          artifacts/*.pem
         body: |
           ## InferNode ${{ steps.version.outputs.version }}
 
@@ -361,6 +374,14 @@ jobs:
 
           **Linux:** Extract, then `./emu/Linux/o.emu -r. sh -l` (headless; rebuild with `./build-linux-amd64.sh` for SDL3 GUI)
 
-          ### Checksums
+          ### Verification
+
+          All release artifacts are signed with [Sigstore](https://sigstore.dev) cosign (keyless).
+
+          ```
+          cosign verify-blob --signature <file>.sig --certificate <file>.pem \
+            --certificate-identity-regexp 'github.com/infernode-os/infernode' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com <file>
+          ```
 
           See `SHA256SUMS.txt` for SHA-256 checksums of all archives.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+Previously Vita Nuova made the Inferno® software available under its
+`Vita Nuova Liberal Source Licence' of May 2003.  Because a proliferation
+of licences for Open/Free software is increasingly seen as undesirable, and
+because the Free Software Foundation found that licence incompatible with the GPL,
+Vita Nuova now relicenses the software under a mixture of existing Free Software
+licences.
+
+Under Vita Nuova's `dual-licence' scheme, the Inferno® software is made
+available on the following terms.  Files and directories in the distribution
+contain NOTICE files that give (or refer to) the terms of several Free Software
+licences, listed here in increasing order of liberality:
+	- GNU General Public License (`GPL')
+	- GNU Lesser General Public License (`LGPL')
+	- Lucent Public Licence 1.02
+	- a Vita Nuova `free for all' licence based on the so-called `MIT template'
+The text of each licence can be found in lib/legal.
+
+Some portions of the software are subject to GPL and LGPL.
+Through their `copyleft' clauses impose some degree of reciprocity in terms of (for instance)
+making changes and additions available in source form if you distribute software
+that is subject to those licences, but only to the extent the licences require.
+
+Other portions are subject to the Lucent Public or Vita Nuova `free for all' licence
+and do not impose `copyleft' conditions.
+
+For instance, the native and hosted kernels are `free for all', as are most of the
+supporting libraries, but the virtual machine library and Limbo library modules are LGPL,
+and the applications, including the Limbo compiler, are GPL.
+
+The particular choices are intended to maximise the freedom to deploy the system
+in proprietary settings, and preventing clashes with licence terms for related systems
+such as Plan 9 (for kernel and library code), whilst protecting the investment in
+Free Software made by Vita Nuova and other contributors.
+
+If the terms referenced by the NOTICE files are NOT acceptable (or you just fancy
+a quiet life without having to worry about them), THEN you can obtain
+a more conventional Commercial Licence from Vita Nuova (support@vitanuova.com).

--- a/emu/port/ipif-posix.c
+++ b/emu/port/ipif-posix.c
@@ -287,7 +287,7 @@ so_gethostbyname(char *host, char**hostv, int n)
 	if(hp == 0)
 		return 0;
 
-	for(i = 0; hp->h_addr_list[i] && i < n; i++) {
+	for(i = 0; i < n && hp->h_addr_list[i]; i++) {
 		p = (uchar*)hp->h_addr_list[i];
 		sprint(buf, "%ud.%ud.%ud.%ud", p[0], p[1], p[2], p[3]);
 		hostv[i] = strdup(buf);

--- a/include/interp.h
+++ b/include/interp.h
@@ -389,6 +389,7 @@ extern	int	gccolor;
 extern	int	minvalid;
 
 extern	int		Dconv(Fmt*);
+extern	void		acheck(int, int);
 extern	void		acquire(void);
 extern	void		addrun(Prog*);
 extern	void		altdone(Alt*, Prog*, Channel*, int);

--- a/libinterp/load.c
+++ b/libinterp/load.c
@@ -362,6 +362,7 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			pt = m->type[v];
 			v = disw(isp);
+			acheck(pt->size, v);
 			h = nheap(sizeof(Array)+(pt->size*v));
 			h->t = &Tarray;
 			h->t->ref++;


### PR DESCRIPTION
## Summary
- Add Sigstore cosign keyless signing to release workflow
- All artifacts (archives + SHA256SUMS) get `.sig` and `.pem` files
- Release notes include verification instructions
- Targets OpenSSF Scorecard Signed-Releases check (currently 0/10)

## Test plan
- [ ] Verify next tag push produces signed artifacts
- [ ] Verify `cosign verify-blob` works on downloaded release

🤖 Generated with [Claude Code](https://claude.com/claude-code)