### PR TITLE
Windows: mount C:\ at /n/local — unified Inferno-side path (INFR-54)

### DIFF
--- a/lib/sh/profile
+++ b/lib/sh/profile
@@ -15,16 +15,15 @@ bind -a '#I' /net >[2] /dev/null
 ndb/cs
 
 # ── Host filesystem + home directory (early — needed for overlays) ──
+# /n/local is the user-visible root of the host filesystem on every
+# platform. Wiring to get there differs (POSIX has a single root;
+# Windows has drive letters), but Inferno-side paths are identical.
 if {~ $emuhost MacOSX Linux Nt}{
 	if {~ $emuhost Nt} {
-		# Windows: mount drive letters via #U, then resolve home.
-		# Pattern from Acme-SAC: #U with drive:/ spec mounts that drive.
-		for i in C D {
-			trfs '#U'^$i^':/' /n/$i >[2] /dev/null
-		}
-		# Construct home from $user. On Windows, profiles live at C:\Users\<name>.
-		# The C: drive is mounted above at /n/C.
-		ghome=/n/C/Users/^$user
+		# Windows: mount C:\ at /n/local. Profiles live at C:\Users\<name>,
+		# so /n/local/Users/$user matches macOS's /n/local/Users/$user.
+		trfs '#UC:/' /n/local >[2] /dev/null
+		ghome=/n/local/Users/^$user
 	}{
 		trfs '#U*' /n/local >[2] /dev/null
 		ghome=/n/local/^`{echo 'echo $HOME' | os sh}


### PR DESCRIPTION
## Summary

From inside the Inferno environment, the user's home directory currently lives at:

- `/n/local/Users/<user>` — macOS
- `/n/local/home/<user>` — Linux
- `/n/C/Users/<user>` — **Windows** ← divergence

This PR brings Windows in line. Tracking: [INFR-54](https://nervsystems-team.atlassian.net/browse/INFR-54).

## Principle

InferNode behaves identically on every platform. Wiring (drive letters vs single root) can differ; user-visible paths inside Inferno cannot.

## Change

In `lib/sh/profile`, the Windows branch now does:

```
trfs '#UC:/' /n/local >[2] /dev/null
ghome=/n/local/Users/^$user
```

(was: mount `C:\` at `/n/C`, `D:\` at `/n/D`, ghome at `/n/C/Users/$user`.)

After this fix:

- `cd /n/local` works on every platform.
- `ghome` is `/n/local/Users/$user` on Windows + macOS, `/n/local/home/$user` on Linux — same idiom; per-host home-naming convention preserved upstream.
- `~/.infernode` overlay logic unchanged.

## Trade-off

Secondary drives (`D:`, `E:`) are no longer auto-mounted at `/n/D`, `/n/E`. Users who need them can `trfs '#UD:/' /n/d` at the shell. If real users want auto-mount, that's a separate decision and can stack on top of this without changing the primary `/n/local` semantics.

## Test plan

- [ ] CI green.
- [ ] On Windows: `cd /n/local` shows contents of `C:\`; `cd /n/local/Users/$user` lands in the host profile.
- [ ] Overlay (`/usr/inferno/secstore` etc. from `~/.infernode`) still binds correctly.
- [ ] macOS / Linux behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)