### PR TITLE
build: defense-in-depth vs stale .dis at wrong path (INFR-28 fallout)

### DIFF
--- a/.github/workflows/verify-dis-paths.yml
+++ b/.github/workflows/verify-dis-paths.yml
@@ -1,0 +1,27 @@
+name: Verify dis-paths
+
+# Universal backstop for the "stale build artefact" bug class
+# (INFR-28 history): a Limbo source file is committed, but the
+# corresponding compiled .dis at the path declared in the module's
+# PATH constant is missing or older than the source.  emu loads the
+# stale .dis; every "fix" appears to do nothing locally.
+#
+# This job runs in seconds and blocks merge.  It catches contributors
+# who don't have the local pre-commit hook installed (hooks/install.sh)
+# or who used the wrong manual `limbo -o ...` target.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify dis paths
+        run: ./tools/verify-dis-paths.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ This means: the runtime tree ships pre-built, but you never commit `.dis` files 
 
 After that, every `git pull` triggers an automatic rebuild of stale bytecode. See `hooks/post-merge` for details.
 
+**The wrong-target trap (READ THIS BEFORE COMPILING ANYTHING).** A separate class of stale-bytecode bug: a module declares `PATH: con "/dis/foo.dis";` so the runtime loads `dis/foo.dis`. The mkfile installs to `dis/foo.dis`. But there is *also* an `appl/cmd/foo.dis` (intermediate) and there used to be a parallel `dis/cmd/foo.dis` tree. If you manually compile with `limbo -o dis/cmd/foo.dis ...` (or any path that is NOT what the module's PATH constant declares), `emu` cheerfully keeps loading the old `dis/foo.dis` while your "fix" silently lands in a directory it never reads from. This has burned multiple debug sessions. The defences:
+
+- **Never run `limbo -o ...` directly.** Use one of:
+  - `tools/compile-limbo.sh <source.b>` — reads the module's `PATH` constant and emits to that exact location. No `-o` to get wrong.
+  - `mk install` from the appropriate `appl/<dir>/` — also installs to the canonical path (`DISBIN=$ROOT/dis`).
+- **Pre-commit hook** (installed by `./hooks/install.sh`) runs `tools/verify-dis-paths.sh`, which refuses any commit where a source's `dis/<PATH>.dis` is missing or older than the source.
+- **CI** (`.github/workflows/verify-dis-paths.yml`) runs the same verifier on every PR — universal backstop for contributors who didn't install the local hook.
+
+If you see "my fix isn't taking effect" symptoms (the bug looks the same after recompile, diagnostic prints don't appear in logs), check `tools/verify-dis-paths.sh` immediately before chasing anything else.
+
 ### Build Commands
 
 Build from macOS terminal (not inside Inferno):

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -5,11 +5,14 @@
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HOOKDIR="$ROOT/.git/hooks"
 
-for hook in "$ROOT"/hooks/post-merge; do
+# Iterate every executable file in hooks/ except install.sh itself.
+# Avoids having to update this loop each time a new hook is added.
+for hook in "$ROOT"/hooks/*; do
     name="$(basename "$hook")"
-    if [ "$name" = "install.sh" ]; then
-        continue
-    fi
+    case "$name" in
+        install.sh|*.md|*.txt) continue ;;
+    esac
+    [ -f "$hook" ] || continue
     cp "$hook" "$HOOKDIR/$name"
     chmod +x "$HOOKDIR/$name"
     echo "installed $name"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# pre-commit — refuse to commit if any tracked Limbo source has a
+# stale or missing .dis at its module's declared PATH.
+#
+# This is the local catch for the recurring "stale build artefacts"
+# bug class: someone (often Claude) edits appl/cmd/lucictx.b, manually
+# compiles to dis/cmd/lucictx.dis, but lucifer loads /dis/lucictx.dis
+# and runs the old code.  Every fix appears to "do nothing" until
+# someone notices the path mismatch.  We've burned multiple debug
+# sessions on this — see INFR-28 history.
+#
+# What this hook does:
+#   1. Run tools/verify-dis-paths.sh, which compares each
+#      appl/cmd/*.b's mtime against dis/<declared-PATH>.dis.
+#   2. If any source is newer than its installed .dis, ABORT the
+#      commit and print the failing source/target pairs.
+#
+# To recover: rebuild with tools/compile-limbo.sh (or `mk install`),
+# then re-run `git commit`.
+#
+# Bypass for emergencies: `git commit --no-verify`.  Don't do it.
+
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -x "$ROOT/tools/verify-dis-paths.sh" ]; then
+	# Hook is newer than the verifier on disk — let the commit through
+	# rather than block on missing infrastructure.
+	exit 0
+fi
+
+if ! "$ROOT/tools/verify-dis-paths.sh"; then
+	echo "" >&2
+	echo "pre-commit: refusing to commit with stale .dis artefacts." >&2
+	echo "  Fix: tools/compile-limbo.sh <changed-source>.b" >&2
+	echo "  Or:  mk install   (in the affected source dir)" >&2
+	echo "  Bypass (don't): git commit --no-verify" >&2
+	exit 1
+fi

--- a/tools/compile-limbo.sh
+++ b/tools/compile-limbo.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# compile-limbo.sh — compile a Limbo source file to the path declared
+# in the module's PATH constant.  The whole point: eliminate the
+# manual `-o <path>` choice that has repeatedly cost us debug sessions
+# (latest: INFR-28 file-browser theme propagation, where every "fix"
+# landed in dis/cmd/lucictx.dis while emu loaded /dis/lucictx.dis).
+#
+# Usage:
+#   tools/compile-limbo.sh appl/cmd/lucictx.b [appl/cmd/another.b ...]
+#
+# For each input file:
+#   1. Parse it to find `implement <Foo>;`
+#   2. Find `<Foo>: module { ... PATH: con "/dis/...path..."; ... }`
+#   3. Run limbo with -o <ROOT>/dis/<...path...> and the include flags
+#      the file needs (auto-derived from its `include` statements).
+#   4. Print "OK <source> -> <output>" on success.
+#
+# If the source has no `implement` (a module-interface file) or no PATH
+# constant, this prints a warning and falls back to mk's behaviour
+# (skip — let `mk` handle it).
+#
+# Use this instead of `limbo -o ...` directly.  CLAUDE.md and the
+# pre-commit hook both refer to this script as the canonical compile
+# entry point.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIMBO_BIN=""
+
+# Find a native limbo compiler.  Prefer the platform-appropriate one
+# already shipped in MacOSX/<arch>/bin or Linux/<arch>/bin.
+case "$(uname -s)-$(uname -m)" in
+	Darwin-arm64)    LIMBO_BIN="$ROOT/MacOSX/arm64/bin/limbo" ;;
+	Darwin-x86_64)   LIMBO_BIN="$ROOT/MacOSX/amd64/bin/limbo" ;;
+	Linux-aarch64)   LIMBO_BIN="$ROOT/Linux/arm64/bin/limbo" ;;
+	Linux-x86_64)    LIMBO_BIN="$ROOT/Linux/amd64/bin/limbo" ;;
+esac
+
+if [[ -z "$LIMBO_BIN" || ! -x "$LIMBO_BIN" ]]; then
+	# Fallback: PATH lookup.
+	LIMBO_BIN="$(command -v limbo 2>/dev/null || true)"
+fi
+
+if [[ -z "$LIMBO_BIN" ]]; then
+	echo "compile-limbo: no limbo compiler found — build the native tools first" >&2
+	exit 2
+fi
+
+scan_module_path() {
+	# Print the PATH constant of the module the file IMPLEMENTS.
+	# See tools/verify-dis-paths.sh for matching rules — kept in sync.
+	awk '
+		/^implement[[:space:]]+[A-Za-z][A-Za-z0-9_]*[[:space:]]*;/ {
+			match($0, /[A-Za-z][A-Za-z0-9_]*[[:space:]]*;/)
+			impl = substr($0, RSTART, RLENGTH)
+			sub(/[[:space:]]*;.*$/, "", impl)
+		}
+		impl != "" && $0 ~ ("^" impl "[[:space:]]*:[[:space:]]*module") { in_mod = 1; next }
+		in_mod && /PATH[[:space:]]*:[[:space:]]*con[[:space:]]*"\/dis\// {
+			match($0, /"\/dis\/[^"]+"/)
+			if(RSTART > 0) {
+				p = substr($0, RSTART+1, RLENGTH-2)
+				print p
+				exit
+			}
+		}
+		in_mod && /^[[:space:]]*}/ { in_mod = 0 }
+	' "$1"
+}
+
+derive_includes() {
+	# Build the -I flag set this file needs.  Default to module/.
+	# Add appl/<subdir>/ for any include that resolves there.
+	local src="$1"
+	local includes="-I$ROOT/module"
+	local extra=""
+	while IFS= read -r inc; do
+		# Search known module subdirs; add to -I if the include exists there.
+		for sub in appl/veltro appl/xenith appl/charon; do
+			if [[ -f "$ROOT/$sub/$inc" ]]; then
+				case " $extra " in
+					*" -I$ROOT/$sub "*) ;;
+					*) extra="$extra -I$ROOT/$sub" ;;
+				esac
+				break
+			fi
+		done
+	done < <(awk '/include[[:space:]]+"/ {
+		match($0, /"[^"]+"/)
+		if(RSTART > 0) print substr($0, RSTART+1, RLENGTH-2)
+	}' "$src")
+	echo "$includes$extra"
+}
+
+if [[ $# -lt 1 ]]; then
+	echo "usage: $0 <source.b> [<source.b> ...]" >&2
+	exit 2
+fi
+
+rc=0
+for src in "$@"; do
+	if [[ ! -f "$src" ]]; then
+		echo "compile-limbo: $src: no such file" >&2
+		rc=1
+		continue
+	fi
+
+	disrel="$(scan_module_path "$src" || true)"
+	if [[ -z "$disrel" ]]; then
+		echo "compile-limbo: $src: no IMPLEMENT or PATH constant; skipping" >&2
+		echo "  (use mk for files that don't declare their own load path)" >&2
+		continue
+	fi
+
+	# Resolve /dis/... to a path inside the source tree.
+	out="$ROOT/${disrel#/}"
+	mkdir -p "$(dirname "$out")"
+
+	flags="$(derive_includes "$src")"
+	# shellcheck disable=SC2086
+	if "$LIMBO_BIN" $flags -gw -o "$out" "$src"; then
+		echo "OK $src -> $out"
+	else
+		echo "FAIL $src" >&2
+		rc=1
+	fi
+done
+
+exit $rc

--- a/tools/verify-dis-paths.sh
+++ b/tools/verify-dis-paths.sh
@@ -30,6 +30,18 @@ cd "$ROOT"
 fail=0
 checked=0
 
+# stat(1) is the classic cross-platform divergence:
+#   macOS / BSD:  stat -f %m FILE   → mtime as epoch seconds
+#   GNU / Linux:  stat -c %Y FILE   → mtime as epoch seconds
+# Picking the wrong one prints filesystem-info text starting with
+# "File:", which the (( … )) arithmetic later treated as an unset
+# variable name and crashed CI.  Detect once and stash a function.
+if stat -c %Y "$0" >/dev/null 2>&1; then
+	mtime() { stat -c %Y "$1"; }
+else
+	mtime() { stat -f %m "$1"; }
+fi
+
 scan_module_path() {
 	# Return the PATH constant of the module that this .b file
 	# IMPLEMENTS (top-level `implement Foo;`), not the first PATH it
@@ -75,8 +87,8 @@ for src in appl/cmd/*.b; do
 		continue
 	fi
 
-	src_t=$(stat -f %m "$src" 2>/dev/null || stat -c %Y "$src")
-	dis_t=$(stat -f %m "$dispath" 2>/dev/null || stat -c %Y "$dispath")
+	src_t=$(mtime "$src")
+	dis_t=$(mtime "$dispath")
 
 	if (( src_t > dis_t )); then
 		echo "FAIL: $src is newer than $dispath (recompile needed)" >&2


### PR DESCRIPTION
## Summary

The "stale build artefact" bug has cost us multiple debug sessions. Latest one: every fix to lucifer-side modules landed in `dis/cmd/X.dis` while `lucifer` loaded `/dis/X.dis`. Old code kept running silently. This PR closes that bug class at three layers.

## Layers of defense

### 1. `tools/compile-limbo.sh` (single source of truth)
Reads the `PATH:` constant declared in the module a .b file IMPLEMENTS, then emits to that exact location. **No `-o` flag means no choice to get wrong.** Falls back to a clear "use mk" message for files without a PATH constant (wm apps etc., where mk's directory convention handles install).

### 2. `hooks/pre-commit` (local)
Refuses any commit where a .b source is newer than `dis/<PATH-it-declares>.dis`. Installed via the existing `hooks/install.sh` (now picks up every executable in `hooks/` instead of a hardcoded list).

### 3. `.github/workflows/verify-dis-paths.yml` (CI)
Runs `tools/verify-dis-paths.sh` on every PR and master push. Universal backstop for contributors who didn't install the local hook. Sub-second job.

### CLAUDE.md
Load-bearing "READ THIS BEFORE COMPILING ANYTHING" section pointing future Claude sessions (and humans) at `tools/compile-limbo.sh` and `mk install` as the only sanctioned compile entry points. Direct `limbo -o ...` is explicitly named as the failure mode.

## Test plan

- [x] `./tools/compile-limbo.sh appl/cmd/lucictx.b` writes to `dis/lucictx.dis` (not `dis/cmd/`)
- [x] `./tools/verify-dis-paths.sh` returns OK on a clean tree
- [x] `./hooks/install.sh` installs both `post-merge` and `pre-commit`
- [x] `./hooks/pre-commit` refuses commit when a source is newer than its installed .dis
- [ ] CI workflow runs and passes

Refs: INFR-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)