### PR TITLE
feat(android): Phase 2a — interactive Inferno shell inside the APK

### DIFF
--- a/android-app/app/src/main/cpp/jni-emu.c
+++ b/android-app/app/src/main/cpp/jni-emu.c
@@ -2,32 +2,23 @@
  * jni-emu.c — JNI bridge between Java (io.infernode.Emu) and the
  * InferNode emulator entry point.
  *
- * Phase 1d (INFR-111) refactor. Previously this file just marshalled
- * argv and called emu_run(...) on the JVM-attached JNI thread. That
- * crashed the process within ~22 ms of libemu.so loading, because
- * emu's headless boot path ends in `for(;;) ospause();` and
- * ospause() does pthread_exit(0). pthread_exit on a JNI-attached
- * thread is undefined; the zygote saw the thread vanish and SIGKILLed
- * the process.
+ * Phase 2a (INFR-NNN): real interactive shell.
+ *   - capture_stdio replaces the previous capture_stdio: it now wires
+ *     fd 0, 1, and 2. fd 0 is the read end of a stdin pipe owned by
+ *     this C side; Java writes to it via writeStdin(). fd 1/2 are
+ *     dup2'd to a stdout pipe whose read end is consumed by a reader
+ *     thread that fans output to logcat AND a Java OutputListener.
+ *   - The reader thread attaches to the JVM so it can call back into
+ *     Kotlin. AttachCurrentThread is required because the thread
+ *     wasn't created by the JVM.
  *
- * Two changes fix it:
+ * Phase 1d (INFR-111) earlier landed:
+ *   - Detached pthread for emu_run so JVM-attached thread can return.
+ *   - Stdio capture to logcat under tag "InferNode".
+ *   - Atomic guard against multiple Emu.run calls per process.
  *
- * 1. emu_run runs on its own detached pthread, not on the JVM caller.
- *    The JVM caller returns to Java immediately. emu's eventual
- *    pthread_exit lands on a thread the JVM doesn't know about, so
- *    the runtime never sees a stray death and the process keeps
- *    running indefinitely.
- *
- * 2. stdio (fd 1 and fd 2) is redirected to a pipe at JNI_OnLoad,
- *    and a reader thread pushes lines to __android_log_write so
- *    emu's print()/fprint() output shows up in logcat under the
- *    "InferNode" tag. Without this, every diagnostic emu emits goes
- *    to /dev/null and the boot is invisible.
- *
- * Single-instance constraint: emu's globals (rootdir, eve, libinit
- * state, etc.) are process-scoped. A static guard ensures emu_run is
- * spawned at most once per process — repeat clicks on the boot
- * button are no-ops.
+ * Single-instance constraint: emu's globals are process-scoped. A
+ * second Emu.run is rejected.
  */
 
 #include <jni.h>
@@ -38,80 +29,136 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include <errno.h>
 
 #define TAG "InferNode"
 
 extern int emu_run(int argc, char **argv);
 
 /*
- * Stdio capture: pipe fd1/fd2 into a reader that flushes line-by-line
- * to logcat. setvbuf on stdout/stderr to line-buffered so prints
- * surface promptly even before any newline.
- *
- * Buffer size 1024 matches emu's internal print buffer in
- * emu/port/main.c iprint(). Long lines get split across reads, which
- * logcat shows as separate entries — acceptable for a debug surface.
+ * JNI globals captured at load time / when a listener registers.
+ * Access to g_listener / g_onLine_mid is guarded by g_listener_lock
+ * because the stdio reader pthread and Java callers both touch them.
  */
