### PR TITLE
Add comprehensive documentation for Lucia, Veltro, and JIT

### DIFF
--- a/docs/DOCUMENTATION-INDEX.md
+++ b/docs/DOCUMENTATION-INDEX.md
@@ -9,6 +9,8 @@
 | [USER-MANUAL.md](USER-MANUAL.md) | **Comprehensive user guide** - namespaces, devices, host integration |
 | [QUICKSTART.md](../QUICKSTART.md) | Get running in 3 commands |
 | [RUN_TOUR.md](../RUN_TOUR.md) | Interactive Veltro feature tour |
+| [LUCIFER-GUI.md](LUCIFER-GUI.md) | **Lucifer/Lucia GUI guide** - three-zone tiling UI, activities, tiles, themes |
+| [VELTRO.md](VELTRO.md) | **Veltro agent guide** - veltro/repl/spawn, 40 tools, models, capabilities |
 | [XENITH.md](XENITH.md) | Xenith AI-native text environment |
 | [NAMESPACE.md](NAMESPACE.md) | Namespace architecture and configuration |
 | [FILESYSTEM-MOUNTING.md](FILESYSTEM-MOUNTING.md) | Filesystem mounting guide |
@@ -19,7 +21,7 @@
 | Document | Description |
 |----------|-------------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System architecture, layer diagram, and component overview |
-| [LUCIFER-EVALUATION.md](LUCIFER-EVALUATION.md) | Lucifer GUI production readiness evaluation (P0/P1/P2 issues) |
+| [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md) | Lucifer GUI production readiness evaluation (P0/P1/P2 issues) |
 | [evaluations/fractal-app-evaluation.md](evaluations/fractal-app-evaluation.md) | Fractal app production readiness evaluation |
 | [architecture-review-veltro-unification.md](architecture-review-veltro-unification.md) | Veltro architecture review |
 | [RECOMMENDED-ADDITIONS.md](RECOMMENDED-ADDITIONS.md) | Recommended feature additions |
@@ -30,6 +32,7 @@
 |----------|-------------|
 | [CLAUDE.md](../CLAUDE.md) | Development guide for Claude Code (build, test, project structure) |
 | [TESTING.md](TESTING.md) | Testing guide (unit tests, integration tests, CI) |
+| [JIT.md](JIT.md) | **JIT compilation guide** - `-c` flag, AMD64/ARM64 backends, coverage, troubleshooting |
 | [PERFORMANCE-SPECS.md](PERFORMANCE-SPECS.md) | Performance specifications and benchmarks |
 | [BENCHMARKS.md](BENCHMARKS.md) | Benchmark results (v1, v2, v3 suites) |
 | [SDL3-GUI-PLAN.md](SDL3-GUI-PLAN.md) | SDL3 cross-platform GUI implementation plan |
@@ -74,7 +77,7 @@
 
 ## ARM64 JIT Compiler
 
-Detailed JIT documentation is in `docs/arm64-jit/` (27 files covering implementation, debugging, benchmarks across all platforms).
+User-facing JIT guide: [JIT.md](JIT.md). Detailed implementation, debug logs, and benchmarks across all platforms are in `docs/arm64-jit/` (27 files).
 
 ## Additional Guides
 

--- a/docs/DOCUMENTATION-INDEX.md
+++ b/docs/DOCUMENTATION-INDEX.md
@@ -9,7 +9,7 @@
 | [USER-MANUAL.md](USER-MANUAL.md) | **Comprehensive user guide** - namespaces, devices, host integration |
 | [QUICKSTART.md](../QUICKSTART.md) | Get running in 3 commands |
 | [RUN_TOUR.md](../RUN_TOUR.md) | Interactive Veltro feature tour |
-| [LUCIFER-GUI.md](LUCIFER-GUI.md) | **Lucifer/Lucia GUI guide** - three-zone tiling UI, activities, tiles, themes |
+| [LUCIA.md](LUCIA.md) | **Lucia GUI guide** - three-zone tiling UI, activities, tiles, themes |
 | [VELTRO.md](VELTRO.md) | **Veltro agent guide** - veltro/repl/spawn, 40 tools, models, capabilities |
 | [XENITH.md](XENITH.md) | Xenith AI-native text environment |
 | [NAMESPACE.md](NAMESPACE.md) | Namespace architecture and configuration |
@@ -21,7 +21,7 @@
 | Document | Description |
 |----------|-------------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System architecture, layer diagram, and component overview |
-| [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md) | Lucifer GUI production readiness evaluation (P0/P1/P2 issues) |
+| [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md) | Lucia GUI production readiness evaluation (P0/P1/P2 issues) |
 | [evaluations/fractal-app-evaluation.md](evaluations/fractal-app-evaluation.md) | Fractal app production readiness evaluation |
 | [architecture-review-veltro-unification.md](architecture-review-veltro-unification.md) | Veltro architecture review |
 | [RECOMMENDED-ADDITIONS.md](RECOMMENDED-ADDITIONS.md) | Recommended feature additions |

