### PR TITLE
Add comprehensive test coverage for Veltro tools and security boundaries

### DIFF
--- a/tests/lucibridge_approval_test.b
+++ b/tests/lucibridge_approval_test.b
@@ -1,0 +1,435 @@
+implement LucibridgeApprovalTest;
+
+#
+# lucibridge_approval_test.b - Tests for needsapproval(), the security gate
+# that decides which agent tool calls require explicit user consent.
+#
+# This is the most safety-relevant pure function in lucibridge.b.  It runs
+# before EVERY tool call (in pretoolapproval) and gates whether the agent's
+# request reaches the tool or pauses for an Allow/Deny dialogue.  A bug
+# here means either:
+#
+#   - false negatives: dangerous calls slip past approval (the bad case)
+#   - false positives: agent is blocked on every read, UX collapses
+#
+# The function is small but has subtle rules.  We re-implement it locally
+# here (matching lucibridge_test.b's pattern) and pin the contract:
+#
+#   exec  ──  rm -r outside /tmp           → require approval
+#         ──  rm -r /tmp/...               → no approval (sandbox cleanup)
+#         ──  bind/mount/unmount anything  → require approval (ns mutation)
+#         ──  anything else                → no approval
+#   write ──  /dis/...  /lib/...  /dev/... → require approval (system files)
+#         ──  /tmp/... or /home/... etc.   → no approval
+#   edit  ──  same rules as write
+#   read/list/find/...                     → never require approval
+#
+# Also tested:
+#   - firstlines(): preview truncation of large tool results.
+#     Used by lucibridge to inline a small preview into the LLM context;
+#     getting "n" wrong leaks bytes or starves the model of context.
+#
+# To run: cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/lucibridge_approval_test.dis
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+LucibridgeApprovalTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/lucibridge_approval_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	"*" =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# ============================================================================
+# Local copies of lucibridge / agentlib helpers.
+#
+# These mirror the production implementations:
+#   - lucibridge.b: needsapproval, firstlines
+#   - agentlib.b:   contains, hasprefix
+#
+# If you change the production behaviour, change these too.
+# ============================================================================
+
+# agentlib->contains
+contains(s, sub: string): int
+{
+	if(len sub > len s)
+		return 0;
+	for(i := 0; i <= len s - len sub; i++) {
+		if(s[i:i+len sub] == sub)
+			return 1;
+	}
+	return 0;
+}
+
+# agentlib->hasprefix
+hasprefix(s, pfx: string): int
+{
+	return len s >= len pfx && s[0:len pfx] == pfx;
+}
+
+# lucibridge->needsapproval
+#
+# Mirrors the implementation at /appl/cmd/lucibridge.b:396.
+needsapproval(toolname, args: string): int
+{
+	if(toolname != "exec" && toolname != "write" && toolname != "edit")
+		return 0;
+	if(toolname == "exec") {
+		if(contains(args, "rm") && contains(args, "-r")) {
+			if(!hasprefix(args, "rm") || !contains(args, "/tmp"))
+				return 1;
+		}
+		if(contains(args, "bind ") || contains(args, "mount ") ||
+		   contains(args, "unmount "))
+			return 1;
+	}
+	if(toolname == "write" || toolname == "edit") {
+		if(hasprefix(args, "/dis/") || hasprefix(args, "/lib/") ||
+		   hasprefix(args, "/dev/"))
+			return 1;
+	}
+	return 0;
+}
+
+# lucibridge->firstlines
+firstlines(s: string, n: int): string
+{
+	out := "";
+	count := 0;
+	for(i := 0; i < len s && count < n; i++) {
+		out[len out] = s[i];
+		if(s[i] == '\n')
+			count++;
+	}
+	return out;
+}
+
+# ============================================================================
+# Read-class tools never require approval
+# ============================================================================
+
+testReadNeverApproval(t: ref T)
+{
+	t.asserteq(needsapproval("read", "/etc/passwd"), 0,
+		"read of any path ok without approval");
+	t.asserteq(needsapproval("read", "/dis/sh.dis"), 0,
+		"read of /dis/sh.dis ok");
+	t.asserteq(needsapproval("list", "/"), 0,
+		"list / ok without approval");
+	t.asserteq(needsapproval("find", "/dis -name *"), 0,
+		"find ok without approval");
+	t.asserteq(needsapproval("search", "password /lib"), 0,
+		"search ok without approval");
+}
+
+# ============================================================================
+# exec: rm -r rules
+# ============================================================================
+
+testExecRmRfRootRequiresApproval(t: ref T)
+{
+	# The classic dangerous case
+	t.asserteq(needsapproval("exec", "rm -rf /"), 1,
+		"rm -rf / requires approval");
+	t.asserteq(needsapproval("exec", "rm -rf /home/user"), 1,
+		"rm -rf /home/user requires approval");
+}
+
+testExecRmInTmpAllowed(t: ref T)
+{
+	# Cleanup inside the sandbox is allowed without prompting — the agent
+	# uses /tmp/veltro/scratch heavily and prompting for every cleanup
+	# would render the agent unusable.
+	t.asserteq(needsapproval("exec", "rm -rf /tmp/scratch"), 0,
+		"rm -rf inside /tmp ok");
+	t.asserteq(needsapproval("exec", "rm -r /tmp/veltro/foo"), 0,
+		"rm -r inside /tmp ok");
+}
+
+testExecRmEmbeddedInPipelineRequiresApproval(t: ref T)
+{
+	# 'rm' is not the first word — the !hasprefix guard catches this.
+	# The shell would still execute it, so it must require approval.
+	t.asserteq(needsapproval("exec", "ls /tmp; rm -r /home/user/data"), 1,
+		"rm -r in shell pipeline (not first cmd) requires approval");
+}
+
+testExecRmWithoutDashRAllowed(t: ref T)
+{
+	# rm without -r doesn't trigger the rule (rm of single files isn't
+	# considered as dangerous as recursive deletion)
+	t.asserteq(needsapproval("exec", "rm /tmp/file"), 0,
+		"rm without -r in /tmp ok");
+	# But check the special case: if "rm" appears but "-r" doesn't, the
+	# whole gate is skipped.
+	t.asserteq(needsapproval("exec", "rm /home/user/file"), 0,
+		"rm without -r outside /tmp ok (rule only catches -r)");
+}
+
+# ============================================================================
+# exec: namespace mutation requires approval
+# ============================================================================
+
+testExecBindRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("exec", "bind /n/local/tmp /tmp"), 1,
+		"bind requires approval");
+}
+
+testExecMountRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("exec", "mount -c #s/srv /n/foo"), 1,
+		"mount requires approval");
+}
+
+testExecUnmountRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("exec", "unmount /n/foo"), 1,
+		"unmount requires approval");
+}
+
+testExecBindWithoutSpaceAllowed(t: ref T)
+{
+	# The rule looks for "bind " (with trailing space) — words like
+	# "rebind" or "binds" must not match.  This is a deliberate check
+	# for the keyword-as-command form.
+	t.asserteq(needsapproval("exec", "echo hello rebinds the keyboard"), 0,
+		"'rebinds' isn't bind");
+	t.asserteq(needsapproval("exec", "echo mounted today"), 0,
+		"'mounted' isn't mount");
+}
+
+testExecOrdinaryCommandsAllowed(t: ref T)
+{
+	# Most exec calls should sail through without prompting
+	t.asserteq(needsapproval("exec", "ls /"), 0, "ls ok");
+	t.asserteq(needsapproval("exec", "cat /tmp/x"), 0, "cat ok");
+	t.asserteq(needsapproval("exec", "echo hello"), 0, "echo ok");
+	t.asserteq(needsapproval("exec", "wc -l /tmp/file"), 0, "wc ok");
+}
+
+# ============================================================================
+# write/edit: system path protection
+# ============================================================================
+
+testWriteToDisRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("write", "/dis/sh.dis hello"), 1,
+		"write to /dis requires approval");
+	t.asserteq(needsapproval("edit", "/dis/sh.dis old new"), 1,
+		"edit /dis requires approval");
+}
+
+testWriteToLibRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("write", "/lib/veltro/system.txt new prompt"), 1,
+		"write to /lib requires approval");
+	t.asserteq(needsapproval("edit", "/lib/veltro/system.txt old new"), 1,
+		"edit /lib requires approval");
+}
+
+testWriteToDevRequiresApproval(t: ref T)
+{
+	t.asserteq(needsapproval("write", "/dev/cons hi"), 1,
+		"write to /dev requires approval");
+	t.asserteq(needsapproval("edit", "/dev/cons old new"), 1,
+		"edit /dev requires approval");
+}
+
+testWriteToTmpAllowed(t: ref T)
+{
+	t.asserteq(needsapproval("write", "/tmp/scratch.txt hello"), 0,
+		"write to /tmp ok");
+	t.asserteq(needsapproval("edit", "/tmp/scratch.txt old new"), 0,
+		"edit /tmp ok");
+}
+
+testWriteToHomeAllowed(t: ref T)
+{
+	# /home, /n/local, /usr — all sandbox-y or user-grant paths
+	t.asserteq(needsapproval("write", "/home/user/file hello"), 0,
+		"write to /home ok");
+	t.asserteq(needsapproval("write", "/n/local/Users/x hello"), 0,
+		"write to /n/local ok");
+}
+
+testWriteRelativePathAllowed(t: ref T)
+{
+	# Relative paths can't reach /dis, /lib, /dev (the gate is path-prefix
+	# based), so they're allowed.  This pins that behaviour — any change
+	# would be a security-relevant policy shift.
+	t.asserteq(needsapproval("write", "scratch.txt hello"), 0,
+		"write to relative path ok");
+}
+
+# ============================================================================
+# Other tools never require approval
+# ============================================================================
+
+testOtherToolsNeverApproval(t: ref T)
+{
+	# Tools not in the {exec, write, edit} set should always return 0.
+	t.asserteq(needsapproval("spawn", "tools=write -- write /dis/x"), 0,
+		"spawn never requires approval (gating happens inside spawn)");
+	t.asserteq(needsapproval("safeexec", "write /dis/x"), 0,
+		"safeexec never requires approval at this layer");
+	t.asserteq(needsapproval("plan", "make a plan"), 0,
+		"plan never requires approval");
+	t.asserteq(needsapproval("memory", "save k v"), 0,
+		"memory ops never require approval");
+}
+
+# ============================================================================
+# firstlines: preview truncation
+# ============================================================================
+
+testFirstlinesShorterThanBuffer(t: ref T)
+{
+	r := firstlines("a\nb\nc\n", 10);
+	t.assertseq(r, "a\nb\nc\n",
+		"input shorter than n returned in full");
+}
+
+testFirstlinesExactN(t: ref T)
+{
+	# Exactly n newlines: returns up to and including the nth newline.
+	# This matches the production implementation: count++ happens when
+	# s[i] == '\n', and the loop exits when count >= n at the next
+	# iteration.
+	r := firstlines("a\nb\nc\nd\n", 3);
+	t.assertseq(r, "a\nb\nc\n",
+		"first 3 lines returned with terminating newline");
+}
+
+testFirstlinesTrunc(t: ref T)
+{
+	r := firstlines("a\nb\nc\nd\ne\nf\n", 2);
+	t.assertseq(r, "a\nb\n",
+		"truncated to first 2 lines");
+}
+
+testFirstlinesZero(t: ref T)
+{
+	r := firstlines("a\nb\nc\n", 0);
+	t.assertseq(r, "",
+		"n=0 returns empty string");
+}
+
+testFirstlinesNoNewlines(t: ref T)
+{
+	# A tool result with no terminating newline: returns the whole string
+	r := firstlines("oneline", 5);
+	t.assertseq(r, "oneline",
+		"no newlines returns whole string");
+}
+
+testFirstlinesEmptyInput(t: ref T)
+{
+	r := firstlines("", 5);
+	t.assertseq(r, "",
+		"empty input returns empty string");
+}
+
+testFirstlinesPreservesContent(t: ref T)
+{
+	# Non-ascii / special chars within the kept lines must survive
+	r := firstlines("hello world\ntab\there\n", 1);
+	t.assertseq(r, "hello world\n",
+		"first line preserves spaces");
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	# Read-class tools
+	run("ReadNeverApproval", testReadNeverApproval);
+
+	# exec rm rules
+	run("ExecRmRfRootRequiresApproval", testExecRmRfRootRequiresApproval);
+	run("ExecRmInTmpAllowed", testExecRmInTmpAllowed);
+	run("ExecRmEmbeddedInPipelineRequiresApproval", testExecRmEmbeddedInPipelineRequiresApproval);
+	run("ExecRmWithoutDashRAllowed", testExecRmWithoutDashRAllowed);
+
+	# exec ns mutation
+	run("ExecBindRequiresApproval", testExecBindRequiresApproval);
+	run("ExecMountRequiresApproval", testExecMountRequiresApproval);
+	run("ExecUnmountRequiresApproval", testExecUnmountRequiresApproval);
+	run("ExecBindWithoutSpaceAllowed", testExecBindWithoutSpaceAllowed);
+	run("ExecOrdinaryCommandsAllowed", testExecOrdinaryCommandsAllowed);
+
+	# write / edit system-path protection
+	run("WriteToDisRequiresApproval", testWriteToDisRequiresApproval);
+	run("WriteToLibRequiresApproval", testWriteToLibRequiresApproval);
+	run("WriteToDevRequiresApproval", testWriteToDevRequiresApproval);
+	run("WriteToTmpAllowed", testWriteToTmpAllowed);
+	run("WriteToHomeAllowed", testWriteToHomeAllowed);
+	run("WriteRelativePathAllowed", testWriteRelativePathAllowed);
+
+	# Tools outside the gated set
+	run("OtherToolsNeverApproval", testOtherToolsNeverApproval);
+
+	# firstlines
+	run("FirstlinesShorterThanBuffer", testFirstlinesShorterThanBuffer);
+	run("FirstlinesExactN", testFirstlinesExactN);
+	run("FirstlinesTrunc", testFirstlinesTrunc);
+	run("FirstlinesZero", testFirstlinesZero);
+	run("FirstlinesNoNewlines", testFirstlinesNoNewlines);
+	run("FirstlinesEmptyInput", testFirstlinesEmptyInput);
+	run("FirstlinesPreservesContent", testFirstlinesPreservesContent);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -62,6 +62,9 @@ TARG=\
 	widget_kbdfilter_test.dis\
 	widget_scrollbar_test.dis\
 	veltro_concurrent_test.dis\
+	veltro_launch_test.dis\
+	veltro_more_tools_test.dis\
+	veltro_safeexec_test.dis\
 	veltro_security_test.dis\
 	veltro_test.dis\
 	veltro_tools_test.dis\
@@ -86,6 +89,7 @@ TARG=\
 	fractal_tool_test.dis\
 	menu_test.dis\
 	wm_apps_test.dis\
+	lucibridge_approval_test.dis\
 	lucibridge_test.dis\
 	lucifer_helpers_test.dis\
 

--- a/tests/veltro_launch_test.b
+++ b/tests/veltro_launch_test.b
@@ -1,0 +1,352 @@
+implement VeltroLaunchTest;
+
+#
+# veltro_launch_test.b - Tests for the Launch tool
+#
+# Launch is the agent's only path for starting GUI applications inside
+# Lucifer's presentation zone.  Its exec() does several security-relevant
+# things before ever talking to luciuisrv:
+#
+#   1. Normalizes the app name (strips /dis/wm/, wm/, .dis suffix)
+#   2. Rejects names that still contain '/' after normalization (path-escape
+#      defense — agents can't reach /dis/auth/factotum.dis or similar)
+#   3. Rejects Tk-only apps that aren't built into emu (clear error rather
+#      than a confusing runtime failure)
+#   4. Rejects apps not in /dis/wm/ unless explicitly whitelisted
+#      (extraapp() — currently only xenith)
+#   5. "list" enumerates non-Tk /dis/wm/ apps + the explicit whitelist
+#
+# These tests exercise the parser + whitelist directly via the loaded
+# module.  They run without lucifer/luciuisrv being up — most of the
+# validation completes (and rejects bad input) before that mount is touched.
+# Tests that would require luciuisrv assert that the validation phase
+# either succeeds enough to reach the "cannot reach presentation zone"
+# error, or short-circuits before then.
+#
+# To run: cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_launch_test.dis
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+# Tool interface (matches /appl/veltro/tool.m)
+Tool: module {
+	init: fn(): string;
+	name: fn(): string;
+	doc:  fn(): string;
+	exec: fn(args: string): string;
+};
+
+VeltroLaunchTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/veltro_launch_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	"*" =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+loadlaunch(t: ref T): Tool
+{
+	tool := load Tool "/dis/veltro/tools/launch.dis";
+	if(tool == nil) {
+		t.skip("cannot load launch.dis");
+		return nil;
+	}
+	err := tool->init();
+	if(err != nil) {
+		t.skip("launch init failed: " + err);
+		return nil;
+	}
+	return tool;
+}
+
+# ============================================================================
+# Identity
+# ============================================================================
+
+testNameAndDoc(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "launch", "name() returns 'launch'");
+
+	doc := tool->doc();
+	t.assert(len doc > 0, "doc() is non-empty");
+	t.assert(hassubstr(doc, "Launch"), "doc mentions Launch");
+	t.assert(hassubstr(doc, "list"), "doc mentions 'list' subcommand");
+	t.assert(hassubstr(doc, "presentation"), "doc mentions presentation zone");
+}
+
+# ============================================================================
+# 'list' — enumerates available apps
+# ============================================================================
+
+testListApps(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	r := tool->exec("list");
+	# /dis/wm should always exist in the runtime tree
+	if(hassubstr(r, "cannot open /dis/wm")) {
+		t.skip("/dis/wm not present in runtime tree");
+		return;
+	}
+
+	# Either "no apps available" or "<N> apps available"
+	t.assert(hassubstr(r, "apps available") || hassubstr(r, "no apps"),
+		"list returns app summary");
+
+	# Common apps should appear
+	t.assert(hassubstr(r, "clock") || hassubstr(r, "date"),
+		"common /dis/wm apps appear in list");
+}
+
+testEmptyArgsListsApps(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# Empty args is documented to behave like 'list'
+	r := tool->exec("");
+	t.assert(hassubstr(r, "apps available") || hassubstr(r, "no apps"),
+		"empty args lists apps");
+}
+
+# ============================================================================
+# Tk-app rejection: apps that need Tk (not built into this emu) are
+# rejected with a helpful message rather than spawning and failing.
+# ============================================================================
+
+testRejectsTkApps(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# Each of these is in the istk() whitelist
+	tkapps := array[] of {"task", "tetris", "sh", "ftree", "deb"};
+	for(i := 0; i < len tkapps; i++) {
+		r := tool->exec(tkapps[i]);
+		t.assert(hassubstr(r, "Tk"),
+			tkapps[i] + " rejection mentions Tk");
+		t.assert(hassubstr(r, "error"),
+			tkapps[i] + " rejected as error");
+	}
+}
+
+# ============================================================================
+# Unknown apps are rejected
+# ============================================================================
+
+testRejectsUnknownApp(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# An app that doesn't exist in /dis/wm/ and isn't whitelisted
+	r := tool->exec("definitelynotrealapp");
+	t.assert(hassubstr(r, "not found") || hassubstr(r, "error"),
+		"unknown app rejected");
+}
+
+# ============================================================================
+# Path-traversal defenses
+#
+# After normalization (strip /dis/wm/, wm/, .dis), the residual name is
+# checked for '/'.  Any survivor is a normalization gap and rejected.
+# These tests probe both pre- and post-normalization escape attempts.
+# ============================================================================
+
+testRejectsAbsolutePathOutsideWm(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# A /dis/auth/... path: stripping the leading /dis/wm/ fails (no match),
+	# then the loop strips up to the last '/'.  After stripping, "factotum"
+	# remains — it has no .dis in /dis/wm/ and isn't whitelisted.
+	r := tool->exec("/dis/auth/factotum");
+	t.assert(hassubstr(r, "not found") || hassubstr(r, "error"),
+		"path outside /dis/wm/ rejected");
+}
+
+testRejectsRelativePath(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# "../something" — after the path-strip loop, only "something" remains
+	r := tool->exec("../something");
+	t.assert(hassubstr(r, "error") || hassubstr(r, "not found"),
+		"relative path traversal rejected");
+}
+
+# ============================================================================
+# Name normalization: many forms of the same app name should resolve
+# to the same .dis target.  We use 'clock' which is reliably in /dis/wm/.
+# When luciuisrv isn't running, the validation phase passes but the
+# eventual presentation/ctl open fails with a recognisable error.
+# ============================================================================
+
+testNormalizationFullPath(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# /dis/wm/clock.dis — full canonical form
+	(ok, nil) := sys->stat("/dis/wm/clock.dis");
+	if(ok < 0) {
+		t.skip("/dis/wm/clock.dis not present");
+		return;
+	}
+	r := tool->exec("/dis/wm/clock.dis");
+	# Either succeeds (luciuisrv up) or fails reaching presentation zone
+	t.assert(hassubstr(r, "launched") || hassubstr(r, "presentation zone"),
+		"full path resolves to clock");
+}
+
+testNormalizationWmPrefix(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	(ok, nil) := sys->stat("/dis/wm/clock.dis");
+	if(ok < 0) {
+		t.skip("/dis/wm/clock.dis not present");
+		return;
+	}
+	r := tool->exec("wm/clock");
+	t.assert(hassubstr(r, "launched") || hassubstr(r, "presentation zone"),
+		"wm/ prefix resolves to clock");
+}
+
+testNormalizationBareName(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	(ok, nil) := sys->stat("/dis/wm/clock.dis");
+	if(ok < 0) {
+		t.skip("/dis/wm/clock.dis not present");
+		return;
+	}
+	r := tool->exec("clock");
+	t.assert(hassubstr(r, "launched") || hassubstr(r, "presentation zone"),
+		"bare name resolves to clock");
+}
+
+# ============================================================================
+# Whitelist enforcement: only apps in /dis/wm/ or extraapp()'s explicit
+# whitelist are launchable.  /dis/cmd/cat.dis exists, but the agent must
+# not be able to launch arbitrary /dis/*.dis files as GUI apps.
+# ============================================================================
+
+testWhitelistOnlyWm(t: ref T)
+{
+	tool := loadlaunch(t);
+	if(tool == nil)
+		return;
+
+	# 'cat' exists at /dis/cat.dis but is NOT in /dis/wm/ and NOT whitelisted
+	r := tool->exec("cat");
+	t.assert(hassubstr(r, "not found") || hassubstr(r, "error"),
+		"non-wm app cat rejected by whitelist");
+}
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+hassubstr(s, sub: string): int
+{
+	if(len sub > len s)
+		return 0;
+	for(i := 0; i <= len s - len sub; i++) {
+		if(s[i:i+len sub] == sub)
+			return 1;
+	}
+	return 0;
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	# Identity
+	run("NameAndDoc", testNameAndDoc);
+
+	# Listing
+	run("ListApps", testListApps);
+	run("EmptyArgsListsApps", testEmptyArgsListsApps);
+
+	# Rejection paths
+	run("RejectsTkApps", testRejectsTkApps);
+	run("RejectsUnknownApp", testRejectsUnknownApp);
+	run("RejectsAbsolutePathOutsideWm", testRejectsAbsolutePathOutsideWm);
+	run("RejectsRelativePath", testRejectsRelativePath);
+
+	# Name normalization
+	run("NormalizationFullPath", testNormalizationFullPath);
+	run("NormalizationWmPrefix", testNormalizationWmPrefix);
+	run("NormalizationBareName", testNormalizationBareName);
+
+	# Whitelist
+	run("WhitelistOnlyWm", testWhitelistOnlyWm);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/veltro_more_tools_test.b
+++ b/tests/veltro_more_tools_test.b
@@ -1,0 +1,604 @@
+implement VeltroMoreToolsTest;
+
+#
+# veltro_more_tools_test.b - Coverage for the long tail of Veltro tools
+#
+# These tools have no dedicated test file.  They share a pattern: the agent
+# calls exec(args), the tool dispatches on the first word, and most error
+# paths are reached without any external service running (no /n/ui, /n/wallet,
+# /n/wikia, /tmp/veltro/man/).  We exercise:
+#
+#   mount    — stub: must always refuse, never expand the namespace
+#   wallet   — argument parsing, command dispatch, missing-arg errors
+#   keyring  — subcommand dispatch (open / need / check), bad-input errors
+#   man      — subcommand dispatch, missing-arg errors
+#   gap      — subcommand dispatch (add / resolve / list), bad-input errors
+#   task     — subcommand dispatch (create / status / list / close), errors
+#   wiki     — argument validation, unmounted-/n/wikia error path
+#
+# These tools are an attack surface for the agent: every tool's exec()
+# accepts a free-form string from the LLM.  Bad parsing here = agent
+# misbehaviour or worse.  Each test asserts both that valid commands are
+# accepted by the parser and that malformed/missing input is rejected with
+# a clear error message rather than crashing the tool or doing nothing.
+#
+# To run: cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_more_tools_test.dis
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+# Tool interface (matches /appl/veltro/tool.m)
+Tool: module {
+	init: fn(): string;
+	name: fn(): string;
+	doc:  fn(): string;
+	exec: fn(args: string): string;
+};
+
+VeltroMoreToolsTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/veltro_more_tools_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	"*" =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# Load a tool and call init().  Returns nil and skips the test if either
+# the load or the init fails.
+loadtool(t: ref T, name: string): Tool
+{
+	path := "/dis/veltro/tools/" + name + ".dis";
+	mod := load Tool path;
+	if(mod == nil) {
+		t.skip("cannot load " + name + " tool");
+		return nil;
+	}
+	err := mod->init();
+	if(err != nil) {
+		t.skip(name + " init failed: " + err);
+		return nil;
+	}
+	return mod;
+}
+
+# ============================================================================
+# mount stub
+#
+# mount is intentionally a stub: agents must not be able to expand their
+# own namespace.  Any non-empty arg should still produce a refusal, never
+# a successful mount.  This is a CRITICAL invariant and worth pinning.
+# ============================================================================
+
+testMountAlwaysRefuses(t: ref T)
+{
+	tool := loadtool(t, "mount");
+	if(tool == nil)
+		return;
+
+	t.assertseq(tool->name(), "mount", "mount tool name");
+	t.assert(hassubstr(tool->doc(), "user"), "doc explains user-only");
+
+	# All call patterns must refuse
+	args := array[] of {
+		"",
+		"/n/local /tmp/foo",
+		"-c #s/* /srv",
+		"anything at all here",
+	};
+	for(i := 0; i < len args; i++) {
+		r := tool->exec(args[i]);
+		t.assert(hassubstr(r, "error"),
+			"mount('" + args[i] + "') refused");
+		t.assert(hassubstr(r, "user operation") || hassubstr(r, "[+]"),
+			"mount refusal explains why");
+	}
+}
+
+# ============================================================================
+# wallet — argument parsing
+#
+# Without /n/wallet mounted, every command path that touches the filesystem
+# returns an error message.  We assert the parser correctly dispatches:
+# missing args produce "error: missing/need ...", unknown commands list the
+# valid set.
+# ============================================================================
+
+testWalletNameDoc(t: ref T)
+{
+	tool := loadtool(t, "wallet");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "wallet", "wallet tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "Wallet"), "doc mentions Wallet");
+	t.assert(hassubstr(doc, "accounts"), "doc lists accounts");
+	t.assert(hassubstr(doc, "pay"), "doc lists pay");
+}
+
+testWalletEmpty(t: ref T)
+{
+	tool := loadtool(t, "wallet");
+	if(tool == nil)
+		return;
+	r := tool->exec("");
+	t.assert(hassubstr(r, "usage") || hassubstr(r, "wallet"),
+		"empty wallet args returns usage");
+}
+
+testWalletUnknownCommand(t: ref T)
+{
+	tool := loadtool(t, "wallet");
+	if(tool == nil)
+		return;
+	r := tool->exec("banana");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "unknown command"),
+		"unknown wallet command rejected");
+	t.assert(hassubstr(r, "accounts"),
+		"unknown-command error lists valid commands");
+}
+
+testWalletMissingArgs(t: ref T)
+{
+	tool := loadtool(t, "wallet");
+	if(tool == nil)
+		return;
+
+	# 'address' / 'balance' / 'chain' / 'history' need an account name
+	for(i := 0; i < 4; i++) {
+		cmd := array[] of {"address", "balance", "chain", "history"};
+		r := tool->exec(cmd[i]);
+		t.assert(hassubstr(r, "error") && hassubstr(r, "missing account"),
+			cmd[i] + " missing-arg rejected");
+	}
+
+	# 'sign' needs account + 64-hex-char hash
+	r := tool->exec("sign");
+	t.assert(hassubstr(r, "error"), "sign with no args rejected");
+
+	# 'sign acct shorthex' rejected for non-64-char hash
+	r = tool->exec("sign myacct deadbeef");
+	t.assert(hassubstr(r, "64 hex"),
+		"sign with short hash rejected");
+
+	# 'pay' needs at least account + amount
+	r = tool->exec("pay myacct");
+	t.assert(hassubstr(r, "error"), "pay with one arg rejected");
+}
+
+testWalletDoubledCommand(t: ref T)
+{
+	tool := loadtool(t, "wallet");
+	if(tool == nil)
+		return;
+
+	# 'wallet wallet accounts' should be normalized to 'wallet accounts'
+	# (handles agents that double-prefix the tool name)
+	r := tool->exec("wallet accounts");
+	# Without /n/wallet mounted, doaccounts() returns a "no accounts
+	# configured" message — never an "unknown command" error.
+	t.assert(!hassubstr(r, "unknown command"),
+		"doubled 'wallet wallet accounts' not treated as unknown");
+}
+
+# ============================================================================
+# keyring — subcommand dispatch
+# ============================================================================
+
+testKeyringNameDoc(t: ref T)
+{
+	tool := loadtool(t, "keyring");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "keyring", "keyring tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "Keyring"), "doc mentions Keyring");
+	t.assert(hassubstr(doc, "factotum") || hassubstr(doc, "credential"),
+		"doc mentions credentials");
+}
+
+testKeyringUnknownSubcommand(t: ref T)
+{
+	tool := loadtool(t, "keyring");
+	if(tool == nil)
+		return;
+	r := tool->exec("destroy everything");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "unknown command"),
+		"unknown keyring subcommand rejected");
+}
+
+testKeyringNeedRequiresDescription(t: ref T)
+{
+	tool := loadtool(t, "keyring");
+	if(tool == nil)
+		return;
+	r := tool->exec("need");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "usage"),
+		"keyring need with no description rejected");
+}
+
+testKeyringCheckRequiresService(t: ref T)
+{
+	tool := loadtool(t, "keyring");
+	if(tool == nil)
+		return;
+	r := tool->exec("check");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "usage"),
+		"keyring check with no service rejected");
+}
+
+testKeyringCheckUnknownService(t: ref T)
+{
+	tool := loadtool(t, "keyring");
+	if(tool == nil)
+		return;
+	# Even without factotum mounted, this returns a structured response
+	# (either "unknown: factotum not available" or "no: ..."), never crashes
+	r := tool->exec("check definitely-not-a-real-service-12345");
+	t.assert(hassubstr(r, "no") || hassubstr(r, "unknown"),
+		"check returns structured response for unknown service");
+}
+
+# ============================================================================
+# man — subcommand dispatch
+# ============================================================================
+
+testManNameDoc(t: ref T)
+{
+	tool := loadtool(t, "man");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "man", "man tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "manual"), "doc mentions manual");
+	t.assert(hassubstr(doc, "scroll"), "doc lists scroll subcommand");
+}
+
+testManEmpty(t: ref T)
+{
+	tool := loadtool(t, "man");
+	if(tool == nil)
+		return;
+	r := tool->exec("");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "no command"),
+		"empty man args rejected");
+}
+
+testManMissingArgs(t: ref T)
+{
+	tool := loadtool(t, "man");
+	if(tool == nil)
+		return;
+
+	# open requires a title or path
+	r := tool->exec("open");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "title"),
+		"man open with no arg rejected");
+
+	# scroll requires direction or line
+	r = tool->exec("scroll");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "direction"),
+		"man scroll with no arg rejected");
+
+	# find requires text
+	r = tool->exec("find");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "search text"),
+		"man find with no arg rejected");
+}
+
+testManUnknownCommand(t: ref T)
+{
+	tool := loadtool(t, "man");
+	if(tool == nil)
+		return;
+	r := tool->exec("teleport SYNOPSIS");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "unknown command"),
+		"unknown man subcommand rejected");
+}
+
+# ============================================================================
+# gap — subcommand dispatch and parsing
+# ============================================================================
+
+testGapNameDoc(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "gap", "gap tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "Gap") || hassubstr(doc, "gap"),
+		"doc mentions gaps");
+	t.assert(hassubstr(doc, "relevance"),
+		"doc explains relevance levels");
+}
+
+testGapEmpty(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	r := tool->exec("");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "no command"),
+		"empty gap args rejected");
+}
+
+testGapAddRequiresDescription(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	r := tool->exec("add");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "usage"),
+		"gap add with no description rejected");
+}
+
+testGapResolveRequiresDescription(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	r := tool->exec("resolve");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "usage"),
+		"gap resolve with no description rejected");
+}
+
+testGapUnknownCommand(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	r := tool->exec("destroy everything");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "unknown command"),
+		"unknown gap subcommand rejected");
+}
+
+testGapAddNoUI(t: ref T)
+{
+	tool := loadtool(t, "gap");
+	if(tool == nil)
+		return;
+	# Without /n/ui mounted, currentactid() returns -1; the tool reports
+	# "no active activity" instead of crashing.
+	r := tool->exec("add \"some thoughtful gap\" high");
+	t.assert(hassubstr(r, "error"),
+		"gap add without /n/ui mounted returns error");
+	t.assert(hassubstr(r, "no active activity") || hassubstr(r, "luciuisrv"),
+		"error explains UI is not running");
+}
+
+# ============================================================================
+# task — subcommand dispatch
+# ============================================================================
+
+testTaskNameDoc(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "task", "task tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "task"), "doc mentions tasks");
+	t.assert(hassubstr(doc, "create"), "doc lists create subcommand");
+}
+
+testTaskEmpty(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	r := tool->exec("");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "no command"),
+		"empty task args rejected");
+}
+
+testTaskCreateRequiresLabel(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	# create with no attrs at all
+	r := tool->exec("create");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "label"),
+		"task create with no label rejected");
+
+	# create with attributes but missing label
+	r = tool->exec("create tools=read,list");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "label"),
+		"task create without label= rejected");
+}
+
+testTaskStatusRequiresId(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	r := tool->exec("status");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "id"),
+		"task status with no id rejected");
+
+	r = tool->exec("status notanumber");
+	t.assert(hassubstr(r, "error"),
+		"task status with non-numeric id rejected");
+}
+
+testTaskCloseRequiresId(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	r := tool->exec("close");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "id"),
+		"task close with no id rejected");
+
+	# Activity 0 is the meta-agent — closing it must be refused
+	r = tool->exec("close 0");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "meta-agent"),
+		"task close 0 (meta-agent) refused");
+}
+
+testTaskUnknownCommand(t: ref T)
+{
+	tool := loadtool(t, "task");
+	if(tool == nil)
+		return;
+	r := tool->exec("forge a backdoor");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "unknown command"),
+		"unknown task subcommand rejected");
+}
+
+# ============================================================================
+# wiki — argument validation
+# ============================================================================
+
+testWikiNameDoc(t: ref T)
+{
+	tool := loadtool(t, "wiki");
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "wiki", "wiki tool name");
+	doc := tool->doc();
+	t.assert(hassubstr(doc, "Wiki") || hassubstr(doc, "wiki"),
+		"doc mentions wiki");
+	t.assert(hassubstr(doc, "ingest"), "doc lists ingest");
+	t.assert(hassubstr(doc, "query"), "doc lists query");
+}
+
+testWikiEmpty(t: ref T)
+{
+	tool := loadtool(t, "wiki");
+	if(tool == nil)
+		return;
+	r := tool->exec("");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "usage"),
+		"empty wiki args rejected");
+}
+
+testWikiUnmounted(t: ref T)
+{
+	tool := loadtool(t, "wiki");
+	if(tool == nil)
+		return;
+	# /n/wikia is the wiki9p mount.  When not mounted, every wiki command
+	# should fail fast with a clear pointer to wiki9p.
+	(ok, nil) := sys->stat("/n/wikia/ctl");
+	if(ok >= 0) {
+		t.skip("/n/wikia is mounted — cannot test the unmounted path");
+		return;
+	}
+
+	r := tool->exec("status");
+	t.assert(hassubstr(r, "error") && hassubstr(r, "/n/wikia"),
+		"wiki status without /n/wikia mounted reports the mount");
+}
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+hassubstr(s, sub: string): int
+{
+	if(len sub > len s)
+		return 0;
+	for(i := 0; i <= len s - len sub; i++) {
+		if(s[i:i+len sub] == sub)
+			return 1;
+	}
+	return 0;
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	# mount
+	run("MountAlwaysRefuses", testMountAlwaysRefuses);
+
+	# wallet
+	run("WalletNameDoc", testWalletNameDoc);
+	run("WalletEmpty", testWalletEmpty);
+	run("WalletUnknownCommand", testWalletUnknownCommand);
+	run("WalletMissingArgs", testWalletMissingArgs);
+	run("WalletDoubledCommand", testWalletDoubledCommand);
+
+	# keyring
+	run("KeyringNameDoc", testKeyringNameDoc);
+	run("KeyringUnknownSubcommand", testKeyringUnknownSubcommand);
+	run("KeyringNeedRequiresDescription", testKeyringNeedRequiresDescription);
+	run("KeyringCheckRequiresService", testKeyringCheckRequiresService);
+	run("KeyringCheckUnknownService", testKeyringCheckUnknownService);
+
+	# man
+	run("ManNameDoc", testManNameDoc);
+	run("ManEmpty", testManEmpty);
+	run("ManMissingArgs", testManMissingArgs);
+	run("ManUnknownCommand", testManUnknownCommand);
+
+	# gap
+	run("GapNameDoc", testGapNameDoc);
+	run("GapEmpty", testGapEmpty);
+	run("GapAddRequiresDescription", testGapAddRequiresDescription);
+	run("GapResolveRequiresDescription", testGapResolveRequiresDescription);
+	run("GapUnknownCommand", testGapUnknownCommand);
+	run("GapAddNoUI", testGapAddNoUI);
+
+	# task
+	run("TaskNameDoc", testTaskNameDoc);
+	run("TaskEmpty", testTaskEmpty);
+	run("TaskCreateRequiresLabel", testTaskCreateRequiresLabel);
+	run("TaskStatusRequiresId", testTaskStatusRequiresId);
+	run("TaskCloseRequiresId", testTaskCloseRequiresId);
+	run("TaskUnknownCommand", testTaskUnknownCommand);
+
+	# wiki
+	run("WikiNameDoc", testWikiNameDoc);
+	run("WikiEmpty", testWikiEmpty);
+	run("WikiUnmounted", testWikiUnmounted);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/veltro_safeexec_test.b
+++ b/tests/veltro_safeexec_test.b
@@ -1,0 +1,310 @@
+implement VeltroSafeExecTest;
+
+#
+# veltro_safeexec_test.b - Tests for the SafeExec tool's security boundary
+#
+# SafeExec is the privileged-without-shell execution path used when an agent
+# was spawned without shellcmds.  spawn.b uses safeexec instead of exec to
+# run whitelisted .dis files directly, bypassing the shell and the entire
+# class of metacharacter-injection attacks that come with it.
+#
+# That makes SafeExec's input validation a security boundary.  These tests
+# exercise it directly via the loaded module:
+#
+#   - empty / whitespace-only args are rejected
+#   - tool names containing path separators or "." are rejected
+#     (defends against ../../escape and absolute-path attacks)
+#   - non-existent tools are rejected before any load attempt
+#   - tool names are case-normalized to lower
+#   - valid tools (read, list) actually execute and return real output
+#   - heredoc/multi-arg payloads are forwarded intact to the wrapped tool
+#
+# To run: cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_safeexec_test.dis
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+# SafeExec's actual exported interface.
+# Note: safeexec.b does NOT declare init() in its module signature
+# (it self-initializes inside exec()).  Loading via the canonical Tool
+# interface — which requires init() — would fail the type check, so we
+# match SafeExec's exports exactly.
+Tool: module {
+	name: fn(): string;
+	doc:  fn(): string;
+	exec: fn(args: string): string;
+};
+
+VeltroSafeExecTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/veltro_safeexec_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	"*" =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# Load SafeExec.  No init() to call — safeexec self-initializes on first
+# exec().
+loadsafeexec(t: ref T): Tool
+{
+	tool := load Tool "/dis/veltro/tools/safeexec.dis";
+	if(tool == nil) {
+		t.skip("cannot load safeexec.dis");
+		return nil;
+	}
+	return tool;
+}
+
+# ============================================================================
+# Identity
+# ============================================================================
+
+testNameAndDoc(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+	t.assertseq(tool->name(), "safeexec", "name() returns 'safeexec'");
+
+	doc := tool->doc();
+	t.assert(len doc > 0, "doc() is non-empty");
+	t.assert(hassubstr(doc, "SafeExec"), "doc mentions SafeExec");
+	t.assert(hassubstr(doc, "shell"), "doc mentions shell behavior");
+	t.assert(hassubstr(doc, "injection"), "doc warns about injection");
+}
+
+# ============================================================================
+# Argument validation
+# ============================================================================
+
+testEmptyArgs(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	r := tool->exec("");
+	t.assert(hassubstr(r, "error"), "empty args rejected");
+	t.assert(hassubstr(r, "no tool"), "error mentions missing tool name");
+}
+
+testWhitespaceOnlyArgs(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	r := tool->exec("   \t  ");
+	t.assert(hassubstr(r, "error"), "whitespace-only args rejected");
+}
+
+# ============================================================================
+# Path-traversal defenses
+#
+# The tool name is validated character-by-character: any '/', '\', or '.'
+# results in a rejection BEFORE any stat or load happens.  These tests
+# exercise common attacker payloads.
+# ============================================================================
+
+testRejectPathTraversal(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Classic ../ traversal
+	r := tool->exec("../etc/passwd");
+	t.assert(hassubstr(r, "error"), "../ traversal rejected");
+	t.assert(hassubstr(r, "invalid tool name"), "error mentions invalid name");
+}
+
+testRejectAbsolutePath(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Absolute path to arbitrary .dis
+	r := tool->exec("/dis/sh.dis some args");
+	t.assert(hassubstr(r, "error"), "absolute path rejected");
+	t.assert(hassubstr(r, "invalid tool name"), "error mentions invalid name");
+}
+
+testRejectBackslash(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Backslash also rejected (Windows-style escape)
+	r := tool->exec("foo\\bar");
+	t.assert(hassubstr(r, "error"), "backslash rejected");
+	t.assert(hassubstr(r, "invalid tool name"), "error mentions invalid name");
+}
+
+testRejectDot(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Bare "." would resolve to "/dis/veltro/tools/..dis" if not blocked
+	r := tool->exec("read.dis foo");
+	t.assert(hassubstr(r, "error"), "tool name with '.' rejected");
+}
+
+# ============================================================================
+# Whitelist: only tools that exist in /dis/veltro/tools/ load
+# ============================================================================
+
+testRejectUnknownTool(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	r := tool->exec("nosuchtool argument");
+	t.assert(hassubstr(r, "error"), "unknown tool rejected");
+	t.assert(hassubstr(r, "tool not found") || hassubstr(r, "cannot load"),
+		"error mentions tool not found");
+}
+
+# ============================================================================
+# Case normalization: tool name is lowercased
+# ============================================================================
+
+testCaseInsensitive(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Read with uppercase should resolve to /dis/veltro/tools/read.dis.
+	# Use this very test file as a known-readable target.
+	r := tool->exec("READ /tests/veltro_safeexec_test.b");
+	# If lowercasing works, read.dis runs and returns file contents
+	# (which include this very implement statement).
+	t.assert(!hassubstr(r, "error: tool not found"),
+		"uppercase READ resolves to read tool");
+	t.assert(hassubstr(r, "VeltroSafeExecTest") || !hassubstr(r, "error:"),
+		"uppercase READ executes successfully");
+}
+
+# ============================================================================
+# Forwarding: arguments after the tool name are passed verbatim
+# ============================================================================
+
+testForwardArgs(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# Use list, which expects a directory path
+	r := tool->exec("list /tests");
+	t.assert(!hassubstr(r, "error: tool not found"), "list tool resolves");
+	t.assert(!hassubstr(r, "error: no tool"), "args were forwarded");
+	# list returns "entries" count on success
+	t.assert(hassubstr(r, "entries") || hassubstr(r, "veltro_safeexec_test"),
+		"list executed and produced output");
+}
+
+testForwardErrorPropagation(t: ref T)
+{
+	tool := loadsafeexec(t);
+	if(tool == nil)
+		return;
+
+	# read of nonexistent file: read tool reports error, safeexec passes through
+	r := tool->exec("read /no/such/file/anywhere");
+	t.assert(hassubstr(r, "error"), "wrapped tool's error propagated");
+}
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+hassubstr(s, sub: string): int
+{
+	if(len sub > len s)
+		return 0;
+	for(i := 0; i <= len s - len sub; i++) {
+		if(s[i:i+len sub] == sub)
+			return 1;
+	}
+	return 0;
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	# Identity
+	run("NameAndDoc", testNameAndDoc);
+
+	# Argument validation
+	run("EmptyArgs", testEmptyArgs);
+	run("WhitespaceOnlyArgs", testWhitespaceOnlyArgs);
+
+	# Path-traversal defenses
+	run("RejectPathTraversal", testRejectPathTraversal);
+	run("RejectAbsolutePath", testRejectAbsolutePath);
+	run("RejectBackslash", testRejectBackslash);
+	run("RejectDot", testRejectDot);
+
+	# Whitelist
+	run("RejectUnknownTool", testRejectUnknownTool);
+
+	# Normalization & forwarding
+	run("CaseInsensitive", testCaseInsensitive);
+	run("ForwardArgs", testForwardArgs);
+	run("ForwardErrorPropagation", testForwardErrorPropagation);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}


### PR DESCRIPTION
## Summary

This PR adds three new test suites that comprehensively cover the Veltro agent tool ecosystem and critical security boundaries. These tests exercise input validation, error handling, and security-relevant behavior across the tool interface.

## Changes

- **veltro_more_tools_test.b**: Tests for the long tail of Veltro tools (mount, wallet, keyring, man, gap, task, wiki) that lack dedicated test files. Covers argument parsing, command dispatch, missing-argument errors, and error paths without external services running. Validates that the mount stub always refuses (critical invariant), and that all tools properly reject malformed input with clear error messages rather than crashing.

- **lucibridge_approval_test.b**: Tests for `needsapproval()`, the security gate that decides which agent tool calls require explicit user consent. Covers the approval rules for exec (rm -r, namespace mutations), write/edit (system path protection), and read-class tools (never require approval). Also tests `firstlines()` preview truncation. This is the most safety-relevant pure function in lucibridge and runs before every tool call.

- **veltro_launch_test.b**: Tests for the Launch tool's security-relevant validation before spawning GUI applications. Covers name normalization (strips /dis/wm/, wm/, .dis), path-traversal defenses (rejects names containing '/' after normalization), Tk-app rejection, whitelist enforcement, and app enumeration.

- **veltro_safeexec_test.b**: Tests for SafeExec's input validation, which is a security boundary for privileged-without-shell execution. Covers rejection of empty/whitespace args, path separators and dots in tool names (defends against ../../ and absolute-path attacks), case normalization, whitelist enforcement, and argument forwarding.

- **tests/mkfile**: Added three new test targets to the build.

## Testing

All tests are designed to run without external services (no /n/ui, /n/wallet, /n/wikia, luciuisrv, etc.) and exercise both valid command paths and error cases. Tests use the testing module framework and can be run with:

```
cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_more_tools_test.dis
cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/lucibridge_approval_test.dis
cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_launch_test.dis
cd $ROOT && ./emu/MacOSX/o.emu -r. /tests/veltro_safeexec_test.dis
```

- [x] Tests pass (`/tests/runner.dis -v`)
- [x] New tests added (comprehensive coverage of security boundaries and tool interfaces)
- [x] Tested on: Inferno emu

## Checklist

- [x] Code follows the existing style of the file(s) modified
- [x] No `.dis` build artifacts committed
- [x] Documentation included in test file headers explaining coverage and rationale
- [x] No secrets, API keys, or credentials included

https://claude.ai/code/session_018KHykJQN3kALqxjoAGbady