### PR TITLE
serve-llm: keyring auth default, --anon-lan opt-in (INFR-16)

### DIFF
--- a/docs/HEADLESS-LLM-DAEMON.md
+++ b/docs/HEADLESS-LLM-DAEMON.md
@@ -206,11 +206,24 @@ Two scripts in the repository wire the daemon together:
   `PATH`, pre-flights the Ollama API, and execs `emu` against the lean
   profile. It is the entry point the systemd unit will call.
 
-Start it ad-hoc to verify everything works before installing the unit:
+First-run prerequisite (since INFR-16): generate the signer keyfile
+that the keyring-authenticated listener requires.
+
+```sh
+./serve-llm.sh --gen-key
+# wrote /home/<you>/.infernode/lib/keyring/serve-llm
+```
+
+Then start the daemon ad-hoc to verify everything works before
+installing the unit:
 
 ```sh
 ./serve-llm.sh
 ```
+
+(If you specifically want anonymous attach on a trusted-LAN deployment,
+pass `--anon-lan` instead — see `Hardening` § `--anon-lan: opting out`
+below for the trade-offs.)
 
 You should see the wrapper announce itself, then a couple of lines of
 emulator startup, then output of the form:
@@ -361,14 +374,22 @@ visible to all child processes that fork the namespace.
 
 ### From the InferNode shell
 
-Equivalent direct command, run from the InferNode shell after start:
+If the server runs the default keyring-authenticated listener, copy the
+server's keyfile (`~/.infernode/lib/keyring/serve-llm` on the server)
+to the client and mount with `-k`:
+
+```sh
+mount -k /usr/$user/keyring/serve-llm 'tcp!server.example.net!5640' /n/llm
+```
+
+If the server explicitly runs `--anon-lan`, mount with `-A`:
 
 ```sh
 mount -A 'tcp!server.example.net!5640' /n/llm
 ```
 
-`-A` selects unauthenticated 9P. For authenticated 9P over an Inferno
-keyring, see the **Hardening** section below.
+`-A` is only safe on a trusted network. See **Hardening** §
+`--anon-lan: opting out` for when this is and isn't appropriate.
 
 ## Step 7: Verify end-to-end
 
@@ -500,33 +521,72 @@ service config (`~/.infernode/lib/ndb/llm`) and restart.
 
 ## Hardening
 
-The defaults in this tutorial trade away security for ease of setup.
-Before exposing the service beyond a trusted network, address each of
-the following.
+The hardening sections below cover non-default concerns. Authentication
+itself is **on by default as of INFR-16** — the section immediately
+below describes how to set up the keyfile a fresh install needs.
 
-### Authentication
+### Authentication (default — keyring)
 
-`listen -A` and `mount -A` bypass authentication. Anyone who can reach
-the TCP port can open sessions. For trusted networks (LAN, ZeroTier,
-Tailscale) this is often acceptable; for the open internet it is not.
+`serve-llm.sh` listens with Inferno Ed25519 keyring authentication by
+default. Clients must dial with `mount -k <keyfile>`. On a fresh
+install the daemon refuses to start until you generate the signer
+keyfile:
 
-To enable Inferno keyring authentication:
+```sh
+./serve-llm.sh --gen-key
+# wrote /home/<you>/.infernode/lib/keyring/serve-llm (~690 bytes; mode 600)
+# clients dial with: mount -k <keyfile> tcp!<host>!5640 /n/llm
+```
 
-1. Generate a keyfile on the server: see `appl/cmd/auth/` for the
-   relevant tooling (`changelogin`, `getauthinfo`).
-2. Distribute the public component to authorised clients.
-3. In `lib/sh/serve-profile`, replace
-   ```
-   listen -sA 'tcp!*!5640' {export /n/llm}
-   ```
-   with
-   ```
-   listen -s -k /usr/$user/keyring/default 'tcp!*!5640' {export /n/llm}
-   ```
-4. On the client, `mount -k /usr/$user/keyring/default 'tcp!host!5640' /n/llm`.
+`--gen-key` invokes `auth/createsignerkey -a ed25519` inside emu and
+stages the file under `~/.infernode/lib/keyring/`. `serve-profile`
+binds that directory over `/lib/keyring` inside the namespace, so the
+in-emu path is `/lib/keyring/serve-llm`. The keyfile is mode 600 —
+keep it that way.
 
