### PR TITLE
test: SKIP-on-missing-prereq + xenith_build path (INFR-33, INFR-34)

### DIFF
--- a/tests/host/llmsrv_tooluse_test.sh
+++ b/tests/host/llmsrv_tooluse_test.sh
@@ -55,8 +55,8 @@ if [[ -z "$API_KEY" ]]; then
 		~/Library/LaunchAgents/com.nervsystems.llm9p.plist 2>/dev/null || true)
 fi
 if [[ -z "$API_KEY" ]]; then
-	echo "ERROR: no API key found (set ANTHROPIC_API_KEY or configure LaunchAgent)" >&2
-	exit 1
+	echo "SKIP: no API key (set ANTHROPIC_API_KEY or configure LaunchAgent)"
+	exit 77
 fi
 
 # Check emulator

--- a/tests/host/tooluse_protocol_test.sh
+++ b/tests/host/tooluse_protocol_test.sh
@@ -85,7 +85,7 @@ if ! nc -z localhost "$LLM9P_PORT" 2>/dev/null; then
 	skip "LLM service not running on port $LLM9P_PORT (start llmsrv or mount remote)"
 	echo ""
 	echo "  Total: 0 passed, $FAILED failed, $SKIPPED skipped"
-	exit 0
+	exit 77
 fi
 info "LLM service listening on port $LLM9P_PORT"
 
@@ -94,6 +94,20 @@ if [[ ! -x "$EMU" ]]; then
 	echo "ERROR: emulator not found at $EMU" >&2
 	exit 1
 fi
+
+# The port being open isn't enough — since INFR-16, llmsrv defaults to
+# keyring auth, so anonymous attaches hang at TVERSION. Probe with an
+# actual anon mount + short timeout; if it doesn't complete, the listener
+# isn't accepting anonymous clients and this test can't run.
+if ! timeout 5 "$EMU" -r"$ROOT" -c0 /dis/sh.dis \
+		-c "mount -A tcp!127.0.0.1!${LLM9P_PORT} /n/llm" \
+		</dev/null >/dev/null 2>&1; then
+	skip "anonymous mount to llmsrv on port $LLM9P_PORT failed (keyring auth required?)"
+	echo ""
+	echo "  Total: 0 passed, $FAILED failed, $SKIPPED skipped"
+	exit 77
+fi
+info "anonymous mount to llmsrv succeeded"
 
 # Build tooluse_test.dis if missing or stale
 TESTDIS="$ROOT/dis/tests/tooluse_test.dis"

--- a/tests/host/wallet_e2e_test.sh
+++ b/tests/host/wallet_e2e_test.sh
@@ -7,7 +7,17 @@ ROOT="${ROOT:-.}"
 
 if [ ! -x "$EMU" ]; then
     echo "SKIP: emu not found at $EMU"
-    exit 0
+    exit 77
+fi
+
+# The test queries Base Sepolia RPC. If we can't reach the public node
+# from the host, the emu's dial inside will fail with "invalid IP address"
+# and the test FAILs — but that's an environment issue, not a wallet
+# regression. Probe reachability up front; SKIP if unreachable.
+RPC_HOST=ethereum-sepolia-rpc.publicnode.com
+if ! nc -z -w 3 "$RPC_HOST" 443 2>/dev/null; then
+    echo "SKIP: cannot reach $RPC_HOST:443 (network/DNS unavailable)"
+    exit 77
 fi
 
 echo "=== wallet end-to-end test (Base Sepolia) ==="

--- a/tests/host/xenith_build_test.sh
+++ b/tests/host/xenith_build_test.sh
@@ -45,7 +45,7 @@ fi
 
 # Get sizes
 XENITH_SIZE=$(stat -f%z "$TMPDIR/xenith.dis" 2>/dev/null || stat -c%s "$TMPDIR/xenith.dis")
-ACME_SIZE=$(stat -f%z "$INFERNODE_ROOT/appl/acme/acme.dis" 2>/dev/null || stat -c%s "$INFERNODE_ROOT/appl/acme/acme.dis")
+ACME_SIZE=$(stat -f%z "$ROOT/dis/acme.dis" 2>/dev/null || stat -c%s "$ROOT/dis/acme.dis")
 
 echo "  xenith.dis size: $XENITH_SIZE bytes"
 echo "  acme.dis size:   $ACME_SIZE bytes"
