### PR TITLE
fix(emu): skip pthread_attr_setinheritsched on Bionic (INFR-107)

### DIFF
--- a/emu/port/kproc-pthreads.c
+++ b/emu/port/kproc-pthreads.c
@@ -168,7 +168,14 @@ kproc(char *name, void (*func)(void*), void *arg, int flags)
 		pthread_attr_setstacksize(&attr, 512*1024);	/* could be a parameter */
 	else if(KSTACK > 0)
 		pthread_attr_setstacksize(&attr, (KSTACK < PTHREAD_STACK_MIN? PTHREAD_STACK_MIN: KSTACK)+1024);
+#ifndef __BIONIC__
+	/* Bionic does not implement pthread_attr_setinheritsched (the
+	 * inherit-sched attribute is unsupported; new threads inherit
+	 * scheduling from the creator by default, which is exactly what
+	 * PTHREAD_INHERIT_SCHED requests). Skip on Bionic — no behavioural
+	 * change, just removing a missing function reference. Phase 0. */
 	pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+#endif
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 	if(pthread_create(&thread, &attr, tramp, p))
 		panic("thr_create failed\n");


### PR DESCRIPTION
## Summary
Bionic does not implement \`pthread_attr_setinheritsched\` at all; the inherit-sched attribute is unsupported. New threads inherit scheduling from the creator by default, which is the exact behaviour the existing call asks for here (\`PTHREAD_INHERIT_SCHED\`), so skipping it on Bionic is semantically identical — not a workaround.

Build error before this patch:

\`\`\`
../port/kproc-pthreads.c:171:2: error: call to undeclared function
  'pthread_attr_setinheritsched'; ISO C99 and later do not support
  implicit function declarations
\`\`\`

Surfaced by the Termux CI runner (#97). Same pattern as the other Phase 0 Bionic shims — gate on \`#ifndef __BIONIC__\`, glibc / macOS / Windows / Plan 9 untouched.

## Test plan
- [ ] Linux ARM64 / AMD64 / macOS / Windows / Plan 9 builds unchanged.
- [ ] Termux on real handset: works (was already passing because Bionic must have been silently tolerating the missing-declaration warning, or another path).
- [ ] termux-docker in CI (#97): kproc-pthreads.c compiles, emu build proceeds.

Unblocks #97 (Termux CI regression gate) further along the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)