### PR TITLE
fix(mk): mkhost-Linux SHELLNAME use PATH lookup (INFR-107)

### DIFF
--- a/mkfiles/mkhost-Linux
+++ b/mkfiles/mkhost-Linux
@@ -2,7 +2,7 @@
 #	Variables for host system type = Linux
 
 SHELLTYPE=	sh
-SHELLNAME=	/bin/sh
+SHELLNAME=	sh		# resolve via PATH; Termux has no /bin/sh
 HOSTMODEL=	Posix
 OSTARG=		os
 


### PR DESCRIPTION
## Summary
\`mkfiles/mkhost-Linux\` hardcodes \`SHELLNAME= /bin/sh\`. mkfiles expand \`$SHELLNAME\` inline — e.g. \`emu/Linux/mkfile-g:16\`:

\`\`\`
<| \$SHELLNAME ../port/mkdevlist  \$CONF
\`\`\`

…becomes \`/bin/sh ../port/mkdevlist emu\`. On every Linux that's fine; on Android handsets \`/bin\` symlinks to \`/system/bin\` so the path resolves. In pure-Termux environments (e.g. \`termux-docker\`) there is no \`/bin/sh\` and the command fails:

\`\`\`
sh: 1: /bin/sh: not found
bad include program status
ERROR: emulator build failed
\`\`\`

Drop the absolute path so the bin name resolves via PATH. Termux's sh is at \`\$PREFIX/bin/sh\` and \`\$PREFIX/bin\` is on PATH; every other Linux has \`/bin\` in PATH and finds \`/bin/sh\` as before. No behaviour change for non-Termux Linux.

This is the second leg of the mk shell-path portability fix:
- #99 — C-level hardcoded \`/bin/sh\` in \`utils/mk/Posix.c\` via \`MKSHELL\`.
- this PR — mkfile-level \`$SHELLNAME\` expansion.

## Test plan
- [ ] Linux ARM64 / AMD64 builds unchanged — PATH still finds \`/bin/sh\`.
- [ ] macOS untouched (separate \`mkhost-MacOSX\`).
- [ ] Termux on real handset: works (was already passing because /bin -> /system/bin).
- [ ] termux-docker in CI (#97): \`<| sh ../port/mkdevlist emu\` resolves Termux's sh, mkfile-g include succeeds, emu build proceeds.

Unblocks #97 (Termux CI regression gate) further along the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)