### PR TITLE
fix(libsec): re-declare getrandom on Bionic (INFR-107)

### DIFF
--- a/libsec/prng.c
+++ b/libsec/prng.c
@@ -3,6 +3,20 @@
 #include <libsec.h>
 #if defined(__linux__)
 #include <sys/random.h>
+#if defined(__BIONIC__)
+/*
+ * Bionic's <sys/random.h> hides the getrandom() declaration behind
+ * __ANDROID_API__ >= 28. Termux's clang may target a lower minSdk
+ * (16/24/etc.) even on a current device, so the prototype stays
+ * invisible and -Werror=implicit-function-declaration kills the build.
+ *
+ * The symbol is in libc.so on every Android Termux supports
+ * (the Linux getrandom syscall has been around since Android 6 / API
+ * 23, and Bionic's wrapper has been exported since 28), so it is safe
+ * to re-declare here. No effect on non-Bionic platforms.
+ */
+extern int getrandom(void *buf, size_t buflen, unsigned int flags);
+#endif
 #elif defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>


### PR DESCRIPTION
## Summary
Bionic's `<sys/random.h>` hides the `getrandom()` prototype behind `__ANDROID_API__ >= 28`. Termux's clang can target a lower minSdk (typically 24) even on a current device, so the declaration stays invisible and `-Werror=implicit-function-declaration` kills the build:

\`\`\`
prng.c:27:15: error: call to undeclared function 'getrandom';
ISO C99 and later do not support implicit function declarations
\`\`\`

The symbol is in `libc.so` on every Android Termux supports (Android 6+ has the kernel syscall; Bionic exports the wrapper at API 28), so re-declare the prototype under `__BIONIC__`. No effect on glibc / musl / macOS / Windows.

Same shape as the lib9.h shims that landed in #96.

## Why it didn't surface on the user's handset
The user's Galaxy A55 build went through cleanly because their Termux install (Play Store `googleplay.2025.10.05`, targetSdk 36) has clang targeting a recent enough API that `<sys/random.h>` exposes the prototype. `termux-docker` in CI (PR #97) uses an older default minSdk and hits the gate. This makes the CI environment a *better* Phase 0 surface than the phone — it catches portability gaps the phone happens to mask.

## Test plan
- [ ] Real-Linux ARM64 build (Jetson) unchanged — `__BIONIC__` not defined; original code path.
- [ ] macOS / x86_64 Linux / Windows unchanged.
- [ ] Termux on real handset still works (re-declaration is harmless redeclaration; matching libc.so signature).
- [ ] termux-docker in CI (#97): prng.c compiles, libsec links, build progresses past the previous failure point.

Unblocks #97 (Termux CI regression gate) further along the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)