+static JavaVM *g_vm;
+static jobject g_listener;          /* global ref */
+static jmethodID g_onLine_mid;
+static pthread_mutex_t g_listener_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * Write end of the stdin pipe — fd 0 is the read end (dup2'd at
+ * capture time). Java's writeStdin writes here; emu's readkbd kproc
+ * reads from fd 0 and pushes to kbdq.
+ */
+static int g_stdin_write_fd = -1;
+
+/*
+ * Reader thread for the stdout/stderr pipe. Splits on '\n' so each
+ * line becomes one logcat entry / one OutputListener call. emu's
+ * print() output reaches both surfaces.
+ */
+static void
+deliver_line(JNIEnv *env, const char *line)
+{
+	if (line[0] != '\0')
+		__android_log_write(ANDROID_LOG_INFO, TAG, line);
+
+	pthread_mutex_lock(&g_listener_lock);
+	jobject listener = g_listener;
+	jmethodID mid = g_onLine_mid;
+	pthread_mutex_unlock(&g_listener_lock);
+
+	if (env != NULL && listener != NULL && mid != NULL) {
+		jstring jline = (*env)->NewStringUTF(env, line);
+		if (jline != NULL) {
+			(*env)->CallVoidMethod(env, listener, mid, jline);
+			(*env)->DeleteLocalRef(env, jline);
+		}
+		if ((*env)->ExceptionCheck(env))
+			(*env)->ExceptionClear(env);
+	}
+}
+
 static void *
 stdio_reader(void *arg)
 {
 	int fd = (int)(intptr_t)arg;
 	char buf[1024];
-	ssize_t n, lineLen;
-	char *p, *eol;
+	ssize_t n;
+	JNIEnv *env = NULL;
 
 	pthread_setname_np(pthread_self(), "emu-stdio");
 
+	/* Attach this pthread to the JVM so we can call into Kotlin. */
+	if (g_vm != NULL &&
+	    (*g_vm)->AttachCurrentThread(g_vm, &env, NULL) != JNI_OK) {
+		env = NULL;
+		__android_log_write(ANDROID_LOG_WARN, TAG,
+			"stdio reader: AttachCurrentThread failed; "
+			"output will reach logcat only, not the Activity");
+	}
+
 	while ((n = read(fd, buf, sizeof(buf) - 1)) > 0) {
 		buf[n] = '\0';
-		/* Split on newlines so each log entry is one line. */
-		p = buf;
+		char *p = buf;
 		while (*p != '\0') {
-			eol = strchr(p, '\n');
-			if (eol != NULL) {
+			char *eol = strchr(p, '\n');
+			if (eol != NULL)
 				*eol = '\0';
-				lineLen = eol - p;
-			} else {
-				lineLen = (ssize_t)strlen(p);
-			}
-			if (lineLen > 0)
-				__android_log_write(ANDROID_LOG_INFO, TAG, p);
+			deliver_line(env, p);
 			if (eol == NULL)
 				break;
 			p = eol + 1;
 		}
 	}
+
+	if (env != NULL && g_vm != NULL)
+		(*g_vm)->DetachCurrentThread(g_vm);
 	return NULL;
 }
 
 static void
 capture_stdio(void)
 {
-	int p[2];
+	int sp[2], op[2];
 	pthread_t reader;
 
-	if (pipe(p) != 0) {
+	/*
+	 * Stdin: read end goes to fd 0; emu's readkbd will read from
+	 * here. Java owns the write end via g_stdin_write_fd.
+	 */
+	if (pipe(sp) != 0) {
 		__android_log_write(ANDROID_LOG_WARN, TAG,
-			"stdio pipe() failed; emu output will not reach logcat");
+			"stdin pipe() failed; emu shell will read /dev/null");
+	} else {
+		dup2(sp[0], STDIN_FILENO);
+		close(sp[0]);
+		g_stdin_write_fd = sp[1];
+	}
+
+	/*
+	 * Stdout + stderr: both dup2'd to the same pipe write end so
+	 * one reader thread sees all emu output in order.
+	 */
+	if (pipe(op) != 0) {
+		__android_log_write(ANDROID_LOG_WARN, TAG,
+			"stdout pipe() failed; emu output discarded");
 		return;
 	}
-	dup2(p[1], STDOUT_FILENO);
-	dup2(p[1], STDERR_FILENO);
-	close(p[1]);
+	dup2(op[1], STDOUT_FILENO);
+	dup2(op[1], STDERR_FILENO);
+	close(op[1]);
 
 	setvbuf(stdout, NULL, _IOLBF, 0);
 	setvbuf(stderr, NULL, _IOLBF, 0);
 
 	if (pthread_create(&reader, NULL, stdio_reader,
-	    (void *)(intptr_t)p[0]) == 0)
+	    (void *)(intptr_t)op[0]) == 0)
 		pthread_detach(reader);
 }
 
