### PR TITLE
fix(mk): honour MKSHELL env var, unbreaks Termux backquote subst (INFR-107)

### DIFF
--- a/build-android-termux.sh
+++ b/build-android-termux.sh
@@ -80,6 +80,12 @@ mkdir -p "$ROOT/Linux/arm64/lib"
 export PATH="$ROOT/Linux/arm64/bin:$PATH"
 export SHELL="$SH_BIN"
 export SHELLNAME=sh
+# mk hardcodes /bin/sh in Posix.c at compile time. On real Android handsets
+# /bin -> /system/bin so /bin/sh resolves; in pure-Termux environments
+# (e.g. termux-docker) it does not. Honour the new MKSHELL hook so mk uses
+# Termux's sh for backquote substitution and recipe execution. See the
+# shellinit() addition in utils/mk/Posix.c.
+export MKSHELL="$SH_BIN"
 
 echo "ROOT=$ROOT"
 echo "CC=$CC"

--- a/utils/mk/Nt.c
+++ b/utils/mk/Nt.c
@@ -15,6 +15,18 @@ enum {
 char *rootdir =		ROOT;
 char *shell =		"Nt/amd64/bin/rcsh.exe";	/* Path relative to root */
 
+/*
+ * shellinit() — no-op on Windows. The MKSHELL hook that Posix.c uses
+ * to override /bin/sh on Termux-style environments has no analogue on
+ * Windows (mk here invokes rcsh.exe directly, not via PATH lookup),
+ * so this stub satisfies the prototype called from main.c on every
+ * platform that builds mk.
+ */
+void
+shellinit(void)
+{
+}
+
 typedef struct Child	Child;
 
 struct Child {

--- a/utils/mk/Posix.c
+++ b/utils/mk/Posix.c
@@ -10,6 +10,35 @@ char 	*shellname =	"sh";
 
 extern char **environ;
 
+/*
+ * shellinit - honour MKSHELL env var for backquote substitution and
+ * recipe execution.
+ *
+ * mk's default shell is hardcoded to /bin/sh at compile time. That works
+ * on Plan 9, glibc Linux, macOS, and on Android handsets where /bin is a
+ * symlink to /system/bin. It does NOT work in pure-Termux environments
+ * such as termux-docker, where /bin/sh does not exist (Termux puts its
+ * sh under $PREFIX/bin/sh). When invoked there, the very first backquote
+ * substitution in mkconfig fails silently and SYSHOST/OBJTYPE end up
+ * empty, breaking every downstream lookup.
+ *
+ * MKSHELL is namespaced to mk on purpose: SHELL on glibc commonly points
+ * at bash, and using bash for mk recipes changes their semantics. Users
+ * who hit the /bin/sh-missing case can set MKSHELL explicitly without
+ * disturbing anything else. The Termux build driver sets it.
+ */
+void
+shellinit(void)
+{
+	char *s = getenv("MKSHELL");
+	if(s != nil && *s != '\0') {
+		char *p;
+		shell = s;
+		p = strrchr(s, '/');
+		shellname = p ? p + 1 : s;
+	}
+}
+
 void
 readenv(void)
 {

--- a/utils/mk/main.c
+++ b/utils/mk/main.c
@@ -22,6 +22,8 @@ void badusage(void);
 short buf[10000];
 #endif
 
+extern void shellinit(void);
+
 void
 main(int argc, char **argv)
 {
@@ -41,6 +43,7 @@ main(int argc, char **argv)
 	 */
 
 	Binit(&bout, 1, OWRITE);
+	shellinit();		/* honour MKSHELL before any backquote subst. */
 	buf = newbuf();
 	whatif = 0;
 	USED(argc);


### PR DESCRIPTION
## Summary
`utils/mk/Posix.c` hardcodes the shell path at compile time:

\`\`\`c
char *shell     = "/bin/sh";
char *shellname = "sh";
\`\`\`

That works on Plan 9, glibc Linux, macOS, and on Android handsets where `/bin -> /system/bin` so `/bin/sh` resolves. It does **not** work in pure-Termux environments such as `termux-docker` (the basis for the CI runner in #97): Termux's sh lives at `\$PREFIX/bin/sh` and there is no `/bin/sh`.

The breakage is silent and downstream-fatal. The very first backquote substitution in `mkconfig`

\`\`\`
SYSHOST=\`{sh -c 'case \$(uname -s) in Darwin) echo MacOSX;; *) uname -s;; esac'}
\`\`\`

fails with `/bin/sh: No such file or directory`, leaving SYSHOST and OBJTYPE empty. Every subsequent `<mkfiles/mkhost-\$SYSHOST` / `<mkfiles/mkfile-\$SYSTARG-\$OBJTYPE` include then expands to a non-existent path, and the whole lib build collapses with `mk: don't know how to make '..///include/lib9.h'`.

This is the actual root cause that the CI run on #97 surfaced once we got past the package-name / exec-bit / mount-perms layers.

## Fix
- `utils/mk/Posix.c` gains a `shellinit()` function that, if `MKSHELL` is set and non-empty, overrides `shell` / `shellname` accordingly. Otherwise the historical `/bin/sh` default is unchanged.
- `utils/mk/main.c` calls `shellinit()` at the top of `main()`, before any mkfile is parsed (and therefore before any backquote substitution).
- `build-android-termux.sh` exports `MKSHELL=\$SH_BIN` (= `\$PREFIX/bin/sh` on Termux) so the bootstrap mk picks it up.

## Why `MKSHELL`, not `SHELL`
The plain `SHELL` env var commonly points at bash on glibc systems. Plan 9 mk recipes assume POSIX-sh semantics; silently swapping in bash would change behaviour for users who haven't asked for it. `MKSHELL` is opt-in, mk-namespaced, and only the Termux driver currently sets it.

## Test plan
- [ ] Real-Linux ARM64 build (Jetson) unchanged — `MKSHELL` not set, `shell` stays `/bin/sh`.
- [ ] macOS / x86_64 Linux unchanged.
- [ ] Plan 9 / Inferno-self-hosted builds unchanged.
- [ ] Termux on real handset: build still works (now also via `MKSHELL` rather than relying on `/bin -> /system/bin`).
- [ ] termux-docker in CI (PR #97): bootstrap mk picks up `MKSHELL`, mkconfig's backquote subst works, SYSHOST and OBJTYPE populate correctly, lib9/libbio/… build cleanly.

Unblocks #97 (Termux CI regression gate) once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)