### PR TITLE
docs(windows): MOTW unblock note + reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ InferNode is a modern Inferno® distribution with JIT compilation on AMD64 (14×
 Every tagged release ships signed binaries for macOS, Linux, and Windows on the [latest release page](https://github.com/infernode-os/infernode/releases/latest). No toolchain, no build step — download and run.
 
 - **macOS (Apple Silicon)** — `infernode-*-macos-arm64.dmg`: open, drag to Applications, launch.
-- **Windows (x86_64)** — `infernode-*-windows-amd64.zip`: extract, optionally run `setup-windows.ps1` (or `setup-windows.bat`) to configure an LLM backend, double-click `InferNode.exe`.
+- **Windows (x86_64)** — `infernode-*-windows-amd64.zip`: **before extracting**, right-click the downloaded zip → Properties → tick **Unblock** → OK. Then extract, optionally run `setup-windows.ps1` (or `setup-windows.bat`) to configure an LLM backend, double-click `InferNode.exe`. (Without the Unblock step Windows propagates the browser's Mark-of-the-Web to every extracted file; SmartScreen then silently refuses to launch the unsigned exe with no error dialog. Code-signing is on the roadmap.)
 - **Linux x86_64 (GUI)** — `infernode-*-linux-amd64-gui.tar.gz`: SDL3 is bundled.
 - **Linux ARM64 (GUI)** — `infernode-*-linux-arm64-gui.tar.gz`: for Jetson, Raspberry Pi, etc.
 - **Linux (headless)** — `infernode-*-linux-amd64.tar.gz` or `infernode-*-linux-arm64.tar.gz`.

--- a/tests/host/reset-windows-install.ps1
+++ b/tests/host/reset-windows-install.ps1
@@ -1,0 +1,154 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Reset a Windows InferNode install to first-run state.
+
+.DESCRIPTION
+    Removes all per-user state that accumulates across InferNode runs:
+      - %USERPROFILE%\.infernode\ (the writable overlay: secstore PAK,
+        ndb/llm config, veltro markers, lucibridge.log, theme, etc.)
+      - Any running o.emu, InferNode, secstored processes that would
+        hold file handles open and block deletion
+      - The cached -ExpectPass log files in %TEMP%
+
+    Does NOT touch:
+      - The repo source tree
+      - %TEMP%\InferNode-dev\ (the dev bundle) - that's a build output,
+        not user state. Pass -DeleteDevBundle to also remove it.
+      - User environment variables (ANTHROPIC_API_KEY, etc.). The shell
+        will report whether one is currently set, but won't delete it -
+        that's a deliberate user choice. Pass -ClearEnv to delete it
+        from the user environment as well.
+
+    After running, launching InferNode again triggers the first-run
+    flow: profile.sh seeds ~/.infernode from /lib (the read-only root),
+    secstored asks for a new password, factotum starts empty, etc.
+
+.PARAMETER DeleteDevBundle
+    Also remove %TEMP%\InferNode-dev. Use this when you want to test
+    the released zip in isolation, not the locally-built dev bundle.
+
+.PARAMETER ClearEnv
+    Also clear ANTHROPIC_API_KEY from the user environment. Default
+    is to leave env vars alone.
+
+.PARAMETER Force
+    Skip the confirmation prompt. Use in CI / non-interactive contexts.
+
+.EXAMPLE
+    .\tests\host\reset-windows-install.ps1
+
+.EXAMPLE
+    # Full reset for an RC-zip fresh-install test:
+    .\tests\host\reset-windows-install.ps1 -DeleteDevBundle -ClearEnv -Force
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$DeleteDevBundle,
+    [switch]$ClearEnv,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$inferno = Join-Path $env:USERPROFILE ".infernode"
+$bundle = Join-Path $env:TEMP "InferNode-dev"
+
+Write-Host "=== Reset plan ===" -ForegroundColor Cyan
+$plan = @()
+if (Test-Path $inferno) {
+    $size = [math]::Round(((Get-ChildItem $inferno -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1KB), 1)
+    $plan += "  DELETE  $inferno  ($size KB)"
+} else {
+    $plan += "  (already absent)  $inferno"
+}
+if ($DeleteDevBundle) {
+    if (Test-Path $bundle) {
+        $size = [math]::Round(((Get-ChildItem $bundle -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum / 1MB), 1)
+        $plan += "  DELETE  $bundle  ($size MB)"
+    } else {
+        $plan += "  (already absent)  $bundle"
+    }
+}
+if ($ClearEnv) {
+    $cur = [Environment]::GetEnvironmentVariable("ANTHROPIC_API_KEY", "User")
+    if ($cur) {
+        $masked = $cur.Substring(0, [Math]::Min(8, $cur.Length)) + "...(masked)"
+        $plan += "  CLEAR   user env ANTHROPIC_API_KEY  ($masked)"
+    } else {
+        $plan += "  (not set)  user env ANTHROPIC_API_KEY"
+    }
+}
+$running = Get-Process -Name "o.emu","InferNode","secstored" -ErrorAction SilentlyContinue
+if ($running) {
+    foreach ($p in $running) {
+        $plan += "  KILL    $($p.Name) PID $($p.Id)"
+    }
+} else {
+    $plan += "  (no running processes)  o.emu / InferNode / secstored"
+}
+$plan | ForEach-Object { Write-Host $_ }
+Write-Host ""
+
+if (-not $Force) {
+    $yn = Read-Host "Proceed? [y/N]"
+    if ($yn -notmatch "^[Yy]") {
+        Write-Host "Aborted." -ForegroundColor Yellow
+        exit 0
+    }
+}
+
+# 1. Kill processes first so their handles don't block deletion.
+if ($running) {
+    Write-Host "Stopping processes..."
+    $running | ForEach-Object {
+        try { $_.Kill() } catch {}
+    }
+    Start-Sleep -Milliseconds 500
+}
+
+# 2. Remove the overlay.
+if (Test-Path $inferno) {
+    Write-Host "Removing $inferno ..."
+    Remove-Item -Recurse -Force $inferno -ErrorAction SilentlyContinue
+    if (Test-Path $inferno) {
+        Write-Host "WARNING: $inferno still present (handle held open?)" -ForegroundColor Yellow
+    } else {
+        Write-Host "  removed" -ForegroundColor Green
+    }
+}
+
+# 3. Optional: remove dev bundle.
+if ($DeleteDevBundle -and (Test-Path $bundle)) {
+    Write-Host "Removing $bundle ..."
+    Remove-Item -Recurse -Force $bundle -ErrorAction SilentlyContinue
+    if (Test-Path $bundle) {
+        Write-Host "WARNING: $bundle still present" -ForegroundColor Yellow
+    } else {
+        Write-Host "  removed" -ForegroundColor Green
+    }
+}
+
+# 4. Optional: clear env vars.
+if ($ClearEnv) {
+    if ([Environment]::GetEnvironmentVariable("ANTHROPIC_API_KEY", "User")) {
+        [Environment]::SetEnvironmentVariable("ANTHROPIC_API_KEY", $null, "User")
+        Write-Host "Cleared ANTHROPIC_API_KEY from user environment." -ForegroundColor Green
+        Write-Host "  (existing shells keep their current value - open a new shell to see the cleared state)" -ForegroundColor DarkGray
+    }
+}
+
+# 5. Clean leftover log files in %TEMP%
+foreach ($pattern in @("infernode-setup-windows*.log", "cdb-infr*.log", "limbo-test-*.log",
+                       "ollama-test*.json", "ollama-resp*.json", "ollama-body.json",
+                       "jit-testsuite-*.txt", "infernode-panic.log")) {
+    $files = Get-ChildItem -Path $env:TEMP -Filter $pattern -ErrorAction SilentlyContinue
+    foreach ($f in $files) {
+        Remove-Item $f.FullName -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host ""
+Write-Host "Reset complete." -ForegroundColor Green
+Write-Host "Next launch of InferNode will go through the first-run flow." -ForegroundColor DarkGray


### PR DESCRIPTION
Two non-functional follow-ups from v0.2.0-rc1 hands-on validation:

1. README: prepend the Windows install bullet with the right-click → Properties → **Unblock** step. Browser-downloaded zips tag every extracted file with Mark-of-the-Web; SmartScreen then silently refuses to launch the unsigned InferNode.exe with no dialog at all. Unblock at the zip level before extracting clears the cascade. Hit during RC1 validation today - first user experience without this step is "double-clicked, nothing happened." Code-signing is the proper fix and is on the v0.3 roadmap (separate ticket).

2. `tests/host/reset-windows-install.ps1`: idempotent reset-to-fresh-install script that kills lingering processes, removes `~/.infernode/`, optionally removes the dev bundle and clears API-key env vars. Used by anyone doing repeat fresh-install testing of future RCs.

Refs: INFR-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)