-The pattern is exercised by `tests/test-distributed.sh`, which sets up
-two emulator instances communicating over authenticated, encrypted 9P.
+Distribute the keyfile to each authorised client (scp, your password
+manager, etc.). Each client mounts with:
+
+```sh
+mount -k /home/<you>/.infernode/lib/keyring/serve-llm 'tcp!server!5640' /n/llm
+```
+
+Or, if you've configured `~/.infernode/lib/ndb/llm` with `mode=remote`
+and `dial=tcp!server!5640`, the desktop will use the keyfile path you
+configure in Settings (after the GUI gains a keyfile field — for now,
+hand-edit `~/.infernode/lib/ndb/llm` to add `keyfile=<path>`).
+
+The pattern is exercised end-to-end by `tests/test-distributed.sh`,
+which sets up two emulator instances communicating over authenticated,
+encrypted 9P.
+
+### `--anon-lan`: opting out
+
+The pre-INFR-16 default was anonymous attach (`-A`) — anyone reaching
+the TCP port could mount `/n/llm` and use the user's local Ollama or
+API credentials. That mode is preserved behind an explicit flag:
+
+```sh
+./serve-llm.sh --anon-lan
+# WARNING: listen mode anon (--anon-lan) - no authentication
+# anyone reaching :5640 can mount /n/llm
+```
+
+Use only on a network where you've already established trust (LAN
+behind a firewall, ZeroTier with strict ACLs, WireGuard / Tailscale
+peer-to-peer). Public-internet exposure with `--anon-lan` is the same
+shape of bug as OpenClaw's CVE-2026-25253 (anonymous attach to a
+service that holds local credentials), at the network layer instead
+of the HTTP layer.
+
+If you have an existing systemd unit invoking `serve-llm.sh` with no
+arguments, **upgrading to a build with INFR-16 requires** either:
+
+- Generating a keyfile (`./serve-llm.sh --gen-key`) — recommended.
+- Editing the unit file to pass `--anon-lan`.
+
+Otherwise the daemon will exit with a clear error pointing at both
+remediations.
 
 ### Network exposure
 

--- a/lib/sh/serve-profile
+++ b/lib/sh/serve-profile
@@ -8,8 +8,12 @@
 # Started by serve-llm.sh on the host:
 #   emu -c1 -r$ROOT sh /lib/sh/serve-profile
 #
-# Round 2 will add gpusrv (TensorRT 9P) once emu is rebuilt with GPU
-# support (mkfile-gpu-1).
+# Listen-side authentication mode is read from the host environment via
+# `os sh`:
+#   SERVE_LLM_AUTH=keyring   (default; requires keyfile)
+#   SERVE_LLM_AUTH=anon      (--anon-lan opt-in; preserves pre-INFR-16 behaviour)
+#   SERVE_LLM_KEY=<path>     (in-emu path to the signer keyfile; default /lib/keyring/serve-llm)
+# These are set by serve-llm.sh; never edit this profile to flip them.
 
 load std
 path=(/dis .)
@@ -22,12 +26,16 @@ ndb/cs
 # ── Host filesystem (read-only is fine for the daemon) ─────
 trfs '#U*' /n/local
 
