### PR TITLE
doc(matrix): point Future-Marketplace section at deferred design tickets

### DIFF
--- a/doc/matrix-architecture.md
+++ b/doc/matrix-architecture.md
@@ -534,7 +534,31 @@ InferNode includes a crypto wallet and supports h402 (HTTP 402 Payment
 Required) micropayments. This creates the infrastructure for a module
 and composition marketplace without building a marketplace platform.
 
-### Mechanism
+The marketplace itself is **not yet designed**. Three design-exploration
+tickets (all deferred) capture the open questions that must be answered
+before any implementation begins:
+
+- **INFR-13** — what trust model does the marketplace use? Publisher-as-mount
+  (each publisher = a 9P share authenticated by keyring; mount is the trust
+  boundary; reuses INFR-16's existing pattern), aggregator-with-attestation
+  (single endpoint, modules carry embedded signatures via the dormant
+  `sign(3)` / SMAGIC facility), or hybrid. Original prescription for
+  detached `.dis.sig` sidecars retracted; see ticket for the architectural
+  framing.
+- **INFR-41** — how does payment actually gate 9P access? The current
+  payment client (`appl/veltro/tools/payfetch.b`) is x402-over-HTTP only;
+  no 9P-level payment gating exists in the tree today. Without it, the
+  mechanism described below is aspirational.
+- **INFR-42** — how do consumers discover publishers? Every P2P consumer
+  in InferNode (mail9p, calendar9p, Matrix shares, serve-llm) currently
+  relies on out-of-band addressing. `ndb` is the Plan-9 answer for the
+  registry shape; question is what attribute schema, what bootstrap,
+  what announcement convention.
+
+The sketch below describes what the marketplace *could* look like once
+those questions are resolved. It is not a specification.
+
+### Mechanism (sketch)
 
 A module or pinned composition is a file. Files are served over 9P.
 9P connections can be gated by payment. Therefore:


### PR DESCRIPTION
## Summary

`doc/matrix-architecture.md` § "Future: Marketplace (h402)" described a mechanism (9P-level payment gating, publisher trust, marketplace discovery) that depends on capabilities the tree doesn't yet have. The architecture review on INFR-13 (2026-05-11) carved each open question into its own deferred design-exploration ticket.

This PR adds a short preamble to that section that:

- Lists the three open design questions and their tracking tickets (INFR-13, INFR-41, INFR-42).
- Reframes the existing "Mechanism" content from "what it does" to "what it could look like once those are resolved."

No code change. No new dependencies. No deletion of existing prose — the original "Mechanism" sketch is preserved verbatim under the new framing.

## Related

- [INFR-13](https://nervsystems-team.atlassian.net/browse/INFR-13) — marketplace trust model (deferred)
- [INFR-41](https://nervsystems-team.atlassian.net/browse/INFR-41) — h402-over-9P (deferred)
- [INFR-42](https://nervsystems-team.atlassian.net/browse/INFR-42) — P2P service discovery (deferred)

## Test plan

- [x] Markdown renders cleanly (visual inspection of diff).
- [x] No source code touched. No `.dis` produced. No build artifacts in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)