### PR TITLE
fix(build): recompile devprof when runt.h changes

### DIFF
--- a/emu/port/portmkfile
+++ b/emu/port/portmkfile
@@ -133,6 +133,7 @@ devroot.$O:	errstr.h
 latin1.$O:	../port/latin1.h
 netif.$O:	../port/netif.h
 devprog.$O:	$RUNT
+devprof.$O:	$RUNT
 devsrv.$O:	$RUNT
 exception.$O:	$RUNT
 inferno.$O:	$RUNT


### PR DESCRIPTION
`devprof.c` includes `runt.h` but the `emu/port/portmkfile` rules did
   not declare `devprof.$O: $RUNT`. When `runt.h` regenerates, `devprof.$O` is not rebuilt, so the emulator can end up     
  linked against a stale `devprof` object.
                                                                                                                           
  This adds the missing dependency alongside the existing `devprog.$O: $RUNT` / `devsrv.$O: $RUNT` entries.              
                                                                                                                           
  Companion to the downstream fix in NERVsystems/infernode#163 — same dependency gap exists here.