-# ── Bind user config over /lib/ndb so the daemon reads the
-#    same backend/model the desktop is configured with. ────
+# ── Bind user config over /lib/ndb (same backend/model the desktop
+#    uses) and /lib/keyring (signer keys) into the in-emu namespace. ──
 ghome=/n/local/^`{echo 'echo $HOME' | os sh}
 infhome=$ghome^/.infernode
 if {ftest -d $infhome/lib/ndb} {
 	bind -bc $infhome/lib/ndb /lib/ndb
+}
+if {ftest -d $infhome/lib/keyring} {
+	mkdir -p /lib/keyring >[2] /dev/null
+	bind -bc $infhome/lib/keyring /lib/keyring
 }
 
 # ── LLM service (mounts /n/llm) ─────────────────────────────
@@ -49,7 +57,28 @@ if {~ $llmbackend openai} {
 sleep 2
 
 # ── 9P export ───────────────────────────────────────────────
-# -A: no auth (LAN/ZeroTier only — switch to keyring for prod)
+# Default: keyring auth (Inferno Ed25519 signer). Clients dial with
+#   mount -k <keyfile> tcp!host!5640 /n/llm
+# --anon-lan: anonymous attach (-A), the pre-INFR-16 default. Only safe
+# on a trusted network (LAN, ZeroTier with strict ACLs, VPN).
 # -s: synchronous, blocks here so emu stays alive while listening.
-# Single quotes around the addr prevent rc from globbing '*'.
-listen -sA 'tcp!*!5640' {export /n/llm}
+#
+# Mode is read from the host environment via `os sh`. serve-llm.sh
+# always exports both vars (defaults baked in there), so we don't try
+# to apply ${VAR:-default} fallbacks here — rc's quoting and brace
+# parsing make that fragile.
+authmode=`{os sh -c 'printf %s "$SERVE_LLM_AUTH"'}
+keyfile=`{os sh -c 'printf %s "$SERVE_LLM_KEY"'}
+if {~ $authmode anon} {
+	echo 'serve-profile: WARNING listen mode anon (--anon-lan) - no authentication'
+	listen -sA 'tcp!*!5640' {export /n/llm}
+}{
+	if {! ftest -f $keyfile} {
+		echo 'serve-profile: ERROR keyring auth requested but keyfile not found at' $keyfile
+		echo 'serve-profile: generate one with: serve-llm.sh --gen-key'
+		echo 'serve-profile: or pass --anon-lan to listen without authentication'
+		exit fail
+	}
+	echo 'serve-profile: listen mode keyring keyfile' $keyfile
+	listen -s -k $keyfile 'tcp!*!5640' {export /n/llm}
+}

--- a/serve-llm.sh
+++ b/serve-llm.sh
@@ -2,27 +2,113 @@
 # serve-llm.sh — Headless InferNode LLM 9P gateway (for systemd).
 #
 # Replaces the standalone llm9p Go daemon with the canonical Limbo
-# llmsrv inside emu, loading lib/sh/serve-profile (a stripped-down
-# rc script that excludes desktop/auth/Veltro overlays).
+# llmsrv inside emu, loading lib/sh/serve-profile.
 #
 # Backend config is read inside emu from
 #   ~/.infernode/lib/ndb/llm
 # (same file the desktop uses).
 #
-# Logs go to stderr; under systemd they land in the journal.
+# Usage:
+#   serve-llm.sh                  # listen with keyring auth (default)
+#   serve-llm.sh --anon-lan       # listen with no authentication
+#                                 # (the pre-INFR-16 default; trusted nets only)
+#   serve-llm.sh --gen-key        # generate the signer keyfile, then exit
+#   serve-llm.sh --help
 #
-# Listener: tcp!*!5640, no auth (-A). For production, swap to
-# `listen -sk /usr/$user/keyring/default ...` and provision keys.
+# Default listener: tcp!*!5640 with Inferno Ed25519 keyring auth.
+# Clients dial with: mount -k <keyfile> tcp!host!5640 /n/llm
+#
+# Logs go to stderr; under systemd they land in the journal.
+# See docs/HEADLESS-LLM-DAEMON.md §Hardening for the full key-distribution
+# story and the trade-offs of --anon-lan.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-EMU="$ROOT/emu/Linux/o.emu"
+
+# Pick the right emu for this platform.
+case "$(uname -s)" in
+	Linux)   EMU="$ROOT/emu/Linux/o.emu" ;;
+	Darwin)  EMU="$ROOT/emu/MacOSX/o.emu" ;;
+	*)       echo "serve-llm: unsupported platform $(uname -s)" >&2; exit 1 ;;
+esac
+
 PROFILE_REL="lib/sh/serve-profile"
 PROFILE_HOST="$ROOT/$PROFILE_REL"
 PROFILE_INF="/$PROFILE_REL"
 
-# Locate Ollama on PATH (it runs outside emu, on the host).
+# Keyfile lives under the user's per-machine state, parallel to the
+# desktop's ~/.infernode/lib/ndb config. serve-profile binds
+# $infhome/lib/keyring over /lib/keyring inside emu, so the in-emu
+# path is /lib/keyring/serve-llm.
+KEY_HOSTPATH="${HOME}/.infernode/lib/keyring/serve-llm"
+KEY_INFPATH="/lib/keyring/serve-llm"
+
+print_help() {
+	sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ───────────────────────────────────────────
+LISTEN_MODE="keyring"
+GEN_KEY=0
+for arg in "$@"; do
+	case "$arg" in
+		--anon-lan) LISTEN_MODE="anon" ;;
+		--gen-key)  GEN_KEY=1 ;;
+		-h|--help)  print_help; exit 0 ;;
+		*) echo "serve-llm: unknown arg: $arg (try --help)" >&2; exit 2 ;;
+	esac
+done
+
+# ── Sanity checks (always) ─────────────────────────────────────
+[ -x "$EMU" ]          || { echo "serve-llm: emu missing at $EMU" >&2; exit 1; }
+[ -f "$PROFILE_HOST" ] || { echo "serve-llm: profile missing at $PROFILE_HOST" >&2; exit 1; }
+
+# ── --gen-key path ─────────────────────────────────────────────
+# One-shot key generation. createsignerkey.dis writes to a path inside
+# the in-emu namespace; we use the in-tree $ROOT/usr/inferno/keyring/
+# (which is the natural Inferno location and where test-distributed.sh
+# also writes) as a staging spot, then mv to the user's $HOME.
+if [ "$GEN_KEY" -eq 1 ]; then
+	if [ -f "$KEY_HOSTPATH" ]; then
+		echo "serve-llm: keyfile already exists at $KEY_HOSTPATH (refusing to overwrite)" >&2
+		echo "serve-llm: delete it manually if you really want to regenerate" >&2
+		exit 1
+	fi
+	mkdir -p "$(dirname "$KEY_HOSTPATH")"
+	OWNER="${USER:-$(id -un)}@$(hostname -s | tr -d '.')"
+	# tr -d '.': createsignerkey rejects '.' in the owner string (it's
+	# a domain-name separator in the keyring's signer protocol).
+
+	STAGE_HOSTPATH="$ROOT/usr/inferno/keyring/serve-llm.staging.$$"
+	STAGE_INFPATH="/usr/inferno/keyring/serve-llm.staging.$$"
+	mkdir -p "$(dirname "$STAGE_HOSTPATH")"
+
+	echo "serve-llm: generating Ed25519 signer key for $OWNER -> $KEY_HOSTPATH" >&2
+
+	# emu may not exit cleanly after the key is written; cap with timeout.
+	# Direct invocation of createsignerkey.dis (no sh -c indirection).
+	timeout 30 "$EMU" -c1 "-r$ROOT" \
+		/dis/auth/createsignerkey.dis \
+		-a ed25519 -f "$STAGE_INFPATH" "$OWNER" \
+		</dev/null >&2 || true
+
+	if [ ! -s "$STAGE_HOSTPATH" ]; then
+		echo "serve-llm: key generation failed (staging file missing or empty)" >&2
+		echo "serve-llm: try running by hand:" >&2
+		echo "  $EMU -r$ROOT /dis/auth/createsignerkey.dis -a ed25519 -f $STAGE_INFPATH $OWNER" >&2
+		rm -f "$STAGE_HOSTPATH"
+		exit 1
+	fi
+
+	mv "$STAGE_HOSTPATH" "$KEY_HOSTPATH"
+	chmod 600 "$KEY_HOSTPATH"
+	echo "serve-llm: wrote $KEY_HOSTPATH ($(wc -c < "$KEY_HOSTPATH") bytes; mode 600)" >&2
+	echo "serve-llm: clients dial with: mount -k $KEY_HOSTPATH tcp!<host>!5640 /n/llm" >&2
+	exit 0
+fi
+
+# ── Locate Ollama on PATH (it runs outside emu, on the host) ──
 # Set OLLAMA_BIN=/full/path/to/ollama if it lives somewhere unusual
 # (e.g. an external SSD on a Jetson).
 if [ -n "${OLLAMA_BIN:-}" ] && [ -x "$OLLAMA_BIN" ]; then
@@ -36,15 +122,38 @@ elif ! command -v ollama >/dev/null 2>&1; then
 	done
 fi
 
-# Sanity checks
-[ -x "$EMU" ]          || { echo "serve-llm: emu missing at $EMU" >&2; exit 1; }
-[ -f "$PROFILE_HOST" ] || { echo "serve-llm: profile missing at $PROFILE_HOST" >&2; exit 1; }
-
 # Pre-flight: warn (don't fail) if Ollama isn't reachable yet — systemd
 # will Restart=always us, so a transient race is fine.
 if ! curl -sf -m 5 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
 	echo "serve-llm: WARN ollama at 127.0.0.1:11434 not responding" >&2
 fi
 
-echo "serve-llm: $(date -Iseconds) emu=$EMU root=$ROOT profile=$PROFILE_INF" >&2
+# ── Validate keyring mode has a keyfile ────────────────────────
+if [ "$LISTEN_MODE" = "keyring" ] && [ ! -s "$KEY_HOSTPATH" ]; then
+	cat >&2 <<EOF
+serve-llm: ERROR no keyfile at $KEY_HOSTPATH
+
+  Anonymous-attach defaults were removed in INFR-16. To proceed, either:
+
+    1. Generate a signer keyfile (recommended):
+         $0 --gen-key
+
+    2. Listen without authentication (only on a trusted network):
+         $0 --anon-lan
+
+  See docs/HEADLESS-LLM-DAEMON.md §Hardening for the trade-offs.
+EOF
+	exit 1
+fi
+
+# ── Hand off to emu, passing intent via env ──────────────────────
+export SERVE_LLM_AUTH="$LISTEN_MODE"
+export SERVE_LLM_KEY="$KEY_INFPATH"
+
+case "$LISTEN_MODE" in
+	keyring) echo "serve-llm: $(date -Iseconds) listen=keyring keyfile=$KEY_HOSTPATH" >&2 ;;
+	anon)    echo "serve-llm: $(date -Iseconds) listen=ANONYMOUS (--anon-lan) anyone reaching :5640 can mount /n/llm" >&2 ;;
+esac
+
+echo "serve-llm: emu=$EMU root=$ROOT profile=$PROFILE_INF" >&2
 exec "$EMU" -c1 "-r$ROOT" sh "$PROFILE_INF"


### PR DESCRIPTION
## Summary
Closes the OpenClaw-CVE-25253-class network-attach hole at the headless LLM daemon: pre-INFR-16 defaults shipped `listen -sA tcp!*!5640 {export /n/llm}` — anyone reachable could mount `/n/llm` and use the user's local Ollama / API credentials with no authentication. Default is now Inferno Ed25519 keyring auth.

- **`serve-llm.sh`** — flag parsing: `--anon-lan` preserves the old `-A` behaviour with a stderr warning; `--gen-key` produces the signer keyfile via `auth/createsignerkey` (matches `tests/test-distributed.sh`); `--help`; default keyring mode refuses to start without a keyfile and prints a remediation block. Cross-platform emu autodetect (Linux / Darwin).
- **`lib/sh/serve-profile`** — reads `SERVE_LLM_AUTH` + `SERVE_LLM_KEY` from host env, binds `$infhome/lib/keyring` over `/lib/keyring` (parallel to the existing ndb bind), branches `listen -sA` vs `listen -s -k <keyfile>`. Refuses keyring mode if keyfile missing.
- **`docs/HEADLESS-LLM-DAEMON.md`** — §Authentication rewritten as "default — keyring" with `--gen-key` flow; new §"`--anon-lan`: opting out" with trust-model trade-offs and the systemd-unit upgrade note; Step 4 / Step 6 examples updated.

Refs: [INFR-16](https://nervsystems-team.atlassian.net/browse/INFR-16)
Spec: ticket § "Architecture" / "Anti-features".

## Architectural alignment
This is the one ticket in the OpenClaw-parity epic where the change is at *network-attach* time, before the namespace exists. The fix is **removing the bypass** (`-A`) and using the existing Inferno keyring primitive — not adding a new layer. No auth daemon, no PKI, no allowlist file format. Per-file changes are surgical.

## Behavioural change for existing deployments
Existing systemd units calling `serve-llm.sh` with no arguments **will fail to start** after this lands. The error message points at the two remediations:
```
serve-llm: ERROR no keyfile at /home/<you>/.infernode/lib/keyring/serve-llm

  Anonymous-attach defaults were removed in INFR-16. To proceed, either:

    1. Generate a signer keyfile (recommended):
         ./serve-llm.sh --gen-key

    2. Listen without authentication (only on a trusted network):
         ./serve-llm.sh --anon-lan
