### PR TITLE
feat(android): Phase 1d — emu_run survives JNI, boots on real A55 (INFR-111)

### DIFF
--- a/android-app/app/src/main/cpp/jni-emu.c
+++ b/android-app/app/src/main/cpp/jni-emu.c
@@ -2,68 +2,218 @@
  * jni-emu.c — JNI bridge between Java (io.infernode.Emu) and the
  * InferNode emulator entry point.
  *
- * Phase 1c scaffold. This file lives under android-app/app/src/main/cpp/
- * but is NOT compiled by Gradle in the v1 packaging strategy — the
- * libemu.so it would produce instead comes from the existing Inferno
- * mkfile chain via a `build-android-apk.sh` driver (Phase 1c follow-up).
+ * Phase 1d (INFR-111) refactor. Previously this file just marshalled
+ * argv and called emu_run(...) on the JVM-attached JNI thread. That
+ * crashed the process within ~22 ms of libemu.so loading, because
+ * emu's headless boot path ends in `for(;;) ospause();` and
+ * ospause() does pthread_exit(0). pthread_exit on a JNI-attached
+ * thread is undefined; the zygote saw the thread vanish and SIGKILLed
+ * the process.
  *
- * That follow-up needs to:
+ * Two changes fix it:
  *
- *   1. Refactor emu/port/main.c so the body of main() becomes a
- *      callable `int emu_run(int argc, char **argv)`. The existing
- *      main() stays as a 3-line shim that just calls emu_run for the
- *      `adb shell /data/local/tmp/o.emu` path.
+ * 1. emu_run runs on its own detached pthread, not on the JVM caller.
+ *    The JVM caller returns to Java immediately. emu's eventual
+ *    pthread_exit lands on a thread the JVM doesn't know about, so
+ *    the runtime never sees a stray death and the process keeps
+ *    running indefinitely.
  *
- *   2. Add a build flag to emu/Android/mkfile-g that produces both
- *      o.emu (PIE executable, current behaviour) and libemu.so
- *      (-shared, exporting Java_io_infernode_Emu_run + emu_run).
+ * 2. stdio (fd 1 and fd 2) is redirected to a pipe at JNI_OnLoad,
+ *    and a reader thread pushes lines to __android_log_write so
+ *    emu's print()/fprint() output shows up in logcat under the
+ *    "InferNode" tag. Without this, every diagnostic emu emits goes
+ *    to /dev/null and the boot is invisible.
  *
- *   3. Symlink or copy the resulting libemu.so into
- *      android-app/app/src/main/jniLibs/arm64-v8a/libemu.so so Gradle
- *      picks it up for assemble.
- *
- * Until that lands, this translation unit is a placeholder — it shows
- * the JNI signature the Java side calls, and what the C side will do
- * once emu_run is extracted. Compiling it standalone right now would
- * produce an unresolved symbol on emu_run.
+ * Single-instance constraint: emu's globals (rootdir, eve, libinit
+ * state, etc.) are process-scoped. A static guard ensures emu_run is
+ * spawned at most once per process — repeat clicks on the boot
+ * button are no-ops.
  */
 
 #include <jni.h>
+#include <android/log.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdatomic.h>
 
-/* Forward declaration. Defined in emu/port/main.c after the v1c.2
- * refactor. */
+#define TAG "InferNode"
+
 extern int emu_run(int argc, char **argv);