@@ -77,7 +77,7 @@ for mod in gui col row; do
     fi
 
     XENITH_MOD_SIZE=$(stat -f%z "$TMPDIR/${mod}.dis" 2>/dev/null || stat -c%s "$TMPDIR/${mod}.dis")
-    ACME_MOD_SIZE=$(stat -f%z "$INFERNODE_ROOT/appl/acme/${mod}.dis" 2>/dev/null || stat -c%s "$INFERNODE_ROOT/appl/acme/${mod}.dis")
+    ACME_MOD_SIZE=$(stat -f%z "$ROOT/dis/acme/${mod}.dis" 2>/dev/null || stat -c%s "$ROOT/dis/acme/${mod}.dis")
 
     echo "    xenith/${mod}.dis: $XENITH_MOD_SIZE bytes"
     echo "    acme/${mod}.dis:   $ACME_MOD_SIZE bytes"


### PR DESCRIPTION
## Summary

Two follow-ups to the test-harness fixes in #50. **Stacked on `fix/test-harness-linux`** — review/merge after #50 (when #50 lands, this PR can be retargeted to `master`).

### [INFR-33](https://nervsystems-team.atlassian.net/browse/INFR-33) — `xenith_build_test.sh` looked at the wrong `.dis` path

The test compared its freshly-built xenith bytecode against `$ROOT/appl/acme/acme.dis` (and per-submodule equivalents). But `appl/**/*.dis` is `.gitignore`d — those are transient build artifacts. Compiled acme bytecode actually lives at `$ROOT/dis/acme.dis` (top-level launcher) and `$ROOT/dis/acme/{gui,col,row}.dis` (submodules). Fixed the two `stat` probes.

Verified locally on Linux/ARM64:

```
xenith.dis size: 39051 bytes
acme.dis  size: 27690 bytes
xenith/gui.dis: 2758 bytes vs acme/gui.dis: 2563 bytes
xenith/col.dis: 10384 bytes vs acme/col.dis: 10469 bytes
xenith/row.dis: 13739 bytes vs acme/row.dis: 13733 bytes
PASS: Xenith build integrity verified
```

### [INFR-34](https://nervsystems-team.atlassian.net/browse/INFR-34) — three host tests `exit 1` (or `exit 0`) on missing env prerequisites; should `exit 77` (SKIP)

`run-tests.sh` has a `77 = SKIP` convention. These three tests treat absent prerequisites as FAILs:

| Test | Old behaviour | New behaviour |
|---|---|---|
| `llmsrv_tooluse_test.sh` | `ERROR: no API key…` + `exit 1` → counted as FAIL | `SKIP: no API key…` + `exit 77` → counted as SKIP |
| `tooluse_protocol_test.sh` | port-closed → `exit 0` (counted as PASS, but ran nothing); port-open-but-auth-required → ran emu, hung at TVERSION, killed by timeout → FAIL | port-closed → `exit 77`; port-open-but-auth-required → 5 s anon-mount probe; if it doesn't complete → `exit 77` |
| `wallet_e2e_test.sh` | always tried to run emu; failed when no network/DNS to Sepolia RPC | `nc -z -w 3 ethereum-sepolia-rpc.publicnode.com 443` up front; SKIP if unreachable. Also: inherited `exit 0` on missing-emu → `exit 77` |

The `tooluse_protocol` probe upgrade is the interesting one: since INFR-16 (PR #41) landed, `llmsrv` defaults to keyring auth and an anonymous attach hangs at TVERSION rather than failing fast. `nc -z` alone reports "port open"; the test would then dial-and-hang. The new probe runs `mount -A tcp!127.0.0.1!5640 /n/llm` inside a 5 s `timeout`-wrapped emu — if it doesn't complete, the listener isn't accepting anonymous clients and the test SKIPs cleanly.

## Test plan

- [x] On Linux/ARM64 (Jetson AGX): all four tests behave correctly. Net change for the four targeted tests: 4 FAILs → 1 PASS (`xenith_build`) + 3 SKIPs (`llmsrv_tooluse`, `tooluse_protocol`, `wallet_e2e`).
- [ ] On macOS with the same prereqs absent, expect the same SKIPs.
- [ ] On macOS with prereqs present (API key set, llmsrv running anonymously, network up), expect PASSes — no behaviour change vs. PR #50 in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)