### PR TITLE
App-bundle launchers skip secstore login on first run (INFR-53)

### DIFF
--- a/Linux/infernode
+++ b/Linux/infernode
@@ -18,4 +18,7 @@ fi
 # LD_LIBRARY_PATH as fallback in case patchelf wasn't applied.
 export LD_LIBRARY_PATH="$SCRIPT_DIR/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-exec "$EMU" -c1 -pheap=1024m -pmain=1024m -pimage=1024m "-r$RESOURCES" sh -l /lib/lucifer/boot.sh
+# skip-login: app-bundle first run skips secstore password + wallet9p
+# so new users can try InferNode without setting up credentials first.
+# Dev path (emu -r$PWD sh -l /lib/lucifer/boot.sh, no arg) still prompts.
+exec "$EMU" -c1 -pheap=1024m -pmain=1024m -pimage=1024m "-r$RESOURCES" sh -l /lib/lucifer/boot.sh skip-login

--- a/MacOSX/Infernode.app/Contents/MacOS/InferNode
+++ b/MacOSX/Infernode.app/Contents/MacOS/InferNode
@@ -19,4 +19,7 @@ esac
 EMU="$SCRIPT_DIR/emu"
 
 # Launch: profile (-l) sets up overlays, then boot.sh starts the GUI.
-exec "$EMU" -c1 "-pheap=1024m" "-pmain=1024m" "-pimage=1024m" "-r$RESOURCES" sh -l /lib/lucifer/boot.sh
+# skip-login: app-bundle first run skips secstore password + wallet9p
+# so new users can try InferNode without setting up credentials first.
+# Dev path (emu -r$PWD sh -l /lib/lucifer/boot.sh, no arg) still prompts.
+exec "$EMU" -c1 "-pheap=1024m" "-pmain=1024m" "-pimage=1024m" "-r$RESOURCES" sh -l /lib/lucifer/boot.sh skip-login

--- a/emu/Nt/infernode-launcher.c
+++ b/emu/Nt/infernode-launcher.c
@@ -45,11 +45,14 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		int h = GetSystemMetrics(SM_CYSCREEN);
 
 		/* -l sources lib/sh/profile; /lib/lucifer/boot.sh is the
-		 * unified GUI boot script shared with macOS/Linux. */
+		 * unified GUI boot script shared with macOS/Linux. The
+		 * skip-login arg tells boot.sh to skip the secstore password
+		 * prompt + wallet9p for frictionless first run (host-env API
+		 * key still flows through via profile). */
 		_snprintf(cmd, sizeof(cmd),
 			"\"%s\\o.emu.exe\" -c1 -g %dx%d"
 			" -pheap=1024m -pmain=1024m -pimage=1024m"
-			" -r . sh -l /lib/lucifer/boot.sh",
+			" -r . sh -l /lib/lucifer/boot.sh skip-login",
 			dir, w, h);
 	}
 

--- a/lib/lucifer/boot.sh
+++ b/lib/lucifer/boot.sh
@@ -8,8 +8,14 @@ user=`{cat /dev/user}
 ls /usr/inferno/secstore >[2] /dev/null
 ls /usr/inferno/secstore/$user >[2] /dev/null
 
-# Login screen (unlocks secstore, loads keys into factotum)
-wm/logon
+# Login screen (unlocks secstore, loads keys into factotum).
+# Skipped when invoked as `sh -l /lib/lucifer/boot.sh skip-login`
+# from app-bundled launchers (InferNode.exe, InferNode.app), where the
+# API key is provisioned from the host env via profile and the friction
+# of a password prompt isn't appropriate for first-run users.
+if {! ~ $* skip-login} {
+	wm/logon
+}
 
 # (Re-)start LLM service in the background.
 #
@@ -40,9 +46,12 @@ wm/logon
 	}
 } &
 
-# Wallet service
-/dis/veltro/wallet9p.dis >[2] /dev/null &
-sleep 1
+# Wallet service. Also skipped on skip-login: wallet9p needs unlocked
+# keys from factotum, which depend on secstore being unlocked.
+if {! ~ $* skip-login} {
+	/dis/veltro/wallet9p.dis >[2] /dev/null &
+	sleep 1
+}
 
 # GUI services
 luciuisrv


### PR DESCRIPTION
## Summary

Ports forward the intent of `preserved/nervsystems/windows-port` commit `61520c98` (2026-03-26) "skip login screen by default for frictionless first run". That commit edited the macOS .app launcher to use its own LUCIFER_CMD skipping `wm/logon` and `wallet9p`. Since then PR #47 unified all platforms onto `/lib/lucifer/boot.sh` — which re-introduced `wm/logon` on every platform. A direct cherry-pick no longer applies.

Tracking: [INFR-53](https://nervsystems-team.atlassian.net/browse/INFR-53).

## Approach

Opt-in `skip-login` arg to `/lib/lucifer/boot.sh`. All three app-bundle launchers pass it:

- `emu/Nt/infernode-launcher.c` (Windows `InferNode.exe`)
- `MacOSX/Infernode.app/Contents/MacOS/InferNode` (macOS app bundle)
- `Linux/infernode` (Linux release tarball launcher)

Dev path (`emu -r$PWD sh -l /lib/lucifer/boot.sh` with no arg) keeps prompting.

```sh
# In boot.sh
if {! ~ $* skip-login} {
    wm/logon
}
...
if {! ~ $* skip-login} {
    /dis/veltro/wallet9p.dis >[2] /dev/null &
    sleep 1
}
```

Rationale: `ANTHROPIC_API_KEY` from the host env flows through `lib/sh/profile` and is enough for Veltro. The secstore prompt is appropriate when users have explicit credentials to unlock, not as a first-run wall.

## Test plan

- [ ] Fresh `%TEMP%\InferNode-dev` bundle: double-click → Lucifer loads with NO login window.
- [ ] Dev path (`emu -r$PWD sh -l /lib/lucifer/boot.sh`) still shows the login screen.
- [ ] `ANTHROPIC_API_KEY` reaches factotum/Veltro through `lib/sh/profile`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)