### PR TITLE
Ship setup-windows.ps1 in Windows release zip + dev bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1112,7 +1112,7 @@ jobs:
 
         New-Item -ItemType Directory -Force -Path "$STAGE\tmp" | Out-Null
 
-        foreach ($f in @("LICENCE", "NOTICE", "TRADEMARK.md", "README.md", "QUICKSTART.md")) {
+        foreach ($f in @("LICENCE", "NOTICE", "TRADEMARK.md", "README.md", "QUICKSTART.md", "setup-windows.ps1")) {
           if (Test-Path $f) {
             Copy-Item $f "$STAGE\"
           }

--- a/build-dev-bundle.ps1
+++ b/build-dev-bundle.ps1
@@ -99,6 +99,12 @@ foreach ($f in @("build-windows-amd64.ps1", "build-windows-sdl3.ps1")) {
     }
 }
 
+# Post-install setup (Anthropic API key / Ollama install + model pull).
+# Users run this once after extracting the bundle to wire up Veltro's LLM.
+if (Test-Path "$ROOT\setup-windows.ps1") {
+    Copy-Item "$ROOT\setup-windows.ps1" "$OutDir\"
+}
+
 # Build provenance stamp.
 $sha = "unknown"
 try {


### PR DESCRIPTION
## Summary

`setup-windows.ps1` configures Veltro's LLM backend on first run (Anthropic API key OR Ollama install + model pull). It's the very first thing a Windows user needs after extracting the release, but the previous packaging paths weren't actually shipping it:

- `build-dev-bundle.ps1` (now on master from PR #60) didn't copy it into the bundle.
- `release.yml` `windows-amd64` job didn't copy it into the release zip.

Fix both. Verified locally: rebuilt dev bundle in `%TEMP%\InferNode-dev` now contains `setup-windows.ps1` alongside `InferNode.exe`, `o.emu.exe`, runtime tree.

## Note

The same gap likely exists for `setup-linux.sh` and `setup-macos.sh` in `release.yml`, but that's outside the scope of the Windows release.

## Test plan

- [x] Local: `.\build-dev-bundle.ps1` produces `%TEMP%\InferNode-dev\setup-windows.ps1`.
- [ ] CI Windows release job (only runs on tag push) packages it into the zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)