### PR TITLE
test: fix host harness on Linux + INFR-25 boot-log diagnostics

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -37,7 +37,7 @@ EMU_PATH=""
 if [ -x "$ROOT/emu/$_EMUHOST/o.emu" ]; then
     EMU_PATH="$ROOT/emu/$_EMUHOST/o.emu"
 fi
-RUNNER_DIS="/tests/runner.dis"
+RUNNER_DIS="/dis/tests/runner.dis"
 VERBOSE=0
 RUN_HOST=1
 RUN_INTERNAL=1

--- a/tests/host/activity_switch_test.sh
+++ b/tests/host/activity_switch_test.sh
@@ -14,7 +14,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/build_test.sh
+++ b/tests/host/build_test.sh
@@ -2,8 +2,17 @@
 #
 # Build InferNode for macOS ARM64 (Headless mode)
 #
+# This test is macOS-specific — it runs `mk` against emu/MacOSX with macOS
+# linker conventions and uses `otool` to check for SDL dependencies. On
+# Linux, exit 77 (skip); use build-linux-{amd64,arm64}.sh instead.
+#
 
 set -e
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "SKIP: build_test is macOS-only (use build-linux-*.sh on Linux)"
+    exit 77
+fi
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 export ROOT

--- a/tests/host/commands_test.sh
+++ b/tests/host/commands_test.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 # Systematically test all compiled utilities
 
+. "$(dirname "$0")/common.sh"
+
 echo "Testing all utilities in dis/*.dis"
 echo "===================================="
 
-cd "$(dirname "$0")/../.."
+cd "$ROOT"
 
 FAILED=0
 PASSED=0
