### PR TITLE
fix(ci): cosign --bundle + correct Windows Quick Start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1175,9 +1175,16 @@ jobs:
 
     - name: Sign release artifacts
       run: |
+        # cosign-installer v4.x ships a cosign that defaults to the new
+        # bundle format and treats --output-signature / --output-certificate
+        # as deprecated. With the new format they get ignored and cosign
+        # then tries to write to an empty --bundle path, failing with
+        # "create bundle file: open : no such file or directory". Pass an
+        # explicit --bundle path to produce a single .sigstore file per
+        # artefact instead of separate .sig/.pem files.
         cd artifacts
         for f in infernode-* SHA256SUMS.txt; do
-          cosign sign-blob --yes --output-signature "${f}.sig" --output-certificate "${f}.pem" "$f"
+          cosign sign-blob --yes --bundle "${f}.sigstore" "$f"
         done
 
     - name: Attest build provenance
@@ -1230,14 +1237,14 @@ jobs:
 
           **Linux (headless):** Extract, then `./infernode-headless`
 
-          **Windows:** Extract the zip, then run `emu\Nt\o.emu.exe -r . sh -l`
+          **Windows:** Extract the zip, optionally run `setup-windows.ps1` (or `setup-windows.bat`) to configure an LLM backend, then double-click `InferNode.exe`. The launcher embeds an icon and version metadata; SDL3 GUI ships in the same zip.
 
           ### Verification
 
-          All release artifacts are signed with [Sigstore](https://sigstore.dev) cosign (keyless).
+          All release artifacts are signed with [Sigstore](https://sigstore.dev) cosign (keyless), one `.sigstore` bundle per file.
 
           ```
-          cosign verify-blob --signature <file>.sig --certificate <file>.pem \
+          cosign verify-blob --bundle <file>.sigstore \
             --certificate-identity-regexp 'github.com/infernode-os/infernode' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com <file>
           ```


### PR DESCRIPTION
v0.2.0-rc1 retry failed at the Sign release artifacts step. cosign-installer v4.x ships a cosign that ignores `--output-signature` / `--output-certificate` (deprecated under `--new-bundle-format`) and then tries to open an empty `--bundle` path, exiting with `create bundle file: open : no such file or directory`. Switch to a single `.sigstore` bundle per artefact.

Also: fix the Windows Quick Start in the release notes - it still said "run `emu\Nt\o.emu.exe -r . sh -l`", which is the dev-from-source invocation. The released zip has `InferNode.exe` at top level; double-click is the actual end-user path.

After this lands, retag v0.2.0-rc1 to re-run the release pipeline.

Refs: INFR-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)