```
Document this in the deployment runbook before merging.

## Test plan
End-to-end verified on macOS against a fresh worktree off `origin/master`:

- [x] `--help` prints usage block, exit 0
- [x] Unknown flag exits 2 with clear message
- [x] `--anon-lan`: listens on `:5640`, profile prints `WARNING listen mode anon`
- [x] Default (no keyfile): exits 1 with the remediation block (no listener bound)
- [x] `--gen-key`: writes 690-byte Ed25519 keyfile, mode 600 (verified `ls -l`)
- [x] Default (keyfile present): listens on `:5640` with `-k`, profile prints `listen mode keyring`
- [x] Client `mount -C none -k <keyfile> tcp!127.0.0.1!5640 /n/llm` from a separate emu: handshake completes (`dial-test: MOUNTED` printed without auth error)
- [x] `bash -n serve-llm.sh` syntax check clean
- [x] No regression to the existing `tests/test-distributed.sh` pattern (server uses `-k` and `mount -k` per its model — matches our new default)

## Notes
- Cleaned up test artifacts (worktree-local `n/`, `lib/keyring/`, symlinked `emu/MacOSX/o.emu`) before commit; no extraneous changes in the diff
- The `~/.infernode/lib/keyring/serve-llm` keyfile I generated during testing is left in place — it's specific to your account and matches what `--gen-key` would have produced anyway. Delete and re-run `--gen-key` if you'd prefer a different owner string

🤖 Generated with [Claude Code](https://claude.com/claude-code)