--- a/docs/JIT.md
+++ b/docs/JIT.md
@@ -109,7 +109,7 @@ Pool quanta affect both the interpreter and the JIT:
 emu -p heap=512m -p main=512m -p image=512m ...
 ```
 
-These are the values the [Lucifer launch scripts](LUCIFER-GUI.md#launching) use. Lower values are fine for a shell or batch tasks; the GUI wants the larger pool because it allocates `Image`s.
+These are the values the [Lucia launch scripts](LUCIA.md#launching) use. Lower values are fine for a shell or batch tasks; the GUI wants the larger pool because it allocates `Image`s.
 
 > 🔑 **The 64-bit fix.** Pool quanta must be 127 on 64-bit (not 31 as on 32-bit) — the single change in `emu/port/alloc.c` that made the 64-bit port work. See [LESSONS-LEARNED.md](LESSONS-LEARNED.md) for the story.
 

--- a/docs/JIT.md
+++ b/docs/JIT.md
@@ -1,0 +1,144 @@
+# JIT Compilation
+
+**Purpose:** What the JIT does, when to enable it, and where to look when something goes wrong.
+
+> Looking for benchmark numbers? See [BENCHMARKS.md](BENCHMARKS.md). Looking for ARM64 implementation details? See [PORTING-ARM64.md](PORTING-ARM64.md) and [docs/arm64-jit/](arm64-jit/). This document is the user-facing summary.
+
+## TL;DR
+
+```sh
+emu -c1 -r.        # JIT enabled (recommended for AMD64 and ARM64)
+emu -c0 -r.        # interpreter only
+emu     -r.        # default depends on the build; treat as interpreter
+```
+
+Use `-c1` on Linux/macOS AMD64 and ARM64. Use `-c0` (or no flag) on Windows — there is no Windows JIT yet, the emulator falls back to the interpreter.
+
+## What it does
+
+InferNode's emulator compiles Dis VM bytecode to native machine code at module load time. Two backends ship and are wired up by `Make` based on the host architecture:
+
+| Backend                    | Targets                                       | Source                       |
+|----------------------------|-----------------------------------------------|------------------------------|
+| `comp-amd64.c`             | x86-64, System V ABI (Linux/macOS) + Windows x64 ABI | `libinterp/comp-amd64.c` |
+| `comp-arm64.c`             | ARMv8-A, AAPCS64 ABI (macOS Apple Silicon, Linux on Jetson/Pi) | `libinterp/comp-arm64.c` |
+
+Older 32-bit backends (`comp-386.c`, `comp-arm.c`, `comp-mips.c`, `comp-power.c`, `comp-sparc.c`, etc.) are kept for completeness but the active 64-bit ports are AMD64 and ARM64.
+
+### W^X compliance
+
+The JIT writes machine code into pages it later executes. Each platform handles W^X differently:
+
+- **macOS** — `mmap(MAP_JIT)` plus `pthread_jit_write_protect_np()` to flip the writable/executable bit per thread. Required on Apple Silicon.
+- **Linux** — `mmap(MAP_ANON)` with `PROT_READ|PROT_WRITE|PROT_EXEC`.
+- **Windows** — `VirtualAlloc(PAGE_READWRITE)` then `VirtualProtect(PAGE_EXECUTE_READ)` once the code is written. (Currently used for the 32-bit `comp-386.c` path; no 64-bit Windows JIT yet.)
+
+## Speedup
+
+Best-of-3 against the interpreter, v1 suite (6 compute benchmarks):
+
+| Platform        | CPU                    | Speedup |
+|-----------------|------------------------|---------|
+| Linux AMD64     | AMD Ryzen 7 H 255      | **14.2×** |
+| Windows AMD64   | AMD Ryzen 7 255        | 13.3× (currently interpreter-only on shipped builds) |
+| macOS ARM64     | Apple M4               | **9.6×**  |
+| Linux ARM64     | Cortex-A78AE (Jetson)  | **8.3×**  |
+
+v2 (26 benchmarks, broader workload mix) drops to 2.6–5.7× because function-call-heavy workloads can't eliminate frame allocation, module pointer validation, and GC interaction. Branch-heavy code can hit 36×; tight inner loops 14–18×; recursive Fibonacci is closer to 3×.
+
+Full numbers: [BENCHMARKS.md](BENCHMARKS.md).
+
+## The `-c` flag
+
+```
+emu -c <level> ...
+```
+
+| Level | Behaviour |
+|-------|-----------|
+| `0`   | Interpreter only. No JIT. |
+| `1`   | JIT enabled. **This is what you want.** |
+| `2`   | Reserved/internal. |
+| `3`   | JIT + cflag-gated logging in the compiler. |
+| `4`   | More verbose JIT logging. |
+| `5–9` | Progressively more diagnostic output, used while debugging the JIT itself. |
+
+Anything above `1` is for compiler bring-up, not normal use. The accepted range is `0`–`9` (see `emu/port/main.c:136`).
+
+## Forcing JIT vs. interpreter for specific code
+
+Two compile-time hints in Limbo source map to Dis module flags:
+
+- `MUSTCOMPILE` — module insists on JIT; load fails on interpreter-only emulators.
+- `DONTCOMPILE` — module is interpreted even when `-c1` is set.
+
+These are set by the Limbo compiler from `pragma`s. Ordinary code does not need them; they exist for modules that depend on a specific code path.
+
+> ⚠️ **Compiler choice matters.** The hosted Limbo (`/dis/limbo.dis` running inside the emulator) sets `MUSTCOMPILE` on the modules it produces. If you compile a `.dis` with the hosted limbo and then load it on an interpreter-only platform, you will get `compiler required` errors. Use the **native** limbo (`MacOSX/arm64/bin/limbo` or `Linux/<arch>/bin/limbo`) to produce portable bytecode. See [CLAUDE.md §JIT Compiler Availability](../CLAUDE.md#jit-compiler-availability).
+
+## Coverage
+
+Not every Dis opcode is JIT-compiled. The compilers fall back to the interpreter for instructions that are rare or whose native sequences would be longer than the interpreter call.
+
+ARM64 (`comp-arm64.c`):
+
+- **155 opcodes (~91 %)** compiled to native ARM64.
+- **16 opcodes (~9 %)** punted to the interpreter (complex string ops, some 64-bit float conversions, send/receive, etc.).
+- All other opcodes are a compile-time error in the JIT — a deliberate conservative choice that surfaces unhandled instructions immediately.
+
+For the full opcode-by-opcode breakdown, see [arm64-jit/OPCODE-ANALYSIS.md](arm64-jit/OPCODE-ANALYSIS.md) and [arm64-jit/OPCODE-DETAILED-ANALYSIS.md](arm64-jit/OPCODE-DETAILED-ANALYSIS.md).
+
+AMD64 has comparable coverage; see `libinterp/comp-amd64.c`.
+
+## Bounds checking
+
+Array bounds checks are on by default and inserted by the JIT. Two flags toggle this:
+
+```
+emu -B ...     # suppress JIT array bounds checks (faster, unsafe)
+emu -b ...     # historical — bounds checks; now the default and a no-op
+```
+
+Disable bounds checks only for benchmarking. Production builds should leave them on.
+
+## Memory pool option
+
+Pool quanta affect both the interpreter and the JIT:
+
+```
+emu -p heap=512m -p main=512m -p image=512m ...
+```
+
+These are the values the [Lucifer launch scripts](LUCIFER-GUI.md#launching) use. Lower values are fine for a shell or batch tasks; the GUI wants the larger pool because it allocates `Image`s.
+
+> 🔑 **The 64-bit fix.** Pool quanta must be 127 on 64-bit (not 31 as on 32-bit) — the single change in `emu/port/alloc.c` that made the 64-bit port work. See [LESSONS-LEARNED.md](LESSONS-LEARNED.md) for the story.
+
+## Diagnosing JIT issues
+
+| Symptom                                              | What to try |
+|------------------------------------------------------|-------------|
+| `compiler required` when loading a `.dis`           | You compiled it with the hosted limbo. Recompile with the native `limbo` from `MacOSX/arm64/bin/` or `Linux/<arch>/bin/`. |
+| Crash inside JIT'd code                             | Re-run with `-c0` to confirm the interpreter works. If yes, file a JIT bug with the exact module and inputs. |
+| Slow despite `-c1`                                   | Workload may be function-call-heavy (Fibonacci-like) — JIT can only do so much. Profile with the v2 suite breakdown ([BENCHMARKS.md](BENCHMARKS.md)). |
+| `mmap(MAP_JIT)` failure on macOS                    | Sandbox / entitlements issue. Confirm the binary is signed and `com.apple.security.cs.allow-jit` is set if shipping notarised. |
+| Windows: no speedup from `-c1`                      | Expected — there is no 64-bit Windows JIT yet. Use `-c0` and the interpreter. |
+| Bring-up debugging the JIT itself                   | Use `-c3` or `-c4` for compiler logging; see the `cflag > 3` gates in `comp-arm64.c` and `comp-amd64.c`. |
+
+For deep debug stories — what worked, what didn't, every blind alley — the [arm64-jit/](arm64-jit/) directory has 27 session logs.
+
+## When to leave JIT off
+
+- **Tiny scripts / shell pipelines.** JIT compilation has a one-time per-module cost; a script that runs for 2 ms gains nothing and pays the compile.
+- **Heap-pressure debugging.** The interpreter is the simpler reference path. Comparing `-c0` and `-c1` results is a useful diagnostic.
+- **Windows builds.** No JIT exists yet; `-c0` is the truthful default.
+
+For every other workload — anything that runs longer than a few milliseconds — `-c1` is the right answer.
+
+## See also
+
+- [BENCHMARKS.md](BENCHMARKS.md) — full v1/v2 suites, cross-language comparisons.
+- [PERFORMANCE-SPECS.md](PERFORMANCE-SPECS.md) — RAM, binary sizes, startup time.
+- [PORTING-ARM64.md](PORTING-ARM64.md) — what porting the JIT to ARM64 actually involved.
+- [arm64-jit/](arm64-jit/) — opcode coverage, bring-up logs, debug stories.
+- [LESSONS-LEARNED.md](LESSONS-LEARNED.md) — pool-quanta fix and other 64-bit gotchas.
+- [CLAUDE.md §JIT Compiler Availability](../CLAUDE.md#jit-compiler-availability) — native vs. hosted limbo and why it matters.

--- a/docs/LUCIA.md
+++ b/docs/LUCIA.md
@@ -1,12 +1,12 @@
-# Lucifer GUI
+# Lucia
 
-**Purpose:** User and operator guide for the Lucifer desktop UI — InferNode's three-zone tiling environment for AI-assisted work. Marketed as **Lucia**, named **Lucifer** in code.
+**Purpose:** User and operator guide for Lucia, InferNode's desktop UI — a three-zone tiling environment for AI-assisted work.
 
 > Looking for the production-readiness audit (P0/P1/P2 issues)? See [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md). This document is the user-facing guide.
 
 ## What it is
 
-Lucifer is a fullscreen Limbo application that splits the display into three vertical zones:
+Lucia is a fullscreen Limbo application that splits the display into three vertical zones:
 
 ```
 +----------------+--------------------+----------------+