-/*
- * Worker thread that owns emu's lifetime. Takes ownership of the
- * heap-allocated argv built by Java_io_infernode_Emu_run; frees it
- * after emu_run returns (which in headless mode means: never).
- */
+/* ─── emu lifecycle ──────────────────────────────────────────── */
+
 struct emu_args {
 	int argc;
 	char **argv;
@@ -127,15 +174,12 @@ emu_thread(void *arg)
 	__android_log_print(ANDROID_LOG_INFO, TAG,
 		"emu_run starting (argc=%d)", a->argc);
 
-	/* In headless mode emu_run never returns — emuinit() does
-	 * for(;;) ospause() and ospause() pthread_exit()s this very
-	 * thread. The free() below only runs if the build path ever
-	 * grows a clean shutdown. */
 	int rc = emu_run(a->argc, a->argv);
 
+	/* Headless emu_run is not supposed to return; if it does, free
+	 * the heap argv we own and report the surprise. */
 	__android_log_print(ANDROID_LOG_INFO, TAG,
 		"emu_run returned %d (unexpected for headless)", rc);
-
 	for (i = 0; i < a->argc; i++)
 		free(a->argv[i]);
 	free(a->argv);
@@ -143,12 +187,6 @@ emu_thread(void *arg)
 	return NULL;
 }
 
-/*
- * Guard against multiple Emu.run calls. emu can only boot once per
- * process; a second call would race on globals and almost certainly
- * crash. Using an atomic flag rather than pthread_once because we
- * want to *report* re-entry via a logcat line, not silently swallow it.
- */
 static atomic_int emu_launched = ATOMIC_VAR_INIT(0);
 
 JNIEXPORT jint JNICALL
@@ -168,8 +206,6 @@ Java_io_infernode_Emu_run(JNIEnv *env, jobject thiz, jobjectArray jargv)
 	struct emu_args *a = (struct emu_args *)calloc(1, sizeof(*a));
 	if (a == NULL)
 		return -1;
-
-	/* argv layout: [0] = "emu", [1..n] = caller args, [n+1] = NULL. */
 	a->argv = (char **)calloc((size_t)n + 2, sizeof(char *));
 	if (a->argv == NULL) {
 		free(a);
@@ -201,19 +237,79 @@ Java_io_infernode_Emu_run(JNIEnv *env, jobject thiz, jobjectArray jargv)
 	return 0;
 }
 
+/* ─── stdin write ────────────────────────────────────────────── */
+
 /*
- * JNI_OnLoad runs once when System.loadLibrary("emu") completes.
- * Wire up stdio capture here so even emu's earliest startup prints
- * (before emu_thread takes off) reach logcat — useful when the
- * crash is in argument parsing or the env scan.
+ * Write the given bytes to emu's stdin pipe. Returns the number of
+ * bytes written (>= 0) or -1 on error. Java is expected to append
+ * '\n' itself for line-oriented input.
  */
+JNIEXPORT jint JNICALL
+Java_io_infernode_Emu_writeStdin(JNIEnv *env, jclass cls, jstring jdata)
+{
+	(void)cls;
+
+	if (g_stdin_write_fd < 0)
+		return -1;
+
+	const char *data = (*env)->GetStringUTFChars(env, jdata, NULL);
+	if (data == NULL)
+		return -1;
+	jsize len = (*env)->GetStringUTFLength(env, jdata);
+
+	ssize_t total = 0;
+	while (total < len) {
+		ssize_t w = write(g_stdin_write_fd, data + total, len - total);
+		if (w < 0) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		total += w;
+	}
+
+	(*env)->ReleaseStringUTFChars(env, jdata, data);
+	return (jint)total;
+}
+
+/* ─── output listener ────────────────────────────────────────── */
+
+JNIEXPORT void JNICALL
+Java_io_infernode_Emu_setOutputListener(JNIEnv *env, jclass cls, jobject listener)
+{
+	(void)cls;
+
+	pthread_mutex_lock(&g_listener_lock);
+
+	if (g_listener != NULL) {
+		(*env)->DeleteGlobalRef(env, g_listener);
+		g_listener = NULL;
+	}
+	g_onLine_mid = NULL;
+
+	if (listener != NULL) {
+		g_listener = (*env)->NewGlobalRef(env, listener);
+		if (g_listener != NULL) {
+			jclass lcls = (*env)->GetObjectClass(env, g_listener);
+			g_onLine_mid = (*env)->GetMethodID(env, lcls,
+				"onLine", "(Ljava/lang/String;)V");
+			if ((*env)->ExceptionCheck(env))
+				(*env)->ExceptionClear(env);
+		}
+	}
+
+	pthread_mutex_unlock(&g_listener_lock);
+}
+
+/* ─── load entry ─────────────────────────────────────────────── */
+
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
-	(void)vm;
 	(void)reserved;
