### PR TITLE
Use headercol for chrome separator lines instead of bordercol

### DIFF
--- a/appl/cmd/lucifer.b
+++ b/appl/cmd/lucifer.b
@@ -767,9 +767,10 @@ drawchrome(r: Rect)
 		}
 	}
 
-	# Header/zone separator
+	# Header/zone separator — drawn with headercol so it blends with the
+	# header bar above instead of standing out as a brighter line.
 	zonety := r.min.y + headerh + 1;
-	mainwin.draw(Rect((r.min.x, zonety - 1), (r.max.x, zonety)), bordercol, nil, (0, 0));
+	mainwin.draw(Rect((r.min.x, zonety - 1), (r.max.x, zonety)), headercol, nil, (0, 0));
 
 	# Zone width calculations (must match zonerects)
 	w := r.dx();
@@ -778,9 +779,10 @@ drawchrome(r: Rect)
 	presx := r.min.x + convw;
 	ctxx  := presx + presw;
 
-	# Zone separator lines (1px vertical)
-	mainwin.draw(Rect((presx, zonety), (presx + 1, r.max.y)), bordercol, nil, (0, 0));
-	mainwin.draw(Rect((ctxx,  zonety), (ctxx + 1,  r.max.y)), bordercol, nil, (0, 0));
+	# Zone separator lines (1px vertical) — headercol matches the subdued
+	# grey used for the header bar, keeping the chrome unobtrusive.
+	mainwin.draw(Rect((presx, zonety), (presx + 1, r.max.y)), headercol, nil, (0, 0));
+	mainwin.draw(Rect((ctxx,  zonety), (ctxx + 1,  r.max.y)), headercol, nil, (0, 0));
 
 	mainwin.flush(Draw->Flushnow);
 }


### PR DESCRIPTION
## Summary

Changes the color of the header/zone separator and vertical zone divider lines from `bordercol` to `headercol` to create a more cohesive, subdued chrome design that blends with the header bar instead of standing out as bright lines.

## Changes

- Changed header/zone separator line color from `bordercol` to `headercol`
- Changed vertical zone separator lines (between presentation and context zones) from `bordercol` to `headercol`
- Updated comments to explain the rationale for using `headercol` for a more unobtrusive appearance

## Testing

No testing needed — this is a visual styling change that affects only the color of UI chrome elements.

## Checklist

- [x] Code follows the existing style of the file(s) modified
- [x] No `.dis` build artifacts committed
- [x] Documentation updated (comments clarified)
- [x] No secrets, API keys, or credentials included

https://claude.ai/code/session_01PCn5S4ByTNMZUp6fMHbCt7