### PR TITLE
Windows build script: cd into source dir + cover appl/veltro/tools (INFR-56)

### DIFF
--- a/build-windows-amd64.ps1
+++ b/build-windows-amd64.ps1
@@ -685,6 +685,8 @@ $MODULE = "$ROOT\module"
 
 # Helper: compile all .b files in a source dir to a target dis dir.
 # Compiles to a temp file first to avoid clobbering existing .dis on failure.
+# Runs limbo with CWD=SrcDir so relative includes (e.g. "../tool.m" in
+# appl/veltro/tools/*.b) resolve the same way mk does them.
 function Build-DisDir {
     param(
         [string]$SrcDir,
@@ -695,10 +697,11 @@ function Build-DisDir {
     $count = 0
     $prevPref = $ErrorActionPreference
     $ErrorActionPreference = "SilentlyContinue"
-    Get-ChildItem -Path $SrcDir -Filter "*.b" -File | ForEach-Object {
+    Push-Location $SrcDir
+    Get-ChildItem -Path . -Filter "*.b" -File | ForEach-Object {
         $name = $_.BaseName
         $tmpDis = "$DisDir\$name.dis.tmp"
-        $output = & $LIMBO -I $MODULE -o $tmpDis $_.FullName 2>&1
+        $output = & $LIMBO -I $MODULE -o $tmpDis $_.Name 2>&1
         if ($LASTEXITCODE -eq 0 -and (Test-Path $tmpDis)) {
             Move-Item -Force $tmpDis "$DisDir\$name.dis"
             $count++
@@ -706,6 +709,7 @@ function Build-DisDir {
             Remove-Item -Force $tmpDis -ErrorAction SilentlyContinue
         }
     }
+    Pop-Location
     $ErrorActionPreference = $prevPref
     return $count
 }
@@ -733,6 +737,13 @@ $totalDis += $n
 $applDirs = @("acme","charon","grid","math","svc","veltro","wm","xenith")
 foreach ($dir in $applDirs) {
     $n = Build-DisDir "$ROOT\appl\$dir" "$ROOT\dis\$dir"
+    $totalDis += $n
+}
+
+# appl/veltro subdirs -> dis/veltro/<sub>/
+$veltroSubdirs = @("sources","tools")
+foreach ($sub in $veltroSubdirs) {
+    $n = Build-DisDir "$ROOT\appl\veltro\$sub" "$ROOT\dis\veltro\$sub"
     $totalDis += $n
 }
 


### PR DESCRIPTION
## Summary

Two bugs in \`build-windows-amd64.ps1\` were causing ~134 .dis files to be silently skipped on every Windows build (Built 467 → Built 604+). Surfaced while smoke-testing the INFR-52 security-fix port; relevant .dis files weren't being regenerated.

Tracking: [INFR-56](https://nervsystems-team.atlassian.net/browse/INFR-56).

## Bug 1 — Build-DisDir didn't cd into the source directory

\`Build-DisDir\` invoked limbo with the .b file's absolute path but kept PowerShell's CWD wherever the script was run from. Limbo resolves \`#include\` paths relative to its own CWD. Concrete failure: \`appl/veltro/tools/exec.b\` line 37 \`include "../tool.m"\` resolved to a path *outside* the repo, failed silently, and the .dis was never replaced.

mk-driven builds work because mk \`cd\`s into each source dir before invoking limbo. The PowerShell helper didn't.

**Fix**: \`Push-Location $SrcDir\` around the foreach loop; pass \`$_.Name\` (not full path) to limbo.

## Bug 2 — appl/veltro/tools/ and appl/veltro/sources/ never built

The build script iterated top-level \`appl/<dir>\` for a fixed list but never descended. \`appl/veltro/tools/\` (41 .b including \`exec\`, \`git\`, \`shell\`, \`webfetch\`, \`mail\`, \`keyring\`, …) and \`appl/veltro/sources/\` (1 .b) were invisible to the Windows build.

**Fix**: explicit \`$veltroSubdirs = @("sources","tools")\` loop mirroring how \`$cmdSubdirs\` is handled for \`appl/cmd\`.

## Why this matters for the v0.2 release

Without this, the Windows zip would ship stale .dis for every Veltro tool whose source has changed since 2026-04-14 — including the security fixes in PR #63 (\`cowfs\` traversal defense, \`exec\` command-chaining defense). The combined effect of #63 + this PR is that those fixes are actually present in shipped bytecode.

## Test plan

- [x] Local rebuild: "Built 604 .dis files" (was 467).
- [x] \`dis/veltro/tools/exec.dis\` regenerates fresh.
- [ ] CI Windows job still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)