@@ -94,7 +94,9 @@ A small `wmsrv` runs inside `lucifer.b` (the `preswmloop`) so app artifacts get 
 - **Tasks** — in-flight background work.
 - **Tool toggles** — enable/disable tools at runtime; reflects bindings in `/tool`.
 
-## Components
+## Components (source layout)
+
+The internal module names use the `luci-` prefix; this is an implementation detail and not a user-facing brand.
 
 | File (in `appl/cmd/`) | Role |
 |-----------------------|------|
@@ -108,7 +110,7 @@ A small `wmsrv` runs inside `lucifer.b` (the `preswmloop`) so app artifacts get 
 
 ## Filesystem map
 
-Lucifer stitches together several 9P services. Once the UI is up, you can `cat` any of these from a shell.
+Lucia stitches together several 9P services. Once the UI is up, you can `cat` any of these from a shell.
 
 | Mount        | Server      | What lives there |
 |--------------|-------------|------------------|
@@ -168,7 +170,7 @@ To switch:
 
 ```sh
 echo halo > lib/lucifer/theme/current
-# restart Lucifer
+# restart Lucia
 ```
 
 ## The default tool budget
@@ -186,7 +188,7 @@ For details on what each tool does and how capability attenuation works, see [VE
 
 ## Multiple activities, scripted setup
 
-You can pre-populate Lucifer at launch by appending commands to `LUCIFER_CMD` in the launch script. Example: open the Veltro tour artifact and a fractal app on startup.
+You can pre-populate Lucia at launch by appending commands to the launch command in `run-lucia*.sh`. Example: open the Veltro tour artifact and a fractal app on startup.
 
 ```
 echo 'create id=tour    type=markdown   label=Tour'   > /n/ui/activity/0/presentation/ctl
@@ -203,13 +205,13 @@ Anything you can write through `/n/ui/...` from a normal shell works at startup 
 | `ANTHROPIC_API_KEY not set` warning | Host env var missing | `export ANTHROPIC_API_KEY=sk-ant-…` and relaunch. |
 | Voice button does nothing for 30s | `speech9p` not running, or no host audio access | Check `/n/speech` exists; on Linux confirm PulseAudio/PipeWire is reachable from the emulator. |
 | `link typecheck` errors at startup | Stale `.dis` after a `git pull` | `./hooks/install.sh` (one-time) or `cd appl/cmd && mk install`. |
-| Apps fail to launch in the presentation zone | `MAXAPPSLOTS` (16) exhausted | Restart Lucifer. Tracked as a known issue in [LUCIA-EVALUATION.md §P0.2](LUCIA-EVALUATION.md). |
+| Apps fail to launch in the presentation zone | `MAXAPPSLOTS` (16) exhausted | Restart Lucia. Tracked as a known issue in [LUCIA-EVALUATION.md §P0.2](LUCIA-EVALUATION.md). |
 | Header shows no activity label | `nslistener` isn't seeing `status`/`label` events | Confirm `luciuisrv` is running: `ps | grep luciuisrv`. |
 
 ## See also
 
 - [USER-MANUAL.md](USER-MANUAL.md) — namespace and host-integration basics.
-- [VELTRO.md](VELTRO.md) — the agent system that drives Lucifer.
+- [VELTRO.md](VELTRO.md) — the agent system that drives Lucia.
 - [XENITH.md](XENITH.md) — the AI-native text environment used inside the presentation zone.
 - [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md) — production-readiness audit (P0/P1/P2 issues).
 - [DIALOGUE-TILES.md](DIALOGUE-TILES.md) — interactive dialogue/form tile reference.

--- a/docs/LUCIFER-GUI.md
+++ b/docs/LUCIFER-GUI.md
@@ -1,0 +1,216 @@
+# Lucifer GUI
+
+**Purpose:** User and operator guide for the Lucifer desktop UI — InferNode's three-zone tiling environment for AI-assisted work. Marketed as **Lucia**, named **Lucifer** in code.
+
+> Looking for the production-readiness audit (P0/P1/P2 issues)? See [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md). This document is the user-facing guide.
+
+## What it is
+
+Lucifer is a fullscreen Limbo application that splits the display into three vertical zones:
+
+```
++----------------+--------------------+----------------+
+| Conversation   |   Presentation     |   Context      |
+|     ~30%       |       ~45%         |     ~25%       |
+|                |                    |                |
+| chat with the  | artifacts:         | resources,     |
+| agent;         | docs, code, PDF,   | knowledge      |
+| send/voice/    | mermaid, images,   | gaps, running  |
+| reset; tiles   | and live apps      | tasks, tool    |
+| with buttons   | (editor, shell,    | toggles        |
+|                | fractal, charon)   |                |
++----------------+--------------------+----------------+
+| header bar: logo · activity label · status · accent  |
++------------------------------------------------------+
+```
+
+The agent (Veltro, via `lucibridge`) drives the right- and centre-zones by writing to a synthetic 9P filesystem mounted at `/n/ui`. Everything you see is a file, and everything the agent does is a write.
+
+## Launching
+
+### macOS / generic
+
+```sh
+./run-lucia.sh
+```
+
+### Linux
+
+```sh
+./run-lucia-linux.sh
+./run-lucia-linux.sh -g 1920x1080      # custom geometry
+```
+
+Both scripts:
+
+1. Set memory limits: `-pheap=512m -pmain=512m -pimage=512m`.
+2. Start `luciuisrv` (the UI 9P filesystem at `/n/ui`).
+3. Create the `Main` activity.
+4. Start `speech9p` (TTS/STT, mounted at `/n/speech`).
+5. Start `tools9p` (tool registry at `/tool` with the default capability budget — see below).
+6. Start `lucibridge` (the agent loop) in the background.
+7. Create a `taskboard` artifact in the presentation zone.
+8. Run `lucifer` (the window owner).
+
+The LLM backend (`llmsrv`) is started by `lib/sh/profile` from `sh -l`, so the launch script does not start it directly. Set `ANTHROPIC_API_KEY` in the host environment before launching; the profile provisions it into factotum.
+
+### What you need
+
+- A built emulator (`emu/MacOSX/o.emu` or `emu/Linux/o.emu`) with SDL3 GUI support.
+- `ANTHROPIC_API_KEY` exported in the host shell (otherwise AI features stay dark; the UI still renders).
+
+## The three zones
+
+### Conversation (`luciconv.b`, left ~30%)
+
+- Chat history with the agent.
+- Text input field at the bottom.
+- Tag bar at the top: **Send · Voice · Clear · Reset · Delete**.
+- Renders interactive **dialogue tiles** and **forms** — messages can carry buttons; clicking one writes the option text back to the conversation as a user message.
+- All keyboard input across the screen routes here, regardless of which zone the mouse is over.
+
+### Presentation (`lucipres.b`, centre ~45%)
+
+Hosts artifacts. Each artifact is a tab. Supported types:
+
+| Type        | Renders                                |
+|-------------|-----------------------------------------|
+| `text`      | plain text                              |
+| `code`      | syntax-highlighted source               |
+| `markdown`  | rendered markdown                       |
+| `doc`       | markdown with layout                    |
+| `mermaid`   | mermaid diagrams → SVG                  |
+| `pdf`       | PDF viewer with page navigation         |
+| `image`     | raster images (PNG, JPEG, GIF)          |
+| `app`       | a live app window (editor, shell, fractal, charon) |
+| `taskboard` | kanban-style task cards                 |
+
+A small `wmsrv` runs inside `lucifer.b` (the `preswmloop`) so app artifacts get a real `wmclient` window and behave like normal Inferno® apps.
+
+### Context (`lucictx.b`, right ~25%)
+
+- **Resources** — files and URLs the agent has surfaced.
+- **Gaps** — things the agent flagged as missing (knowledge, files, capabilities).
+- **Tasks** — in-flight background work.
+- **Tool toggles** — enable/disable tools at runtime; reflects bindings in `/tool`.
+
+## Components
+
+| File (in `appl/cmd/`) | Role |
+|-----------------------|------|
+| `lucifer.b`     | Main window owner. Header bar, separators, mouse routing, mini wmsrv for the presentation zone, font and theme loading. |
+| `luciconv.b`    | Conversation zone implementation. |
+| `lucictx.b`     | Context zone implementation; mounts `/tool` for tool discovery. |
+| `lucipres.b`    | Presentation zone implementation; renderer registry and app lifecycle. |
+| `luciuisrv.b`   | 9P server backing `/n/ui`. Activities, conversation, presentation, context — all UI state lives here. |
+| `lucibridge.b`  | Agent bridge. Reads user input from `/n/ui/activity/N/conversation/input`, runs the Veltro tool loop, writes responses back. |
+| `lucitheme.b`   | Theme loader and colour lookup. |
+
+## Filesystem map
+
+Lucifer stitches together several 9P services. Once the UI is up, you can `cat` any of these from a shell.
+
+| Mount        | Server      | What lives there |
+|--------------|-------------|------------------|
+| `/n/ui`      | luciuisrv   | All UI state. `/n/ui/ctl` to create/delete activities; `/n/ui/activity/N/{conversation,presentation,context}` for each zone. |
+| `/n/llm`     | llmsrv      | LLM sessions. `/n/llm/new` clones a fresh session; each `/n/llm/N/` exposes `ask`, `stream`, `model`, `thinking`, `system`, `compact`, `context`. |
+| `/n/speech`  | speech9p    | `say` (write text → TTS), `hear` (write `start`, then read transcription), `voices`, `ctl`. |
+| `/tool`      | tools9p     | Tool registry. `/tool/tools` lists tools; `/tool/paths` lists exposed host paths; `/tool/ctl` toggles state. |
+| `/n/local`   | (lucibridge)| Read-only host paths plus per-activity writable directories. |
+
+### Activities
+
+An **activity** is a conversation session. The launch script creates `Main` (id `0`); you can add more via:
+
+```
+; echo activity create Sidebar > /n/ui/ctl
+```
+
+Each activity is rooted at `/n/ui/activity/N/` with three subtrees mirroring the zones. Multiple activities can run; the header bar shows the focused one.
+
+### Driving the UI from the shell
+
+The presentation zone's control file is `/n/ui/activity/N/presentation/ctl`. Examples:
+
+```
+; echo 'create id=notes type=markdown label=Notes' > /n/ui/activity/0/presentation/ctl
+; echo 'create id=todo  type=taskboard label=Tasks' > /n/ui/activity/0/presentation/ctl
+; echo 'destroy id=notes'                          > /n/ui/activity/0/presentation/ctl
+```
+
+This is the same surface the agent uses — so anything Veltro does, you can do by hand.
+
+## Voice
+
+Click **Voice** in the conversation zone:
+
+1. `luciconv` spawns a `voiceworker` goroutine.
+2. The worker writes `start` to `/n/speech/hear` (speech9p) and reads the transcription (30-second timeout).
+3. On success, the transcribed text is written to `/n/ui/activity/N/conversation/input` as a user message.
+4. The agent's reply can optionally be read back by writing it to `/n/speech/say`.
+
+`speech9p` is started by the launch script; it ships with InferNode and runs entirely inside the emulator.
+
+## Themes
+
+Themes live in `lib/lucifer/theme/`:
+
+```
+lib/lucifer/theme/
+├── current        # one line: name of the active theme
+├── brimstone      # default dark theme (key/value, hex colours)
+└── halo           # alternate
+```
+
+Theme files are flat `key value` pairs (`#` comments allowed). The launch script writes `brimstone` to `current` if no theme is selected. Custom themes go alongside; `lucitheme.m` defines about 80 colour keys (core UI, conversation, code, editor, mermaid, menu, window chrome). Missing keys fall back to Brimstone defaults — partial themes are fine.
+
+To switch:
+
+```sh
+echo halo > lib/lucifer/theme/current
+# restart Lucifer
+```
+
+## The default tool budget
+
+`tools9p` is started with these capabilities (see `run-lucia*.sh`):
+
+```
+-b read,list,find,search,grep,write,edit,exec,launch,spawn,diff,json,http,
+   git,memory,todo,plan,websearch,mail,keyring,present,gap
+```
+
+The `-b` list is the **delegation budget** — the maximum a parent agent can hand to a `spawn`'d child. The trailing positional args are the tools loaded for the bridge agent itself. To run more locked down, edit the launch script and remove tools.
+
+For details on what each tool does and how capability attenuation works, see [VELTRO.md](VELTRO.md) and [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md).
+
+## Multiple activities, scripted setup
+
+You can pre-populate Lucifer at launch by appending commands to `LUCIFER_CMD` in the launch script. Example: open the Veltro tour artifact and a fractal app on startup.
+
+```
+echo 'create id=tour    type=markdown   label=Tour'   > /n/ui/activity/0/presentation/ctl
+echo 'create id=fractal type=app app=fractal label=Fractal' > /n/ui/activity/0/presentation/ctl
+```
+
+Anything you can write through `/n/ui/...` from a normal shell works at startup too.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Blank black window, no header | `lucitheme` failed to load (corrupted `.dis`, missing file). | Rebuild: `cd appl/cmd && mk lucitheme.dis`. See [LUCIA-EVALUATION.md §P0.1](LUCIA-EVALUATION.md). |
+| `ANTHROPIC_API_KEY not set` warning | Host env var missing | `export ANTHROPIC_API_KEY=sk-ant-…` and relaunch. |
+| Voice button does nothing for 30s | `speech9p` not running, or no host audio access | Check `/n/speech` exists; on Linux confirm PulseAudio/PipeWire is reachable from the emulator. |
+| `link typecheck` errors at startup | Stale `.dis` after a `git pull` | `./hooks/install.sh` (one-time) or `cd appl/cmd && mk install`. |
+| Apps fail to launch in the presentation zone | `MAXAPPSLOTS` (16) exhausted | Restart Lucifer. Tracked as a known issue in [LUCIA-EVALUATION.md §P0.2](LUCIA-EVALUATION.md). |
+| Header shows no activity label | `nslistener` isn't seeing `status`/`label` events | Confirm `luciuisrv` is running: `ps | grep luciuisrv`. |
+
+## See also
+
+- [USER-MANUAL.md](USER-MANUAL.md) — namespace and host-integration basics.
+- [VELTRO.md](VELTRO.md) — the agent system that drives Lucifer.
+- [XENITH.md](XENITH.md) — the AI-native text environment used inside the presentation zone.
+- [LUCIA-EVALUATION.md](LUCIA-EVALUATION.md) — production-readiness audit (P0/P1/P2 issues).
+- [DIALOGUE-TILES.md](DIALOGUE-TILES.md) — interactive dialogue/form tile reference.
+- [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md) — namespace isolation model.

--- a/docs/VELTRO.md
+++ b/docs/VELTRO.md
@@ -22,7 +22,7 @@ Three things the agent sees as files: **the LLM, the tools, the host filesystem*
 | `veltro`  | one-shot, `veltro "do X"`     | scripted tasks, batch runs, resumable sessions                        |
 | `repl`    | interactive                   | iterative work; opens a Xenith window if available, terminal otherwise|
 | `spawn`   | inside a tool call            | parallel subagents launched by a parent agent                         |
-| `lucibridge` | embedded in Lucifer GUI    | the agent loop driving the [Lucifer](LUCIFER-GUI.md) UI               |
+| `lucibridge` | embedded in Lucia          | the agent loop driving the [Lucia](LUCIA.md) UI                       |
 
 ### `veltro` — one-shot
 
@@ -119,7 +119,7 @@ When `tools9p` is started, two flags shape what agents see:
 - The **positional tools** are loaded for the agent running this `tools9p`.
 - The `-b` budget is the **maximum a child can be granted**. Subagents can never exceed it.
 
-The Lucifer launch scripts (`run-lucia.sh`, `run-lucia-linux.sh`) show a typical configuration. Edit them to lock down a deployment.
+The Lucia launch scripts (`run-lucia.sh`, `run-lucia-linux.sh`) show a typical configuration. Edit them to lock down a deployment.
 
 ## LLM configuration
 
@@ -216,9 +216,9 @@ Spawn -- tools=read,list,grep :: find every place that touches /n/llm
 
 The three children run in parallel, each in its own restricted namespace. Results stream back to the parent's conversation.
 
-### Embedded in Lucifer
+### Embedded in Lucia
 
-The Lucifer launch scripts wire everything up: `tools9p` with the default budget, `lucibridge` as the agent loop, `speech9p` for voice. See [LUCIFER-GUI.md](LUCIFER-GUI.md).
+The Lucia launch scripts wire everything up: `tools9p` with the default budget, `lucibridge` as the agent loop, `speech9p` for voice. See [LUCIA.md](LUCIA.md).
 
 ## Hardening checklist
 
@@ -246,7 +246,7 @@ For deployments where untrusted prompts may reach the agent:
 
 - [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md) — namespace isolation model (the security boundary).
 - [appl/veltro/IDEAS.md](../appl/veltro/IDEAS.md) — implemented features and roadmap.
-- [LUCIFER-GUI.md](LUCIFER-GUI.md) — the GUI driven by `lucibridge`.
+- [LUCIA.md](LUCIA.md) — the GUI driven by `lucibridge`.
 - [NAMESPACE.md](NAMESPACE.md) — namespace primitives Veltro builds on.
 - [WALLET-AND-PAYMENTS.md](WALLET-AND-PAYMENTS.md) — wallet and x402, used by `wallet` and `payfetch` tools.
 - [formal-verification/README.md](../formal-verification/README.md) — TLA+/SPIN/CBMC proofs of namespace isolation.

--- a/docs/VELTRO.md
+++ b/docs/VELTRO.md
@@ -1,0 +1,252 @@
+# Veltro
+
+**Purpose:** User and operator guide for Veltro, InferNode's AI agent system.
+
+> Looking for the security model? See [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md) for the namespace isolation design (FORKNS + bind-replace, capability attenuation, three harness entry points). This document covers day-to-day usage.
+
+## What it is
+
+Veltro is a Limbo-native agent harness:
+
+- Talks to an LLM via the **`/n/llm`** 9P filesystem (Anthropic Claude or any OpenAI-compatible backend through `llmsrv`).
+- Calls **40 tools** via the **`/tool`** 9P filesystem, each tool a separate `.dis` module.
+- Runs inside a **restricted namespace** (FORKNS + bind-replace) so an agent only sees the files and capabilities its caller granted.
+- Can **spawn subagents** with strictly narrower namespaces (capability attenuation).
+
+Three things the agent sees as files: **the LLM, the tools, the host filesystem**. There is no SDK, no JSON-RPC, no HTTP — everything is read/write on a 9P tree.
+
+## Entry points
+
+| Command   | Form                          | Use for                                                               |
+|-----------|-------------------------------|-----------------------------------------------------------------------|
+| `veltro`  | one-shot, `veltro "do X"`     | scripted tasks, batch runs, resumable sessions                        |
+| `repl`    | interactive                   | iterative work; opens a Xenith window if available, terminal otherwise|
+| `spawn`   | inside a tool call            | parallel subagents launched by a parent agent                         |
+| `lucibridge` | embedded in Lucifer GUI    | the agent loop driving the [Lucifer](LUCIFER-GUI.md) UI               |
+
+### `veltro` — one-shot
+
+```sh
+; veltro "summarise the changes in this branch"
+; veltro -t -p $home/proj "refactor the auth module"
+; veltro -r last  "now add tests"          # resume the most recent session
+; veltro -r work-1 "..."                   # resume a named session
+; veltro -v "..."                          # verbose
+```
+
+Flags:
+
+- `-v` — verbose tool/LLM logging.
+- `-t` — enable extended thinking (8000-token budget).
+- `-r name` — resume a persisted session (`last` = most recent).
+- `-p paths` — comma-separated host paths to expose under `/n/local/`.
+
+Sessions persist to `/usr/inferno/veltro/sessions/`. The hard step cap is 200 (the LLM's `end_turn` is the primary stop condition).
+
+### `repl` — interactive
+
+```sh
+; repl
+; repl -v
+; repl -n 80      # raise per-turn step cap (default 50, max 100)
+```
+
+Two modes, picked automatically:
+
+- **Xenith mode** (when `/chan` is available) — a window with **Send · Voice · Clear · Reset · Delete** tag buttons. Voice records via `speech9p` and transcribes with the `hear` tool.
+- **Terminal mode** — line-oriented stdin/stdout fallback.
+
+Both establish a persistent LLM session for the duration of the REPL invocation. Each turn injects the current namespace into the system prompt so the agent always knows what tools and paths it actually has.
+
+### `spawn` (subagents)
+
+A parent agent calls the `spawn` tool to launch up to 5 subagents in parallel:
+
+```
+Spawn -- tools=read,list :: explore appl/veltro
+       -- tools=write,edit :: update the README
+```
+
+Each child gets:
+
+- A forked namespace with `bind-replace` restrictions narrower than the parent's.
+- Its own LLM session with optional model/temperature/thinking overrides.
+- A pre-loaded set of tool modules (no `tools9p` for subagents).
+- A 5-minute default timeout.
+
+A child can never exceed the parent's capabilities; it can only narrow them further. See [SECURITY.md §Capability attenuation](../appl/veltro/SECURITY.md).
+
+## Tools
+
+Forty tools live in `appl/veltro/tools/`. Each is a `.dis` module implementing a small interface (`init`, `name`, `doc`, `exec`) defined in [`tool.m`](../appl/veltro/tool.m). Tools are loaded on demand and exposed to the agent through `/tool`.
+
+| Category       | Tools |
+|----------------|-------|
+| **Files**      | `read`, `write`, `edit`, `list`, `find`, `search`, `grep`, `diff` |
+| **Execution**  | `exec`, `shell`, `launch`, `spawn`, `safeexec` |
+| **Code**       | `git`, `json`, `vision`, `editor` |
+| **Web**        | `webfetch`, `websearch`, `browse`, `charon`, `http` |
+| **Comms**      | `mail`, `say`, `hear` |
+| **Persistence**| `memory`, `todo`, `task`, `wiki`, `keyring`, `wallet`, `payfetch` |
+| **UI**         | `xenith`, `present`, `gap`, `man`, `fractal`, `plan` |
+| **System**     | `mount`, `gpu` |
+
+Run `cat /tool/tools` in a Veltro shell to list whatever tools the running agent actually has — the namespace-restricted view, not the full 40.
+
+## Capabilities and the tool budget
+
+Capabilities are granted at **namespace construction time**, not per call. The `Capabilities` adt in [`nsconstruct.m`](../appl/veltro/nsconstruct.m) names the dimensions:
+
+| Field         | Meaning |
+|---------------|---------|
+| `tools`       | Which tools to load and expose. |
+| `paths`       | Host filesystem dirs surfaced under `/n/local/`. |
+| `shellcmds`   | If non-nil, enables `exec` with this allowlist plus `sh.dis`. |
+| `llmconfig`   | Per-agent model, temperature, system prompt, thinking budget. |
+| `xenith`      | Grant `/chan` (Xenith window access). |
+| `memory`      | Enable persistent memory store. |
+| `mcproviders` | mc9p providers to spawn (HTTP, fs, search) with domain/network grants. |
+
+When `tools9p` is started, two flags shape what agents see:
+
+```sh
+/dis/veltro/tools9p \
+  -m /tool \
+  -b read,list,find,search,grep,write,edit,...   # delegation budget (max for spawn)
+  read list find present say hear ...            # tools loaded for THIS agent
+```
+
+- The **positional tools** are loaded for the agent running this `tools9p`.
+- The `-b` budget is the **maximum a child can be granted**. Subagents can never exceed it.
+
+The Lucifer launch scripts (`run-lucia.sh`, `run-lucia-linux.sh`) show a typical configuration. Edit them to lock down a deployment.
+
+## LLM configuration
+
+LLM state lives at `/n/llm`, served by `llmsrv` (`appl/cmd/llmsrv.b`).
+
+```
+/n/llm/new            # read it to allocate a fresh session id
+/n/llm/N/ask          # write a user message, read a full response
+/n/llm/N/stream       # streaming response
+/n/llm/N/model        # haiku | sonnet | opus  (or any backend-specific id)
+/n/llm/N/temperature  # 0.0 – 2.0
+/n/llm/N/thinking     # disabled | max | <integer token budget>
+/n/llm/N/system       # write-only system prompt
+/n/llm/N/context      # read current conversation as JSON
+/n/llm/N/compact      # summarise+truncate to free tokens
+```
+
+Default model: **haiku**. Override with the `LLMConfig` field of `Capabilities`, or by writing to `/n/llm/N/model` directly.
+
+### Backends
+
+`llmsrv` is started by `lib/sh/profile`. To use a non-Anthropic backend:
+
+```sh
+llmsrv -b openai -u https://my-host/v1 -M my-model
+```
+
+`-b api` (default) is the Anthropic Claude API; `-b openai` speaks any OpenAI-compatible endpoint (Ollama, vLLM, OpenAI itself).
+
+The host environment variable `ANTHROPIC_API_KEY` is provisioned into factotum by the profile and consumed by `llmsrv` automatically.
+
+## Agent prompts
+
+System prompts and per-type prompts live in `lib/veltro/`:
+
+| File                          | Role |
+|-------------------------------|------|
+| `lib/veltro/system.txt`       | Default system prompt for `veltro`/`repl`. |
+| `lib/veltro/meta.txt`         | "Chief of Staff" prompt used by Lucia: never executes, always delegates via `task`. |
+| `lib/veltro/agents/default.txt`  | Subagent baseline. Pre-loaded tools, machine-parseable output, terminate with `DONE`. |
+| `lib/veltro/agents/explore.txt`  | Read-only codebase analysis. No speculation; report file paths and dependencies. |
+| `lib/veltro/agents/plan.txt`     | Architecture/design only. Never implements. |
+| `lib/veltro/agents/task.txt`     | Autonomous task execution; uses `plan`/`todo` for multi-step work. |
+| `lib/veltro/agents/secretary.txt`| Mail-handling agent for the `mail` tool. |
+
+Custom agents: drop a `.txt` file into `lib/veltro/agents/` and pick it via `agenttype=` in a `spawn` call.
+
+## Reminders
+
+`lib/veltro/reminders/` holds short context snippets that are injected into the system prompt when the relevant capability or state is detected:
+
+```
+file-modified.txt    git.txt              inferno-shell.txt
+plan-mode.txt        security.txt         xenith.txt
+```
+
+`agentlib->discovernamespace()` runs at the start of each turn, sees what's mounted, and selects matching reminders. Add a reminder by dropping a new `.txt` file alongside the existing ones — the discovery code picks it up automatically when its trigger condition fires.
+
+## Memory and persistence
+
+Two distinct stores:
+
+- **`memory` tool** — agent-controlled key/value store. `memory save K V`, `memory load K`, `memory list`, `memory clear`. Persists to `/tmp/veltro/memory/{agentid}/`.
+- **Sessions** — full conversation transcripts for `veltro`, written to `/usr/inferno/veltro/sessions/`. Resume with `veltro -r name` or `veltro -r last`.
+
+`repl` does **not** persist conversations across REPL restarts; use `veltro` for that.
+
+## Common workflows
+
+### One-shot scripted task
+
+```sh
+; veltro "list every TODO in appl/veltro and group by file"
+```
+
+### Iterative exploration
+
+```sh
+; repl
+> walk me through how spawn enforces capability attenuation
+> show me where MREPL is used in nsconstruct.b
+> are there tests for this?
+```
+
+### Parallel delegation
+
+A parent agent issues a single tool call:
+
+```
+Spawn -- tools=read,list,grep :: find every place that touches /n/llm
+       -- tools=read,list,grep :: find every place that touches /n/ui
+       -- tools=read,list,grep :: find every place that touches /tool
+```
+
+The three children run in parallel, each in its own restricted namespace. Results stream back to the parent's conversation.
+
+### Embedded in Lucifer
+
+The Lucifer launch scripts wire everything up: `tools9p` with the default budget, `lucibridge` as the agent loop, `speech9p` for voice. See [LUCIFER-GUI.md](LUCIFER-GUI.md).
+
+## Hardening checklist
+
+For deployments where untrusted prompts may reach the agent:
+
+1. **Trim the tool budget** — remove `exec`, `shell`, `launch`, `spawn`, `mail`, `git`, `keyring`, `wallet` from `-b` and the positional tool list in your launch script.
+2. **Restrict `-p` paths** — only mount what the agent legitimately needs.
+3. **Disable `xenith` and `memory`** in the `Capabilities` you construct.
+4. **Pin `llmconfig.model`** so prompt-injected attempts to switch to a more permissive model can't take effect.
+5. **Use the `secretary` or a custom prompt** rather than `meta.txt` to avoid Chief-of-Staff delegation patterns.
+6. Read [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md) end to end. The namespace model is the security boundary; treat the LLM and its prompt as untrusted.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `cannot load module testing.dis` and friends | Stale `.dis` after `git pull` | `./hooks/install.sh` (once); `mk install` in `appl/cmd` and `appl/veltro` |
+| `/n/llm: file does not exist` | `llmsrv` not started | Run as `sh -l` so `lib/sh/profile` starts it; check `ANTHROPIC_API_KEY` |
+| Agent says it has tool X but `/tool` doesn't list it | Tool not in the positional list of `tools9p` | Add it to the launch script, or rely on `spawn` (subject to `-b` budget) |
+| `tools9p` deadlock on the first tool call | Self-mount race during namespace restriction | Already mitigated; if it recurs, check `nsconstruct.b` hasn't been edited to add a `stat()` on the restricted root |
+| Subagent times out at 5 minutes | Default `spawn` timeout | Pass `timeout=N` (seconds) in the `spawn` call |
+| Memory writes silently lost | Wrong agent id | The `memory` tool keys by sandbox id; confirm with `memory list` |
+
+## See also
+
+- [appl/veltro/SECURITY.md](../appl/veltro/SECURITY.md) — namespace isolation model (the security boundary).
+- [appl/veltro/IDEAS.md](../appl/veltro/IDEAS.md) — implemented features and roadmap.
+- [LUCIFER-GUI.md](LUCIFER-GUI.md) — the GUI driven by `lucibridge`.
+- [NAMESPACE.md](NAMESPACE.md) — namespace primitives Veltro builds on.
+- [WALLET-AND-PAYMENTS.md](WALLET-AND-PAYMENTS.md) — wallet and x402, used by `wallet` and `payfetch` tools.
+- [formal-verification/README.md](../formal-verification/README.md) — TLA+/SPIN/CBMC proofs of namespace isolation.


### PR DESCRIPTION
## Summary

This PR adds three major user-facing documentation files to guide operators and developers through InferNode's key subsystems:

1. **LUCIA.md** — Complete guide to the Lucia desktop UI, covering the three-zone layout, launching, activities, voice input, themes, and troubleshooting.
2. **VELTRO.md** — Comprehensive agent system guide covering entry points (veltro/repl/spawn/lucibridge), 40 tools, capability model, LLM configuration, and hardening checklist.
3. **JIT.md** — User-facing JIT compilation summary: when to enable it, speedup numbers, opcode coverage, W^X compliance, and diagnostics.

All three documents are cross-linked to each other and to existing docs (SECURITY.md, XENITH.md, BENCHMARKS.md, etc.). The DOCUMENTATION-INDEX.md is updated to surface these new guides.

## Changes

- **docs/LUCIA.md** (218 lines) — Three-zone UI architecture, component layout, filesystem map, activities, voice, themes, tool budget, and troubleshooting table.
- **docs/VELTRO.md** (252 lines) — Agent entry points, 40 tools by category, capability model, LLM backends, system prompts, memory/persistence, workflows, and hardening checklist.
- **docs/JIT.md** (144 lines) — JIT overview, speedup benchmarks, `-c` flag levels, opcode coverage (ARM64/AMD64), W^X compliance, and diagnostics.
- **docs/DOCUMENTATION-INDEX.md** (modified) — Added LUCIA.md and VELTRO.md to the index with brief descriptions.

## Testing

No testing needed — these are documentation-only additions. The files are self-contained guides with no code changes or build artifacts.

## Checklist

- [x] Documentation added and cross-linked
- [x] No code or build artifacts modified
- [x] No secrets or credentials included
- [x] Follows existing documentation style and structure

https://claude.ai/code/session_01L9X13vMFPhHUauYHAUx7VS