### PR TITLE
fix(emu): zero-initialize mount links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,7 +907,18 @@ jobs:
     - name: Install build dependencies
       shell: powershell
       run: |
-        choco install winflexbison3 -y
+        $attempts = 3
+        for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+          choco install winflexbison3 -y --no-progress
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq $attempts) {
+            throw "Failed to install winflexbison3 after $attempts attempts"
+          }
+          Write-Warning "winflexbison3 install attempt $attempt failed with exit code $LASTEXITCODE; retrying..."
+          Start-Sleep -Seconds (15 * $attempt)
+        }
 
     - name: Setup MSVC environment
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1026,7 +1026,18 @@ jobs:
     - name: Install build dependencies (win_bison via choco)
       shell: pwsh
       run: |
-        choco install winflexbison3 -y
+        $attempts = 3
+        for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+          choco install winflexbison3 -y --no-progress
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq $attempts) {
+            throw "Failed to install winflexbison3 after $attempts attempts"
+          }
+          Write-Warning "winflexbison3 install attempt $attempt failed with exit code $LASTEXITCODE; retrying..."
+          Start-Sleep -Seconds (15 * $attempt)
+        }
 
     - name: Setup MSVC environment
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592571 # v1

--- a/emu/port/pgrp.c
+++ b/emu/port/pgrp.c
@@ -93,7 +93,7 @@ pgrpcpy(Pgrp *to, Pgrp *from)
 				runlock(&f->lock);
 				nexterror();
 			}
-			mh = malloc(sizeof(Mhead));
+			mh = mallocz(sizeof(Mhead), 1);
 			if(mh == nil)
 				error(Enomem);
 			mh->from = f->from;

--- a/emu/port/pgrp.c
+++ b/emu/port/pgrp.c
@@ -212,7 +212,7 @@ newmount(Mhead *mh, Chan *to, int flag, char *spec)
 {
 	Mount *m;
 
-	m = malloc(sizeof(Mount));
+	m = mallocz(sizeof(Mount), 1);
 	if(m == nil)
 		error(Enomem);
 	m->to = to;


### PR DESCRIPTION
## Summary
- zero-initialize newly allocated `Mount` records in `newmount()`
- stop mount-list traversal and cleanup from reading indeterminate `next`/`spec` fields

## Why
`newmount()` was using plain `malloc(sizeof(Mount))` and then only initializing part of the struct. That left `next`, `copy`, `order`, and sometimes `spec` undefined even though later code immediately traverses mount chains and always frees `spec` in `mountfree()`.

For mount lifecycle code this is the wrong failure mode: even if most allocators hand back zeroed pages often enough to hide it, the implementation was depending on uninitialized state.

## Validation
- `TMPDIR=/private/tmp ./tests/host/build_test.sh`
- `./tests/host/mount_clone_walk_test.sh`

Related: `INFR-57`