### PR TITLE
fix(ci): correct ilammy/msvc-dev-cmd SHA in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1040,7 +1040,7 @@ jobs:
         }
 
     - name: Setup MSVC environment
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592571 # v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: amd64
 


### PR DESCRIPTION
v0.2.0-rc1 release pipeline failed at `Set up job` on the Windows matrix entry because the pinned SHA for `ilammy/msvc-dev-cmd` was off by 4 hex digits at the end (`...571` -> `...756`). The real v1.13.0 SHA is `0b201ec74fa43914dc39ae48a89fd1d8cb592756`. Once this merges, v0.2.0-rc1 will be retagged at the new master HEAD.

Refs: INFR-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)