+
+/*
+ * Stdio capture: pipe fd1/fd2 into a reader that flushes line-by-line
+ * to logcat. setvbuf on stdout/stderr to line-buffered so prints
+ * surface promptly even before any newline.
+ *
+ * Buffer size 1024 matches emu's internal print buffer in
+ * emu/port/main.c iprint(). Long lines get split across reads, which
+ * logcat shows as separate entries — acceptable for a debug surface.
+ */
+static void *
+stdio_reader(void *arg)
+{
+	int fd = (int)(intptr_t)arg;
+	char buf[1024];
+	ssize_t n, lineLen;
+	char *p, *eol;
+
+	pthread_setname_np(pthread_self(), "emu-stdio");
+
+	while ((n = read(fd, buf, sizeof(buf) - 1)) > 0) {
+		buf[n] = '\0';
+		/* Split on newlines so each log entry is one line. */
+		p = buf;
+		while (*p != '\0') {
+			eol = strchr(p, '\n');
+			if (eol != NULL) {
+				*eol = '\0';
+				lineLen = eol - p;
+			} else {
+				lineLen = (ssize_t)strlen(p);
+			}
+			if (lineLen > 0)
+				__android_log_write(ANDROID_LOG_INFO, TAG, p);
+			if (eol == NULL)
+				break;
+			p = eol + 1;
+		}
+	}
+	return NULL;
+}
+
+static void
+capture_stdio(void)
+{
+	int p[2];
+	pthread_t reader;
+
+	if (pipe(p) != 0) {
+		__android_log_write(ANDROID_LOG_WARN, TAG,
+			"stdio pipe() failed; emu output will not reach logcat");
+		return;
+	}
+	dup2(p[1], STDOUT_FILENO);
+	dup2(p[1], STDERR_FILENO);
+	close(p[1]);
+
+	setvbuf(stdout, NULL, _IOLBF, 0);
+	setvbuf(stderr, NULL, _IOLBF, 0);
+
+	if (pthread_create(&reader, NULL, stdio_reader,
+	    (void *)(intptr_t)p[0]) == 0)
+		pthread_detach(reader);
+}
+
+/*
+ * Worker thread that owns emu's lifetime. Takes ownership of the
+ * heap-allocated argv built by Java_io_infernode_Emu_run; frees it
+ * after emu_run returns (which in headless mode means: never).
+ */
+struct emu_args {
+	int argc;
+	char **argv;
+};
+
+static void *
+emu_thread(void *arg)
+{
+	struct emu_args *a = (struct emu_args *)arg;
+	int i;
+
+	pthread_setname_np(pthread_self(), "emu-main");
+	__android_log_print(ANDROID_LOG_INFO, TAG,
+		"emu_run starting (argc=%d)", a->argc);
+
+	/* In headless mode emu_run never returns — emuinit() does
+	 * for(;;) ospause() and ospause() pthread_exit()s this very
+	 * thread. The free() below only runs if the build path ever
+	 * grows a clean shutdown. */
+	int rc = emu_run(a->argc, a->argv);
+
+	__android_log_print(ANDROID_LOG_INFO, TAG,
+		"emu_run returned %d (unexpected for headless)", rc);
+
+	for (i = 0; i < a->argc; i++)
+		free(a->argv[i]);
+	free(a->argv);
+	free(a);
+	return NULL;
+}
+
+/*
+ * Guard against multiple Emu.run calls. emu can only boot once per
+ * process; a second call would race on globals and almost certainly
+ * crash. Using an atomic flag rather than pthread_once because we
+ * want to *report* re-entry via a logcat line, not silently swallow it.
+ */
+static atomic_int emu_launched = ATOMIC_VAR_INIT(0);
 
 JNIEXPORT jint JNICALL
 Java_io_infernode_Emu_run(JNIEnv *env, jobject thiz, jobjectArray jargv)
 {
 	(void)thiz;
 
+	int expected = 0;
+	if (!atomic_compare_exchange_strong(&emu_launched, &expected, 1)) {
+		__android_log_write(ANDROID_LOG_WARN, TAG,
+			"Emu.run called more than once — ignoring");
+		return -1;
+	}
+
 	const jsize n = (*env)->GetArrayLength(env, jargv);
 
-	/* argv layout: [0] = "emu", [1..n] = caller args, [n+1] = NULL. */
-	char **argv = (char **)calloc((size_t)n + 2, sizeof(char *));
-	if (argv == NULL)
+	struct emu_args *a = (struct emu_args *)calloc(1, sizeof(*a));
+	if (a == NULL)
 		return -1;
 
-	argv[0] = strdup("emu");
+	/* argv layout: [0] = "emu", [1..n] = caller args, [n+1] = NULL. */
+	a->argv = (char **)calloc((size_t)n + 2, sizeof(char *));
+	if (a->argv == NULL) {
+		free(a);
+		return -1;
+	}
+	a->argv[0] = strdup("emu");
+	a->argc = 1;
 
-	int i;
-	for (i = 0; i < n; i++) {
+	for (int i = 0; i < n; i++) {
 		jstring s = (jstring)(*env)->GetObjectArrayElement(env, jargv, i);
 		const char *cs = (*env)->GetStringUTFChars(env, s, NULL);
-		argv[i + 1] = strdup(cs);
+		a->argv[a->argc++] = strdup(cs);
 		(*env)->ReleaseStringUTFChars(env, s, cs);
 		(*env)->DeleteLocalRef(env, s);
 	}
 
-	const int rc = emu_run(n + 1, argv);
+	pthread_t t;
+	if (pthread_create(&t, NULL, emu_thread, a) != 0) {
+		__android_log_write(ANDROID_LOG_ERROR, TAG,
+			"pthread_create for emu-main failed");
+		for (int i = 0; i < a->argc; i++)
+			free(a->argv[i]);
+		free(a->argv);
+		free(a);
+		return -1;
+	}
+	pthread_detach(t);
 
-	for (i = 0; i <= n; i++)
-		free(argv[i]);
-	free(argv);
+	return 0;
+}
 
-	return (jint)rc;
+/*
+ * JNI_OnLoad runs once when System.loadLibrary("emu") completes.
+ * Wire up stdio capture here so even emu's earliest startup prints
+ * (before emu_thread takes off) reach logcat — useful when the
+ * crash is in argument parsing or the env scan.
+ */
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+	(void)vm;
+	(void)reserved;
+	capture_stdio();
+	__android_log_write(ANDROID_LOG_INFO, TAG,
+		"libemu.so JNI_OnLoad — stdio routed to logcat");
+	return JNI_VERSION_1_6;
 }

