### PR TITLE
docs: introduce harness/agent terminology distinction

### DIFF
--- a/appl/veltro/SECURITY.md
+++ b/appl/veltro/SECURITY.md
@@ -4,7 +4,24 @@
 
 Veltro uses Inferno OS namespace isolation to create secure environments for AI agents. The core primitive is `restrictdir(target, allowed, writable)`: create a shadow directory containing only allowed items, then bind-replace the target. Anything not in the allowlist becomes invisible. The `writable` flag adds `MCREATE` to the final bind, needed for `/tmp` so agents can create files there.
 
-Three entry points apply namespace restriction:
+### Terminology
+
+This document distinguishes:
+
+- **Harness** — the namespace-restriction machinery itself: `nsconstruct`,
+  `tools9p`, `lucibridge`, and the `veltro`/`repl`/`spawn` entry points that
+  call `restrictns(caps)`. The harness defines what an agent *can* do.
+- **Agent** — a running process executing the harness loop with a model and a
+  capability set. Each `repl`, `veltro`, `lucibridge`, or `spawn`'d child is a
+  separate agent with its own restricted namespace.
+- **Subagent** — an agent created by another agent via the `spawn` tool.
+  Subagents inherit an already-restricted namespace and can only narrow it
+  further (capability attenuation).
+
+The security model applies to **agents**: the harness restricts what each
+running instance sees. The harness itself is trusted code.
+
+Three harness entry points apply namespace restriction:
 
 | Entry Point | Where | When |
 |-------------|-------|------|
@@ -66,7 +83,7 @@ Both levels use the same `restrictdir()` primitive. Capability attenuation is na
 
 ## Namespace After Restriction
 
-### Parent Agent (tools9p / repl)
+### Parent agent (started via `tools9p` / `repl` harness entry points)
 
 ```
 /

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,8 +61,9 @@ Host OS (macOS / Linux / Windows)
 
 ### tools9p (`appl/veltro/tools9p.b`)
 
-The shared configuration and execution server for the agent stack. Both the GUI (lucictx)
-and the agent bridge (lucibridge) interact with it as their common intermediary.
+A harness component: the shared configuration and execution server that running agents
+dispatch tool calls through. Both the GUI (lucictx) and the GUI-side harness bridge
+(lucibridge) interact with it as their common intermediary.
 
 Filesystem layout at `/tool`:
 
@@ -86,7 +87,8 @@ Key design properties:
 
 ### lucibridge (`appl/cmd/lucibridge.b`)
 
-The agent bridge: connects the GUI conversation UI to the LLM.
+The GUI-side harness bridge: connects the GUI conversation UI to the LLM and runs the
+agent loop for that session.
 
 - Runs in background, started by Lucifer
 - Reads user input from `/n/ui/activity/{id}/conversation/input`

--- a/docs/NAMESPACE_SECURITY_REVIEW.md
+++ b/docs/NAMESPACE_SECURITY_REVIEW.md
@@ -2,7 +2,9 @@
 
 ## Executive Summary
 
-Veltro is an AI agent for Inferno OS where **namespace IS the capability system**. This document compares two approaches for implementing namespace-based security when spawning subagents with restricted capabilities.
+Veltro is an agent harness for Inferno OS where **namespace IS the capability system**. The harness (`nsconstruct`, `tools9p`, `lucibridge`, and the `veltro`/`repl`/`spawn` entry points) restricts what each running agent can see; agents themselves are running harness instances with a model and a capability set. See the README "Terminology" section for the full model/harness/agent/subagent distinction.
+
+This document compares two approaches for implementing namespace-based security when spawning subagents with restricted capabilities.
 
 **Approaches under consideration:**
 1. **NEWNS + Build Up**: Start with empty namespace, construct only what's granted
@@ -16,7 +18,7 @@ We seek expert review on security properties, implementation feasibility, and po
 
 ### 1.1 What is Veltro?
 
-Veltro is an AI agent that runs inside Inferno OS. It:
+Veltro is an agent harness that runs inside Inferno OS. A *running agent* (a `repl`, `veltro`, `lucibridge`, or `spawn`'d child) drives the harness loop and:
 - Receives tasks from users or parent agents
 - Has access to tools (read, write, list, find, search, edit, exec, spawn)
 - Can spawn subagents with **attenuated capabilities**

--- a/docs/OPERATIONAL-OVERVIEW.md
+++ b/docs/OPERATIONAL-OVERVIEW.md
@@ -12,15 +12,17 @@ Inferno OS running as a native process on macOS ARM64, with a working JIT compil
 
 **tools9p** is a 9P file server mounted at `/tool`. It registers tool modules and serves them as a filesystem: `/tool/tools` (what's active), `/tool/paths` (namespace paths), `/tool/ctl` (add/remove tools, bind/unbind paths). This is the unified configuration store — both the GUI and the agent bridge write here.
 
-**Veltro** (`appl/veltro/veltro.b`) is the CLI agent. You give it a task and a tool set; it forks a restricted namespace, calls tools in a loop via the LLM, and terminates when done. It runs one-shot or as a REPL.
+**Veltro** (`appl/veltro/veltro.b`) is the CLI harness entry point. You give it a task and a tool set; the running agent forks a restricted namespace, calls tools in a loop via the LLM, and terminates when done. It runs one-shot or as a REPL.
 
-**lucibridge** is the agent bridge for the GUI session. It runs in the background, connects Lucifer's conversation UI to the LLM, re-reads tool and path state at the start of each agent turn, and handles slash commands (`/bind`, `/unbind`, `/tools +/-name`) for interactive namespace management.
+**lucibridge** is the GUI-side harness bridge. It runs in the background, connects Lucifer's conversation UI to the LLM, re-reads tool and path state at the start of each agent turn, and handles slash commands (`/bind`, `/unbind`, `/tools +/-name`) for interactive namespace management.
+
+(See the README "Terminology" section for the harness/agent distinction.)
 
 ---
 
 ## The Tools
 
-The agent has tools registered by default:
+A running agent has tools registered by default:
 
 | Category | Tools |
 |----------|-------|

--- a/docs/USER-MANUAL.md
+++ b/docs/USER-MANUAL.md
@@ -18,7 +18,7 @@ A practical guide to using InferNode, the AI-agent-friendly operating system.
 10. [The Login Screen](#the-login-screen)
 11. [The Text Editor](#the-text-editor)
 12. [Wallet and Payments](#wallet-and-payments)
-13. [Security and AI Agent Isolation](#security-and-ai-agent-isolation)
+13. [Security and Agent Namespace Isolation](#security-and-agent-namespace-isolation)
 14. [Common Tasks](#common-tasks)
 15. [Troubleshooting](#troubleshooting)
 
@@ -744,13 +744,13 @@ See [docs/WALLET-AND-PAYMENTS.md](WALLET-AND-PAYMENTS.md) for the full architect
 
 ---
 
-## Security and AI Agent Isolation
+## Security and Agent Namespace Isolation
 
 ### The Namespace is the Security Boundary
 
-InferNode's security model is simple: **a process can only access what's in its namespace**.
+InferNode's security model is simple: **a process can only access what's in its namespace**. The Veltro harness uses this primitive to sandbox each running agent — see the README "Terminology" section for the harness/agent distinction.
 
-An AI agent running in a restricted namespace:
+A running agent in a restricted namespace:
 ```
 /
 ├── mnt/


