### PR TITLE
fix(walk): handle zero-element clone walks

### DIFF
--- a/emu/Nt/devfs.c
+++ b/emu/Nt/devfs.c
@@ -445,7 +445,7 @@ fswalk(Chan *c, Chan *nc, char **name, int nname)
 
 	alloc = 0;
 	current = nil;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc && wq->clone != nil)
 			cclose(wq->clone);

--- a/emu/Plan9/devfs.c
+++ b/emu/Plan9/devfs.c
@@ -95,7 +95,7 @@ fswalk(Chan *c, Chan *nc, char **name, int nname)
 
 	alloc = 0;
 	current = nil;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc && wq->clone!=nil)
 			cclose(wq->clone);

--- a/emu/Plan9/devsrv9.c
+++ b/emu/Plan9/devsrv9.c
@@ -119,7 +119,7 @@ srv9walk(Chan *c, Chan *nc, char **name, int nname)
 		isdir(c);
 
 	alloc = 0;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc)
 			cclose(wq->clone);

--- a/emu/port/dev.c
+++ b/emu/port/dev.c
@@ -128,7 +128,7 @@ devwalk(Chan *c, Chan *nc, char **name, int nname, Dirtab *tab, int ntab, Devgen
 		isdir(c);
 
 	alloc = 0;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc && wq->clone!=nil)
 			cclose(wq->clone);

--- a/emu/port/devfs-posix.c
+++ b/emu/port/devfs-posix.c
@@ -160,7 +160,7 @@ fswalk(Chan *c, Chan *nc, char **name, int nname)
 	alloc = 0;
 	gotstat = 0;
 	current = nil;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc && wq->clone != nil)
 			cclose(wq->clone);

--- a/emu/port/devmnt.c
+++ b/emu/port/devmnt.c
@@ -425,7 +425,7 @@ mntwalk(Chan *c, Chan *nc, char **name, int nname)
 	if(nname > MAXWELEM)
 		error("devmnt: too many name elements");
 	alloc = 0;
-	wq = smalloc(sizeof(Walkqid)+(nname-1)*sizeof(Qid));
+	wq = smalloc(sizeof(Walkqid)+(nname > 0 ? nname-1 : 0)*sizeof(Qid));
 	if(waserror()){
 		if(alloc && wq->clone!=nil)
 			cclose(wq->clone);


### PR DESCRIPTION
## Summary
- fix `Walkqid` allocation for `walk(..., 0)` clone paths in the generic device walkers and `devmnt`
- keep zero-element walks allocating the base `Walkqid` shape instead of computing `(nname-1)` for `nname == 0`

## Why
This is another `INFR-57` follow-up.

`cclone()` calls `devtab[c->type]->walk(c, nil, nil, 0)`. Several device walkers still used the traditional `sizeof(Walkqid) + (nname-1)*sizeof(Qid)` allocation pattern without guarding the zero-name clone case. For `nname == 0`, that can under-allocate the `Walkqid` header and turn a clone walk into memory corruption or allocator misuse.

The fix is mechanical but important: zero-name clone walks now allocate the base `Walkqid` object everywhere this pattern appears in the emulator-side C walkers.

## Validation
- `TMPDIR=/private/tmp ./tests/host/build_test.sh`
- `./emu/MacOSX/o.emu -r. /dis/sh.dis -c "load std; mount -ac {mntgen} /n >[2] /dev/null; echo OK"`

Related: `INFR-57`