### PR TITLE
docs: surface the existing Veltro tour as onboarding (INFR-15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ For the SDL3 GUI, see [docs/WINDOWS-BUILD.md](docs/WINDOWS-BUILD.md).
 
 The `-c1` flag enables the JIT; `-r.` tells the emulator to use the current directory as the Inferno® root. See [QUICKSTART.md](QUICKSTART.md) and [docs/USER-MANUAL.md](docs/USER-MANUAL.md) for more.
 
+## Try the agent
+
+Once Lucia is up, type **`run the tour`** in the conversation zone on the left. Veltro (the in-system AI agent) walks you through the system live — opening windows, launching the fractal viewer and editor, demonstrating namespace isolation, persistent memory, and voice — using its own tools in real time. Twelve self-paced sections, nothing pre-recorded. Headless: `./emu/<plat>/o.emu -c1 -r. veltro 'run the tour'`. Full notes in [RUN_TOUR.md](RUN_TOUR.md).
+
 ## Highlights
 
 - **Lightweight** — 15–30 MB RAM, 2-second startup, ~10 MB on disk.
@@ -99,6 +103,7 @@ Speedups are v1 suite (6 benchmarks, best-of-3). Full data: [docs/BENCHMARKS.md]
 ## Documentation
 
 - [QUICKSTART.md](QUICKSTART.md) — running in under a minute
+- [RUN_TOUR.md](RUN_TOUR.md) — interactive Veltro feature tour (`run the tour`)
 - [docs/USER-MANUAL.md](docs/USER-MANUAL.md) — namespaces, devices, host integration
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system architecture
 - [docs/XENITH.md](docs/XENITH.md) — AI-native text environment

--- a/docs/USER-MANUAL.md
+++ b/docs/USER-MANUAL.md
@@ -2,6 +2,12 @@
 
 A practical guide to using InferNode, the AI-agent-friendly operating system.
 
+> **First time?** The fastest way to see what InferNode does is the
+> interactive guided tour. Launch Lucia and type `run the tour` in the
+> conversation zone, or run `veltro 'run the tour'` from a headless
+> shell. See [RUN_TOUR.md](../RUN_TOUR.md). The rest of this manual is
+> the reference; the tour is the demo.
+
 ---
 
 ## Table of Contents

--- a/lib/veltro/welcome.md
+++ b/lib/veltro/welcome.md
@@ -22,7 +22,20 @@ across sessions, browse the web, send email, draw fractals, and more.
 Everything I do is visible — my tools are files, my actions show up in
 your workspace. 
 
-## Things to try
+## Start here: the guided tour
+
+> **Say "run the tour"** in the conversation zone on the left.
+
+I will walk you through the system interactively — opening windows,
+demonstrating tools, and letting you try things hands-on. It is the
+fastest way to see what InferNode actually does. Twelve sections,
+self-paced, runs live (nothing pre-recorded; I am using my own tools
+in real time).
+
+If you would rather poke around on your own, the rest of this page is
+the cheat sheet.
+
+## Other things to try
 
 **Talk to me.** Ask a question, give me a task, or just say hello.
 
@@ -34,10 +47,6 @@ your workspace.
 
 **Explore the system.** Ask me to show you what's in `/appl` or
 `/module`, or to explain how the namespace works.
-
-**Run the guided tour.** Say **"run the tour"** and I will walk you
-through the system interactively — opening windows, demonstrating tools,
-and letting you try things hands-on.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
Promote the interactive `run the tour` demo from a buried fourth bullet to the recommended first action across the three doc surfaces a new user lands on:

- **README.md** — new "Try the agent" section right after Quick Start; RUN_TOUR.md added to the Documentation list
- **docs/USER-MANUAL.md** — callout block at the top of the manual ("First time? The fastest way…")
- **lib/veltro/welcome.md** (Lucia first-launch) — tour becomes the recommended first action, no longer one of four bullets

Refs: [INFR-15](https://nervsystems-team.atlassian.net/browse/INFR-15)

## Non-changes (per ticket non-goals)
- The twelve-section tour script in `lib/veltro/demos/tour.txt` is unchanged
- The `veltro` / `repl` dispatch path is unchanged
- No new onboarding wizard built — we have one (the tour); this PR makes it findable

## Test plan
- [x] Markdown structural lint clean on all three files (balanced fences, no broken links)
- [x] `appl/cmd/lucibridge.b::showwelcome()` confirmed to read welcome.md as raw bytes (`sys->open` → `read` → push to `/n/ui/.../presentation/welcome/data`) — no parser, no structural expectations on the markdown
- [x] Tour-related runtime code paths verified unchanged: `lib/veltro/demos/tour.txt`, `appl/veltro/{veltro,repl}.b`, the `present`/`launch`/`say` tools the tour invokes
- [x] Visually verified rendering by launching Lucia from this branch (worktree off origin/master), backing up the `welcome_shown`/`tour_offered` markers, logging in, and confirming welcome.md centers in the presentation zone with the new "Start here: the guided tour" callout as the first action below the intro. Markers restored after the test.

## Notes
- Hit a pre-existing `origin/master` defect during the smoke test: stale `.dis` files (`lucifer`, `lucictx`, `luciconv`, `lucipres`) compiled against the old `lucitheme.m` interface caused a black post-login screen on a fresh clone. **Filed separately as [INFR-20](https://nervsystems-team.atlassian.net/browse/INFR-20).** Worked around in this worktree by recompiling those four files; rebuilt `.dis` are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)