### PR DESCRIPTION
## Summary

Adds a Terminology block to `appl/veltro/SECURITY.md` and sweeps the high-traffic technical docs to use:

- **Harness** — the runtime machinery (lucibridge, tools9p, nsconstruct, veltro/repl entry points). What Veltro *is*.
- **Agent** — a *running* harness instance pursuing a task. What you get when the harness is executing.
- **Subagent** — a child agent created via the `spawn` tool, with attenuated capabilities.

This resolves a conflation in the previous prose where "Veltro is an AI agent" was used for both the framework itself and a single running session.

Files touched (5 — no README): `appl/veltro/SECURITY.md`, `docs/NAMESPACE_SECURITY_REVIEW.md`, `docs/OPERATIONAL-OVERVIEW.md`, `docs/ARCHITECTURE.md`, `docs/USER-MANUAL.md`.

### Note on README

The original upstream cherry-pick (NERVsystems/infernode `29f8c3a8`) also touched `README.md` to add a Terminology block under the "Veltro - AI Agent System" section. After upstream's recent README simplification (efac2d07 onward), that section no longer exists in this README, so the README portion of the original commit has been **dropped** and is not part of this PR. The technical docs touched here still benefit from the cleanup.

## Test plan

- [ ] Confirm `appl/veltro/SECURITY.md` has a "Terminology" block under Overview defining harness / agent / subagent
- [ ] Confirm `docs/USER-MANUAL.md` §13 is renamed to "Security and Agent Namespace Isolation" (TOC + heading)
- [ ] Confirm `docs/OPERATIONAL-OVERVIEW.md` describes `veltro` and `lucibridge` as harness entry points (not "the agent")
- [ ] Confirm `docs/NAMESPACE_SECURITY_REVIEW.md` exec-summary opens with "Veltro is an agent harness"
- [ ] Confirm `docs/ARCHITECTURE.md` tools9p / lucibridge sections are tightened to call them harness components

🤖 Generated with [Claude Code](https://claude.com/claude-code)