--- a/android-app/app/src/main/java/io/infernode/InfernodeActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeActivity.kt
@@ -16,31 +16,31 @@ import java.io.FileOutputStream
 import kotlin.concurrent.thread
 
 /**
- * Phase 1c v1 Activity — a text-only console placeholder.
+ * Phase 1d Activity (INFR-111). The Phase 1c scaffold deferred
+ * `emu_run()` invocation behind an opt-in button because the call
+ * SIGKILLed the process. Phase 1d makes the button actually work:
  *
- * The shape of the UI here is intentionally minimal: this is the
- * "prove the build path end-to-end" milestone, not the design
- * milestone. Once everything links, a Compose-based real UI replaces
- * the TextView.
+ *   1. jni-emu.c spawns a detached pthread for emu_run, so the
+ *      JVM-attached JNI thread returns immediately and emu's
+ *      eventual pthread_exit lands on a thread the JVM doesn't track.
  *
- * Lifecycle:
- *   onCreate -> extract /dis/ assets to filesDir/inferno-root/
- *             -> request RECORD_AUDIO
- *             -> wait for user tap on the "boot" button before
- *                spawning emu-boot (see DEFERRED_EMU_BOOT below)
+ *   2. The argv below includes `-s` ("no trap handling") which tells
+ *      emu to skip installing SIGILL/SIGFPE/SIGBUS/SIGSEGV handlers.
+ *      Without this flag emu overwrites the JVM's signal handlers in
+ *      libinit, and the first JVM-internal SIGSEGV (used for null-
+ *      pointer-exception, GC barriers, etc.) routes to emu's
+ *      trapmemref, which panics from a non-Inferno-Proc context and
+ *      kills the process. -s is the correct Phase 1d flag; the
+ *      Phase 2+ work is a proper chained-handler scheme so emu can
+ *      catch Limbo runtime traps on Android without clobbering the
+ *      JVM.
  *
- * DEFERRED_EMU_BOOT — Phase 1c milestone is "the build path works":
- * APK assembled, libemu.so loaded, JNI entry callable. The actual
- * emu_run integration is Phase 1d, because emu's threading model
- * (libinit -> kproc(emuinit) -> for(;;) ospause(); ospause() does
- * pthread_exit(0)) tears down the calling thread. On Android that
- * thread is a JVM-managed JNI thread; pthread_exit on it is UB and
- * the zygote reaps the process with SIGKILL within ~20ms. Fix
- * requires either a fork()-and-exec-from-asset-dir scheme or a
- * proper Posix main-loop-on-detached-pthread refactor in emu/port.
- * The button below makes the crash opt-in so the build artefact
- * survives the smoke test until that work lands. See INFR-NEW
- * (Phase 1d emu_run/JNI lifecycle).
+ *   3. stdio (fd1/fd2) is captured in JNI_OnLoad and routed to
+ *      logcat under the "InferNode" tag so emu's print() output
+ *      surfaces in the device log instead of /dev/null.
+ *
+ * The Activity itself is unchanged in shape — single console TextView
+ * and a boot button. Replacing it with a Compose chat UI is Phase 2.
  */
 class InfernodeActivity : Activity() {
 
@@ -54,13 +54,13 @@ class InfernodeActivity : Activity() {
             orientation = LinearLayout.VERTICAL
         }
         consoleView = TextView(this).apply {
-            text = "InferNode APK v0.1.0-phase1c\n" +
-                "libemu.so loaded.\n" +
-                "Tap to attempt emu_run() — known to SIGKILL the process " +
-                "until the Phase 1d threading refactor lands.\n"
+            text = "InferNode APK v0.1.0-phase1d\n" +
+                "libemu.so loaded; tap below to boot Inferno. " +
+                "emu output appears in logcat under tag \"InferNode\" " +
+                "(adb logcat -s InferNode:*).\n"
         }
         bootButton = Button(this).apply {
-            text = "Boot Inferno (Phase 1d preview)"
+            text = "Boot Inferno"
             setOnClickListener {
                 isEnabled = false
                 post("Booting...\n")
@@ -89,10 +89,27 @@ class InfernodeActivity : Activity() {
         val infernoRoot = File(filesDir, "inferno-root").apply { mkdirs() }
         extractAssetsIfNeeded(infernoRoot)
         post("Inferno root: ${infernoRoot.absolutePath}\n")
+
+        // -s: skip emu's trap-handler installation. Required on Android
+        // so libinit doesn't overwrite the JVM's SIGSEGV/SIGBUS/SIGILL/
+        // SIGFPE handlers. See INFR-111 / class doc for the rationale.
+        //
+        // -c1: JIT compile (the A55 is arm64 and the ARM64 JIT works).
+        // -r:  set Inferno root to filesDir/inferno-root, where
+        //      extractAssetsIfNeeded unpacked the dis/ + lib/ + module/
+        //      trees from the APK assets.
+        // /dis/sh.dis: boot the Inferno shell. It will EOF on stdin
+        //      almost immediately (Android JNI stdin is /dev/null) and
+        //      idle in the kproc loop — the process stays alive but no
+        //      further commands run until a real stdin pipe is wired
+        //      up (Phase 2 work).
         val exit = Emu.run(
-            arrayOf("-c1", "-r", infernoRoot.absolutePath, "/dis/sh.dis")
+            arrayOf("-s", "-c1", "-r", infernoRoot.absolutePath, "/dis/sh.dis")
         )
-        post("emu exited with status $exit\n")
+        // emu_run returns immediately in Phase 1d (the JNI bridge
+        // spawns a detached pthread). A non-zero return here means the
+        // bridge refused to launch, not that emu itself exited.
+        post("emu launched (jni rc=$exit)\nWatch logcat for boot output.\n")
     }
 
     /**

--- a/emu/Android/mkfile-g
+++ b/emu/Android/mkfile-g
@@ -46,10 +46,16 @@ CFLAGS=\
 KERNDATE=`{$NDATE}
 
 # Headless build — no X11, no SDL3. AAudio backend (audio-aaudio.c)
-# replaces the Phase 0 no-op stub.
+# replaces the Phase 0 no-op stub. -llog is the Android system log
+# library, used by jni-emu.c (Phase 1d, INFR-111) to surface emu's
+# stdio output to logcat. liblog.so is always present on every
+# Android device, so the dep is free; o.emu links against it too but
+# doesn't call it — at most a few unresolved-relocation table bytes
+# in the standalone executable.
 SYSLIBS=\
 	-lm\
 	-laaudio\
+	-llog\
 
 # Note: no -lpthread on Android. Bionic merges pthread into libc.
 

--- a/emu/Android/os.c
+++ b/emu/Android/os.c
@@ -3,6 +3,7 @@
 #include	<termios.h>
 #include	<signal.h>
 #include 	<pwd.h>
+#include	<pthread.h>  /* cleanexit calls pthread_exit on Android (INFR-111) */
 #include	<sched.h>
 #include	<sys/resource.h>
 #include	<sys/wait.h>
@@ -135,7 +136,10 @@ cleanexit(int x)
 {
 	USED(x);
 
-	if(up->intwait) {
+	/* up can be nil if cleanexit is called from a signal handler
+	 * before any kproc has been bound to a thread. The original
+	 * code dereferenced it unconditionally. */
+	if(up != nil && up->intwait) {
 		up->intwait = 0;
 		return;
 	}
@@ -143,8 +147,22 @@ cleanexit(int x)
 	if(dflag == 0)
 		termrestore();
 
+	/* On the standalone o.emu binary, kill(0, SIGKILL) followed by
+	 * exit(0) is the documented Plan 9 "everyone in this process
+	 * group goes away now" gesture — it tears down all the kproc
+	 * pthreads at once. Inside an APK, libemu.so shares its process
+	 * (and process group) with the Activity's JVM; kill(0, SIGKILL)
+	 * takes the whole Activity down, which is exactly the SIGKILL
+	 * we saw in INFR-111 when the shell EOFed on stdin and routed
+	 * here via Limbo exits(). On Android, just let this thread die;
+	 * the other emu kprocs (and the JVM) keep running. emuinit() is
+	 * already sitting in `for(;;) ospause();` and will continue. */
+#ifdef ANDROID_ARM64
+	pthread_exit(0);
+#else
 	kill(0, SIGKILL);
 	exit(0);
+#endif
 }
 
 void


### PR DESCRIPTION
## Summary

Phase 1d fixes the SIGKILL that took down the Phase 1c APK the moment `emu_run()` was invoked. Three stacked bugs, one fix each. After this PR, tapping **Boot Inferno** on the APK actually boots Inferno — the process stays alive, the shell starts, and emu's print output streams to logcat.

## The three bugs

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | Process SIGKILLed ~22 ms after `libemu.so` load, no AndroidRuntime FATAL, no tombstone | `emu_run` ran on the JVM-attached JNI thread; emu's `for(;;) ospause();` does `pthread_exit(0)` and the JVM aborts when a thread it owns disappears | Spawn a detached pthread for `emu_run` in `jni-emu.c`; the JNI bridge returns to Java immediately |
| 2 | After fix #1: emu boots far enough to print `fs: fsqid: top-bit dev: 0xfe4f` and the shell prompt `;` then dies | `libinit()` installs SIGSEGV/SIGBUS/SIGILL/SIGFPE handlers, overwriting the JVM's; first JVM-internal SIGSEGV (NPE, GC barriers, etc.) routes to emu's `trapmemref` and panics from a non-Inferno-Proc context | Pass `-s` in the argv (emu's built-in "no trap handling" escape hatch) |
| 3 | After fix #2: clean boot then immediate death when shell EOFs on stdin | `cleanexit()` in `emu/Android/os.c` does `kill(0, SIGKILL); exit(0);` — `kill(0, …)` is *process-group*, which on Android is the entire APK | Gate the `kill(0)` behind `#ifndef ANDROID_ARM64`; on Android, just `pthread_exit` the calling thread |

## Also wired

- `JNI_OnLoad` redirects fd1/fd2 to a pipe → reader pthread → `__android_log_write` under tag `"InferNode"`. emu's `print()` reaches logcat instead of `/dev/null`. Visible via `adb logcat -s InferNode:*`.
- `emu/Android/mkfile-g` links against `-llog`.
- Latent nil-deref in `cleanexit` (which deref'd `up` unconditionally even when called from a signal handler before any kproc existed) fixed in passing.

## Validation (Galaxy A55, RZCXB1PPNFP, Android 15, 2026-05-19)

```
adb logcat -s InferNode:*
InferNode: libemu.so JNI_OnLoad — stdio routed to logcat
InferNode: emu_run starting (argc=6)
InferNode: fs: fsqid: top-bit dev: 0xfe4f
InferNode: ;
```

Process status 20s after boot tap: `S` (sleeping). No SIGKILL. Screenshot in chat history.

## Phase 2 follow-up (not this PR)

- Wire a real stdin pipe so the shell doesn't EOF immediately
- Surface stdout/stderr to the Activity (not just logcat)
- Compose chat UI replaces the placeholder TextView
- Service-based 9P bridge between UI and emu kernel

## Test plan
- [ ] All pre-existing CI checks pass
- [ ] APK assemble in CI succeeds (`infernode-debug-apk` artefact uploaded)

Refs: INFR-111

🤖 Generated with [Claude Code](https://claude.com/claude-code)