+	g_vm = vm;
 	capture_stdio();
 	__android_log_write(ANDROID_LOG_INFO, TAG,
-		"libemu.so JNI_OnLoad — stdio routed to logcat");
+		"libemu.so JNI_OnLoad — stdin/stdout routed");
 	return JNI_VERSION_1_6;
 }

--- a/android-app/app/src/main/java/io/infernode/Emu.kt
+++ b/android-app/app/src/main/java/io/infernode/Emu.kt
@@ -3,25 +3,30 @@ package io.infernode
 /**
  * JNI bridge to the InferNode emulator (libemu.so).
  *
- * The C side lives in android-app/app/src/main/cpp/jni-emu.c and is
- * itself a thin wrapper over emu's `emu_run()` entry — the same path
- * used by the existing `main()` for the `adb shell /data/local/tmp/o.emu`
- * use case. JNI does no work other than translating argv between
- * Java and C.
+ * The C side lives in android-app/app/src/main/cpp/jni-emu.c.
  *
- * The library name `emu` resolves to `libemu.so`, which is produced by
- * `build-android-apk.sh` (a Phase 1c follow-up driver) from the same
- * Inferno mkfile chain that produces the standalone o.emu binary in
- * Phase 1a/1b.
+ * Threading: `run` is fire-and-forget. The native side spawns its
+ * own pthread for emu and returns to Java immediately. `writeStdin`
+ * is safe to call from any thread; the C side writes are atomic for
+ * pipe-buffer-sized writes (PIPE_BUF, typically 4 KiB).
  *
- * Threading: `run` blocks for the lifetime of the emulator. Call it
- * from a dedicated background thread (typically inside a
- * [InfernodeService]); the caller is responsible for not invoking it
- * twice in the same process — the emulator was historically not
- * designed for multiple instantiations and refactoring that out is
- * tracked separately.
+ * Single-instance: emu can only boot once per process. A second
+ * `run` returns -1.
  */
 object Emu {
+
+    /**
+     * Output sink for emu's stdout/stderr. The native reader thread
+     * calls [onLine] once per newline-terminated chunk it sees. Use
+     * [setOutputListener] to register / clear.
+     *
+     * Implementations should be cheap and non-blocking — they run on
+     * a JNI-attached pthread, not the Android UI thread. Marshal to
+     * the UI via `Activity.runOnUiThread` or a `Handler`.
+     */
+    interface OutputListener {
+        fun onLine(line: String)
+    }
 
     init {
         System.loadLibrary("emu")
@@ -30,14 +35,24 @@ object Emu {
     /**
      * Boot the emulator with the given argv. Mirrors `main(int argc, char **argv)`.
      *
-     * Typical args:
-     *   ["-c1", "-r", root, "/dis/sh.dis"]            # interactive shell
-     *   ["-c1", "-r", root, "/dis/sh.dis", "/serve9p.b"]  # 9P daemon
-     *
-     * @param argv the argument vector, *without* the leading program name
-     *             (the C side prepends "emu" itself).
-     * @return the emulator's exit code.
+     * Returns 0 on successful launch (emu is now running on its own
+     * pthread), -1 if a previous Emu.run already claimed the slot.
      */
     @JvmStatic
     external fun run(argv: Array<String>): Int
+
+    /**
+     * Write bytes to emu's stdin. Caller appends `\n` for line input.
+     * Returns the number of bytes written, or -1 on error.
+     */
+    @JvmStatic
+    external fun writeStdin(data: String): Int
+
+    /**
+     * Register an output sink. Pass `null` to clear. The native side
+     * holds a JNI global ref to the listener; the previous listener
+     * is released. Only one listener at a time.
+     */
+    @JvmStatic
+    external fun setOutputListener(listener: OutputListener?)
 }

--- a/android-app/app/src/main/java/io/infernode/InfernodeActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeActivity.kt
@@ -5,9 +5,13 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.content.res.AssetManager
 import android.os.Bundle
-import android.util.Log
+import android.text.method.ScrollingMovementMethod
+import android.view.Gravity
+import android.view.ViewGroup
 import android.widget.Button
+import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -16,67 +20,145 @@ import java.io.FileOutputStream
 import kotlin.concurrent.thread
 
 /**
- * Phase 1d Activity (INFR-111). The Phase 1c scaffold deferred
- * `emu_run()` invocation behind an opt-in button because the call
- * SIGKILLed the process. Phase 1d makes the button actually work:
+ * Phase 2a Activity — interactive Inferno shell inside the APK.
  *
- *   1. jni-emu.c spawns a detached pthread for emu_run, so the
- *      JVM-attached JNI thread returns immediately and emu's
- *      eventual pthread_exit lands on a thread the JVM doesn't track.
+ * Previous phases (1c branding, 1d threading) proved emu boots inside
+ * libemu.so without taking the JVM down with it. This phase wires the
+ * I/O the other direction: a stdin pipe so the user can type commands,
+ * and an output listener so emu's stdout shows up in the Activity
+ * (not just `adb logcat`).
  *
- *   2. The argv below includes `-s` ("no trap handling") which tells
- *      emu to skip installing SIGILL/SIGFPE/SIGBUS/SIGSEGV handlers.
- *      Without this flag emu overwrites the JVM's signal handlers in
- *      libinit, and the first JVM-internal SIGSEGV (used for null-
- *      pointer-exception, GC barriers, etc.) routes to emu's
- *      trapmemref, which panics from a non-Inferno-Proc context and
- *      kills the process. -s is the correct Phase 1d flag; the
- *      Phase 2+ work is a proper chained-handler scheme so emu can
- *      catch Limbo runtime traps on Android without clobbering the
- *      JVM.
+ * Layout (top-to-bottom): scrolling output view, input row (EditText
+ * + Send button). The whole thing is a plain View hierarchy — Compose
+ * is Phase 2b. Keeping it minimal here so the integration concern
+ * (does the pipe wiring actually work end-to-end?) is testable
+ * independently of UI choice.
  *
- *   3. stdio (fd1/fd2) is captured in JNI_OnLoad and routed to
- *      logcat under the "InferNode" tag so emu's print() output
- *      surfaces in the device log instead of /dev/null.
- *
- * The Activity itself is unchanged in shape — single console TextView
- * and a boot button. Replacing it with a Compose chat UI is Phase 2.
+ * Boot is automatic on onCreate. The Phase 1c/1d boot button is
+ * gone — emu_run is safe now.
  */
-class InfernodeActivity : Activity() {
+class InfernodeActivity : Activity(), Emu.OutputListener {
 
-    private lateinit var consoleView: TextView
-    private lateinit var bootButton: Button
+    private lateinit var outputView: TextView
+    private lateinit var outputScroll: ScrollView
+    private lateinit var inputView: EditText
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(buildLayout())
+        ensureRecordAudioPermission()
 
-        val layout = LinearLayout(this).apply {
+        Emu.setOutputListener(this)
+        thread(name = "emu-boot") { bootInferno() }
+    }
+
+    override fun onDestroy() {
+        // Release the native global ref. emu itself keeps running in
+        // the background — the process stays alive even after the
+        // Activity goes away — but without a listener the output
+        // just goes to logcat until the Activity comes back.
+        Emu.setOutputListener(null)
+        super.onDestroy()
+    }
+
+    /**
+     * OutputListener.onLine runs on a JNI-attached pthread, not the
+     * UI thread. Marshal to the UI thread before touching views.
+     */
+    override fun onLine(line: String) {
+        runOnUiThread {
+            outputView.append(line)
+            outputView.append("\n")
+            outputScroll.post { outputScroll.fullScroll(ScrollView.FOCUS_DOWN) }
+        }
+    }
+
+    private fun buildLayout(): LinearLayout {
+        val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
+            setPadding(16, 16, 16, 16)
         }
-        consoleView = TextView(this).apply {
-            text = "InferNode APK v0.1.0-phase1d\n" +
-                "libemu.so loaded; tap below to boot Inferno. " +
-                "emu output appears in logcat under tag \"InferNode\" " +
-                "(adb logcat -s InferNode:*).\n"
+
+        outputView = TextView(this).apply {
+            text = "InferNode v0.1.0-phase2a\nBooting Inferno...\n"
+            typeface = android.graphics.Typeface.MONOSPACE
+            textSize = 13f
+            setTextIsSelectable(true)
+            movementMethod = ScrollingMovementMethod()
         }
-        bootButton = Button(this).apply {
-            text = "Boot Inferno"
-            setOnClickListener {
-                isEnabled = false
-                post("Booting...\n")
-                thread(name = "emu-boot") { bootInferno() }
+
+        outputScroll = ScrollView(this).apply {
+            addView(
+                outputView,
+                LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+            )
+        }
+        root.addView(
+            outputScroll,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                /* weight = */ 1f
+            )
+        )
+
+        val inputRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        inputView = EditText(this).apply {
+            hint = "type a command, e.g. ls /dis"
+            typeface = android.graphics.Typeface.MONOSPACE
+            isSingleLine = true
+            setOnEditorActionListener { _, _, _ ->
+                sendCurrentInput()
+                true
             }
         }
-        layout.addView(consoleView)
-        layout.addView(bootButton)
-        setContentView(layout)
+        val sendButton = Button(this).apply {
+            text = "Send"
+            setOnClickListener { sendCurrentInput() }
+        }
+        inputRow.addView(
+            inputView,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        )
+        inputRow.addView(
+            sendButton,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+        root.addView(
+            inputRow,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
 
-        ensureRecordAudioPermission()
+        return root
+    }
+
+    private fun sendCurrentInput() {
+        val line = inputView.text.toString()
+        // Echo locally so the user sees what they typed (the Inferno
+        // shell on the other side of the pipe will reflect this back
+        // too if cons echo is on, but echoing here makes the UI feel
+        // responsive regardless of cons mode).
+        outputView.append("> $line\n")
+        Emu.writeStdin("$line\n")
+        inputView.text.clear()
     }
 
     private fun ensureRecordAudioPermission() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
-            != PackageManager.PERMISSION_GRANTED) {
+            != PackageManager.PERMISSION_GRANTED
+        ) {
             ActivityCompat.requestPermissions(
                 this,
                 arrayOf(Manifest.permission.RECORD_AUDIO),
@@ -88,41 +170,28 @@ class InfernodeActivity : Activity() {
     private fun bootInferno() {
         val infernoRoot = File(filesDir, "inferno-root").apply { mkdirs() }
         extractAssetsIfNeeded(infernoRoot)
-        post("Inferno root: ${infernoRoot.absolutePath}\n")
 
-        // -s: skip emu's trap-handler installation. Required on Android
-        // so libinit doesn't overwrite the JVM's SIGSEGV/SIGBUS/SIGILL/
-        // SIGFPE handlers. See INFR-111 / class doc for the rationale.
-        //
-        // -c1: JIT compile (the A55 is arm64 and the ARM64 JIT works).
-        // -r:  set Inferno root to filesDir/inferno-root, where
-        //      extractAssetsIfNeeded unpacked the dis/ + lib/ + module/
-        //      trees from the APK assets.
-        // /dis/sh.dis: boot the Inferno shell. It will EOF on stdin
-        //      almost immediately (Android JNI stdin is /dev/null) and
-        //      idle in the kproc loop — the process stays alive but no
-        //      further commands run until a real stdin pipe is wired
-        //      up (Phase 2 work).
-        val exit = Emu.run(
+        // -s: skip emu trap-handler installs — they'd clobber the
+        //     JVM's signal handlers and crash the process (INFR-111).
+        // -c1: arm64 JIT.
+        // -r: Inferno root = extracted asset tree under filesDir.
+        // /dis/sh.dis: boot the Inferno shell. Now that stdin is a
+        //     real pipe (Phase 2a), the shell stays alive waiting
+        //     for input instead of EOFing.
+        val rc = Emu.run(
             arrayOf("-s", "-c1", "-r", infernoRoot.absolutePath, "/dis/sh.dis")
         )
-        // emu_run returns immediately in Phase 1d (the JNI bridge
-        // spawns a detached pthread). A non-zero return here means the
-        // bridge refused to launch, not that emu itself exited.
-        post("emu launched (jni rc=$exit)\nWatch logcat for boot output.\n")
+        if (rc != 0) {
+            runOnUiThread {
+                outputView.append("Emu.run failed (rc=$rc)\n")
+            }
+        }
     }
 
     /**
-     * Extract the Inferno runtime tree shipped as APK assets (`dis/`,
-     * `lib/`, `module/` under `assets/inferno-root/`) on first launch.
-     * Idempotent: skipped if the version marker file is present, so
-     * repeat starts are cheap.
-     *
-     * The version suffix on the marker (`.extracted-v1`) lets a future
-     * APK release force a re-extract just by bumping the suffix when
-     * the runtime tree changes. Bytecode is recompiled into the APK
-     * with each release; users who upgrade get the new runtime
-     * automatically.
+     * Extract /dis/, /lib/, /module/ from APK assets to filesDir on
+     * first launch. Idempotent: skipped if the version marker is
+     * present.
      */
     private fun extractAssetsIfNeeded(root: File) {
         val marker = File(root, ".extracted-v1")
@@ -131,36 +200,19 @@ class InfernodeActivity : Activity() {
         marker.createNewFile()
     }
 
-    /**
-     * Recursively copy `src` (an asset path, relative to the APK's
-     * assets/ root) into `dst` (a host directory). Preserves the
-     * directory tree; files become regular files under `dst`.
-     *
-     * `AssetManager.list(path)` returns an empty array for files, which
-     * is how we distinguish file-vs-dir nodes — there is no `isFile`
-     * predicate on the asset namespace.
-     */
     private fun copyAssetTree(am: AssetManager, src: String, dst: File) {
         val children = am.list(src) ?: emptyArray()
         if (children.isEmpty()) {
-            // Leaf: copy as a regular file.
             dst.parentFile?.mkdirs()
             am.open(src).use { input ->
                 FileOutputStream(dst).use { output -> input.copyTo(output) }
             }
             return
         }
-        // Directory: recurse into each child.
         dst.mkdirs()
         for (child in children) {
             val childSrc = if (src.isEmpty()) child else "$src/$child"
             copyAssetTree(am, childSrc, File(dst, child))
         }
-    }
-
-    private fun logTag(): String = "InferNode"
-
-    private fun post(text: String) {
-        runOnUiThread { consoleView.append(text) }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1d proved emu can boot inside `libemu.so` without crashing the JVM. **Phase 2a wires the I/O so the shell is actually usable from the Activity.**

Before this PR, emu booted to the `;` prompt and immediately EOFed on stdin (Android JNI fd 0 is `/dev/null`); without Phase 1d's pthread_exit fix this would have killed the process, and even with it the shell was inert. Now:

- **stdin** is a pipe; Java writes to it via `Emu.writeStdin(String)`.
- **stdout/stderr** are captured by a reader pthread that fans output to both logcat AND a registered `OutputListener` on the Java side.
- **Activity** is `OutputListener` itself and appends each line to a scrolling monospace TextView. EditText + Send button at the bottom; both the button and the soft-keyboard Enter action call `sendCurrentInput()`.
- Boot is **automatic** on `onCreate` — the Phase 1c/1d boot button is gone.

## Architecture

```
EditText ──>  Emu.writeStdin   ─JNI─>  write(g_stdin_write_fd, …)
                                         │
                                       pipe
                                         │
                                       fd 0  ─>  readkbd  ─>  kbdq  ─>  /dev/cons  ─>  sh.dis

sh.dis  ─>  fd 1/2  ─>  pipe  ─>  stdio_reader pthread  ─┬─>  __android_log_write
                                                          └─>  Emu.OutputListener.onLine  ─>  TextView
```

The reader pthread `AttachCurrentThread`s to the JVM so the callback path resolves. A pthread_mutex guards the listener global ref against the race with `setOutputListener`.

## Verified on Galaxy A55 (2026-05-19)

A transient self-test wrote `echo hello\n` to stdin 4 s after boot. Logcat:

```
InferNode: ;
InferNode: echo hello   <- shell echoed the input
InferNode: hello        <- shell ran echo, printed "hello"
InferNode: ;
```

UI screenshot in chat history shows the round-trip rendered in the Activity. Process stayed alive throughout (no SIGKILL, no FATAL).

The self-test was removed before commit. Real soft-keyboard typing works as expected.

## What's NOT in this PR
- Compose UI (Phase 2b)
- llmsrv / Veltro integration (Phase 2c)
- STT / TTS via Android system services (Phase 2d)

## Test plan
- [ ] All existing CI checks pass (libemu cross-build, JNI symbol verification, APK assemble)
- [ ] APK uploaded as `infernode-debug-apk` artefact

Refs: INFR-110 (hellaphone vector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)