@@ -22,12 +24,12 @@ for cmd in dis/*.dis; do
     printf "Testing %s... " "$CMD_NAME"
 
     # Try running with -h or --help or no args
-    timeout 2 ./emu/MacOSX/o.emu -r. "$cmd" 2>&1 | grep -qi "usage\|badop\|illegal"
+    timeout 2 "$EMU" -r. "$cmd" 2>&1 | grep -qi "usage\|badop\|illegal"
     RESULT=$?
 
     if [ $RESULT -eq 0 ]; then
         # Got usage or error
-        timeout 2 ./emu/MacOSX/o.emu -r. "$cmd" 2>&1 | grep -qi "badop\|illegal"
+        timeout 2 "$EMU" -r. "$cmd" 2>&1 | grep -qi "badop\|illegal"
         if [ $? -eq 0 ]; then
             echo "❌ FAIL (illegal instruction)"
             FAILED=$((FAILED + 1))

--- a/tests/host/common.sh
+++ b/tests/host/common.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# tests/host/common.sh — shared setup for host-side test scripts.
+#
+# Source from each test:
+#     . "$(dirname "$0")/common.sh"
+#
+# Exports:
+#     ROOT     — absolute path to the InferNode root (computed if unset or ".").
+#     EMUHOST  — "MacOSX" on Darwin, "Linux" on Linux.
+#     EMU      — $ROOT/emu/$EMUHOST/o.emu.
+#
+# On unsupported platforms the script exits 77 (skip), per run-tests.sh.
+
+if [ -z "$ROOT" ] || [ "$ROOT" = "." ]; then
+    ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fi
+
+case "$(uname -s)" in
+    Darwin) EMUHOST=MacOSX ;;
+    Linux)  EMUHOST=Linux  ;;
+    *)      echo "SKIP: unsupported platform $(uname -s)"; exit 77 ;;
+esac
+
+EMU="$ROOT/emu/$EMUHOST/o.emu"
+
+export ROOT EMUHOST EMU

--- a/tests/host/common.sh
+++ b/tests/host/common.sh
@@ -21,6 +21,14 @@ case "$(uname -s)" in
     *)      echo "SKIP: unsupported platform $(uname -s)"; exit 77 ;;
 esac
 
-EMU="$ROOT/emu/$EMUHOST/o.emu"
+case "$(uname -m)" in
+    x86_64)         OBJTYPE=amd64 ;;
+    aarch64|arm64)  OBJTYPE=arm64 ;;
+    *) echo "SKIP: unsupported arch $(uname -m)"; exit 77 ;;
+esac
 
-export ROOT EMUHOST EMU
+EMU="$ROOT/emu/$EMUHOST/o.emu"
+BINDIR="$ROOT/$EMUHOST/$OBJTYPE/bin"
+LIMBO="$BINDIR/limbo"
+
+export ROOT EMUHOST OBJTYPE EMU BINDIR LIMBO

--- a/tests/host/dialogue_test.sh
+++ b/tests/host/dialogue_test.sh
@@ -14,7 +14,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/factotum_keyfile_test.sh
+++ b/tests/host/factotum_keyfile_test.sh
@@ -4,7 +4,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"

--- a/tests/host/jit_boot_test.sh
+++ b/tests/host/jit_boot_test.sh
@@ -77,8 +77,11 @@ if [[ "$FAIL" -eq 0 ]]; then
     MODS=$(grep -c '^JIT compiled ' "$LOG" || true)
     echo "PASS: $MODS modules JIT-compiled, $TOOLS tools loaded, no crashes"
 else
-    echo "--- boot log tail ---"
-    tail -20 "$LOG"
+    # tail -20 was not enough to localise [Sh] Broken: messages — see INFR-25.
+    # Dump the full boot log so the failing shell command is visible in CI.
+    echo "--- full boot log ---"
+    cat "$LOG"
+    echo "--- end boot log ---"
 fi
 
 rm -f "$LOG"

--- a/tests/host/llmsrv_tooluse_test.sh
+++ b/tests/host/llmsrv_tooluse_test.sh
@@ -13,7 +13,7 @@
 #
 # Requirements:
 #   - ANTHROPIC_API_KEY (env var or LaunchAgent plist)
-#   - Inferno emulator at $ROOT/emu/MacOSX/o.emu
+#   - Inferno emulator at $EMU (set by common.sh; MacOSX or Linux)
 #
 # Usage:
 #   ./tests/host/llmsrv_tooluse_test.sh        # run all tests
@@ -23,7 +23,7 @@
 set -e
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 VERBOSE=0
 
 while getopts "v" opt; do

--- a/tests/host/pathmanage_test.sh
+++ b/tests/host/pathmanage_test.sh
@@ -11,7 +11,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/payfetch_test.sh
+++ b/tests/host/payfetch_test.sh
@@ -19,7 +19,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 X402_SERVER="$ROOT/../x402-test-server"
 PASS="payfetchtest42"
 

--- a/tests/host/run-pdf-conformance.sh
+++ b/tests/host/run-pdf-conformance.sh
@@ -7,7 +7,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 RESULTS="$ROOT/usr/inferno/test-pdfs/results.txt"
 HEAP=1024  # MB per process
 

--- a/tests/host/secstore_apikey_test.sh
+++ b/tests/host/secstore_apikey_test.sh
@@ -13,7 +13,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 PASS="testpass-apikey"
 USER="testuser-apikey"
 

--- a/tests/host/secstore_e2e_test.sh
+++ b/tests/host/secstore_e2e_test.sh
@@ -4,7 +4,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"

--- a/tests/host/secstore_logon_test.sh
+++ b/tests/host/secstore_logon_test.sh
@@ -12,7 +12,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 PASS="testpass123"
 
 if [ ! -x "$EMU" ]; then

--- a/tests/host/secstored_test.sh
+++ b/tests/host/secstored_test.sh
@@ -4,7 +4,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"

--- a/tests/host/stripe_test.sh
+++ b/tests/host/stripe_test.sh
@@ -13,7 +13,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 PASS="stripetest42"
 
 if [ ! -x "$EMU" ]; then

--- a/tests/host/tools9p_activity_ns_test.sh
+++ b/tests/host/tools9p_activity_ns_test.sh
@@ -20,7 +20,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/tools9p_basics_test.sh
+++ b/tests/host/tools9p_basics_test.sh
@@ -11,7 +11,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/tools9p_integration_test.sh
+++ b/tests/host/tools9p_integration_test.sh
@@ -15,7 +15,7 @@
 #
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 SH="/dis/sh.dis"
 VERBOSE=0
 

--- a/tests/host/tooluse_protocol_test.sh
+++ b/tests/host/tooluse_protocol_test.sh
@@ -100,9 +100,9 @@ TESTDIS="$ROOT/dis/tests/tooluse_test.dis"
 TESTB="$ROOT/tests/tooluse_test.b"
 if [[ ! -f "$TESTDIS" ]] || [[ "$TESTB" -nt "$TESTDIS" ]]; then
 	info "Building tooluse_test.dis..."
-	PATH="$ROOT/MacOSX/arm64/bin:$PATH" \
+	PATH="$BINDIR:$PATH" \
 		ROOT="$ROOT" \
-		"$ROOT/MacOSX/arm64/bin/limbo" \
+		"$LIMBO" \
 		-I"$ROOT/module" -I"$ROOT/appl/veltro" -gw \
 		-o "$TESTDIS" "$TESTB" 2>&1 || {
 		echo "ERROR: failed to build tooluse_test.dis" >&2

--- a/tests/host/tooluse_protocol_test.sh
+++ b/tests/host/tooluse_protocol_test.sh
@@ -11,7 +11,7 @@
 #
 # Requirements:
 #   - LLM 9P service running on LLM9P_PORT (default 5640)
-#   - Inferno emulator at $ROOT/emu/MacOSX/o.emu
+#   - Inferno emulator at $EMU (set by common.sh; MacOSX or Linux)
 #
 # Usage:
 #   ./tests/host/tooluse_protocol_test.sh            # port 5640
@@ -22,7 +22,7 @@
 set -e
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 LLM9P_PORT="${LLM9P_PORT:-5640}"
 VERBOSE=0
 

--- a/tests/host/wallet9p_test.sh
+++ b/tests/host/wallet9p_test.sh
@@ -2,18 +2,11 @@
 # wallet9p integration test (host-side)
 set -e
 
-ROOT="${ROOT:-.}"
-
-# Detect platform and locate emulator
-case "$(uname -s)" in
-    Darwin) EMU="$ROOT/emu/MacOSX/o.emu" ;;
-    Linux)  EMU="$ROOT/emu/Linux/o.emu" ;;
-    *)      echo "SKIP: unsupported platform $(uname -s)"; exit 0 ;;
-esac
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"
-    exit 0
+    exit 77
 fi
 
 echo "=== wallet9p integration test ==="

--- a/tests/host/wallet_e2e_test.sh
+++ b/tests/host/wallet_e2e_test.sh
@@ -3,7 +3,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"

--- a/tests/host/wallet_persist_test.sh
+++ b/tests/host/wallet_persist_test.sh
@@ -16,7 +16,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 PASS="wallettest42"
 
 if [ ! -x "$EMU" ]; then

--- a/tests/host/wallet_tx_test.sh
+++ b/tests/host/wallet_tx_test.sh
@@ -16,7 +16,7 @@
 set -e
 
 ROOT="${ROOT:-.}"
-EMU="$ROOT/emu/MacOSX/o.emu"
+. "$(dirname "$0")/common.sh"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"

--- a/tests/host/xenith_build_test.sh
+++ b/tests/host/xenith_build_test.sh
@@ -16,13 +16,13 @@
 
 set -e
 
-INFERNODE_ROOT="${INFERNODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-LIMBO="${INFERNODE_ROOT}/MacOSX/arm64/bin/limbo"
+. "$(dirname "$0")/common.sh"
+INFERNODE_ROOT="$ROOT"
 
 # Check if limbo compiler exists
 if [ ! -x "$LIMBO" ]; then
-    echo "SKIP: limbo compiler not found at $LIMBO"
-    exit 0
+    echo "SKIP: limbo compiler not found at $LIMBO (run build-{linux,macos}-*.sh first)"
+    exit 77
 fi
 
 echo "Testing Xenith build integrity..."


### PR DESCRIPTION
## Summary

Fixes [INFR-24](https://nervsystems-team.atlassian.net/browse/INFR-24): the `./run-tests.sh` host harness was broken on Linux. Net result on Linux/ARM64 (Jetson AGX):

| | Before | After this PR |
|---|---:|---:|
| **Passed** | 14 | **21** |
| **Failed** | 16 | 8 |
| **Skipped** | 0 | 1 |

7 net new PASSes; the remaining 8 FAILs are all pre-existing failures **unrelated to harness state**, each tracked in its own Jira ticket and deferred (see "Remaining failures" below).

## Fixes

1. **Most `tests/host/*_test.sh` hardcoded `emu/MacOSX/o.emu`**, so they failed on Linux even though `run-tests.sh` itself does platform detection. Extracted detection into a shared `tests/host/common.sh`:

   ```sh
   case "$(uname -s)" in
       Darwin) EMUHOST=MacOSX ;;
       Linux)  EMUHOST=Linux  ;;
       *)      echo "SKIP: ..."; exit 77 ;;
   esac
   case "$(uname -m)" in
       x86_64)         OBJTYPE=amd64 ;;
       aarch64|arm64)  OBJTYPE=arm64 ;;
       *) echo "SKIP: ..."; exit 77 ;;
   esac
   EMU="$ROOT/emu/$EMUHOST/o.emu"
   BINDIR="$ROOT/$EMUHOST/$OBJTYPE/bin"
   LIMBO="$BINDIR/limbo"
   ```

   22 host tests now `. "$(dirname "$0")/common.sh"` and use `$EMU` / `$LIMBO` / `$BINDIR` instead of hardcoded paths.

2. **`run-tests.sh:40`** invoked `/tests/runner.dis` but the file lives at `/dis/tests/runner.dis` (the existence check at line 164 already used the correct path — the invocation didn't). Internal EMU tests have therefore never run from this harness on any platform. Fixed.

3. **Four host scripts shipped without the executable bit**: `wallet_tx_test.sh`, `factotum_keyfile_test.sh`, `secstored_test.sh`, `secstore_e2e_test.sh`. All four now 100755 in the index.

4. **Two more macOS-hardcoded paths** to the native limbo compiler (`$ROOT/MacOSX/arm64/bin/limbo`) in `tooluse_protocol_test.sh` and `xenith_build_test.sh` — same bug class, fixed via `$LIMBO` from common.sh. `xenith_build_test.sh` also had a pre-existing wrong `INFERNODE_ROOT` (`dirname/..` resolving to `tests/`, not project root), now repaired.

5. **`build_test.sh`** is genuinely macOS-only (uses `mk` against `emu/MacOSX` and `otool` for SDL checks). Added `if [ "$(uname -s)" != "Darwin" ]; then exit 77; fi` — Linux now correctly skips instead of failing.

6. **Bonus — addresses [INFR-25](https://nervsystems-team.atlassian.net/browse/INFR-25) step 1**: `tests/host/jit_boot_test.sh` was dumping only `tail -20` of the boot log on failure — not enough to localise the `[Sh] Broken: "dereference of nil"` we caught on AMD64 in PR #44. Now dumps the full log between `--- full boot log ---` / `--- end boot log ---` markers so the next AMD64 trip will be debuggable.

## Test plan

- [x] `./run-tests.sh -h` on Linux/ARM64 (Jetson AGX): **21 passed, 8 failed, 1 skipped** (was 14/16/0).
- [x] No `tests/host/*.sh` script remains with `emu/MacOSX/o.emu` or `MacOSX/arm64/bin/limbo` hardcoded in code (the two doc-comment references in `llmsrv_tooluse_test.sh`/`tooluse_protocol_test.sh` were also updated to mention `$EMU` / `common.sh`).
- [x] `tests/host/jit_boot_test.sh` still PASSes on Linux/ARM64 (regression check).
- [ ] CI should still pass on macOS — detection picks `MacOSX` there, behaviour unchanged.

## Remaining failures (all deferred to their own tickets)

| Test | Ticket | Class |
|---|---|---|
| `modifier_mouse_emulation_test.sh` | [INFR-31](https://nervsystems-team.atlassian.net/browse/INFR-31) | source-grep regression (drifted from current `draw-sdl3.c`) |
| `sdl3_keyboard_test.sh` | [INFR-31](https://nervsystems-team.atlassian.net/browse/INFR-31) | source-grep regression |
| `xenith_scroll_focus_test.sh` | [INFR-31](https://nervsystems-team.atlassian.net/browse/INFR-31) | source-grep regression |
| `tools9p_activity_ns_test.sh` | [INFR-32](https://nervsystems-team.atlassian.net/browse/INFR-32) | activity ID after FORKNS — likely INFR-17 (NODEVS) interaction |
| `xenith_build_test.sh` | [INFR-33](https://nervsystems-team.atlassian.net/browse/INFR-33) | looks for `appl/acme/acme.dis` (should be `dis/acme.dis`) |
| `wallet_e2e_test.sh` | [INFR-34](https://nervsystems-team.atlassian.net/browse/INFR-34) | needs Sepolia RPC reachability — should `exit 77` on dial failure |
| `llmsrv_tooluse_test.sh` | [INFR-34](https://nervsystems-team.atlassian.net/browse/INFR-34) | needs `ANTHROPIC_API_KEY` — should `exit 77` when absent |
| `tooluse_protocol_test.sh` | [INFR-34](https://nervsystems-team.atlassian.net/browse/INFR-34) | needs `/n/llm` mounted — should `exit 77` when llmsrv not running |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
