### PR TITLE
build(android): Phase 2b.0 — SDL3 cross-build + GUI libemu.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ n/local/
 # chain stages these into the Android-app tree at build time; they
 # are produced fresh by ./build-android-apk.sh on every invocation.
 android-app/app/src/main/jniLibs/arm64-v8a/libemu.so
+android-app/app/src/main/jniLibs/arm64-v8a/libSDL3.so
 android-app/app/src/main/assets/inferno-root/
 emu/Android/libemu.so
 emu/Android/o.emu

--- a/build-android-apk.sh
+++ b/build-android-apk.sh
@@ -44,13 +44,31 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 GRADLE_TASK=assembleDebug
 SKIP_GRADLE=0
+GUIBACK=${GUIBACK:-headless}
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --release)     GRADLE_TASK=assembleRelease; shift ;;
         --skip-gradle) SKIP_GRADLE=1; shift ;;
+        --gui)         GUIBACK="$2"; shift 2 ;;
+        --gui=*)       GUIBACK="${1#--gui=}"; shift ;;
         *)             echo "unknown option: $1" >&2; exit 2 ;;
     esac
 done
+
+# GUIBACK is exported so both the inner NDK cross-build (which runs
+# build-android-ndk-arm64.sh in a subshell) and the direct mk invocation
+# below pick it up. For sdl3, ensure SDL3 is built and stage libSDL3.so
+# into jniLibs alongside libemu.so so the APK has both at runtime.
+export GUIBACK
+if [ "$GUIBACK" = "sdl3" ]; then
+    : "${SDL3_PREFIX:=$HOME/sdks/SDL3-android-arm64}"
+    if [ ! -f "$SDL3_PREFIX/lib/libSDL3.so" ]; then
+        echo "::: SDL3 not at $SDL3_PREFIX — building via build-sdl3-android.sh"
+        "$ROOT/build-sdl3-android.sh" || {
+            echo "ERROR: SDL3 cross-build failed" >&2; exit 1; }
+    fi
+    export SDL3_PREFIX
+fi
 
 echo "=== InferNode APK build (Phase 1c) ==="
 echo ""
@@ -69,10 +87,14 @@ echo "::: 2/4  Link libemu.so (shared variant for JNI)"
 export ROOT
 export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-${HOME}/Android/Sdk/ndk/android-ndk-r29}"
 export PATH="$ROOT/Linux/amd64/bin:$PATH"
+MKARGS="SYSTARG=Android OBJTYPE=arm64 GUIBACK=$GUIBACK"
+if [ "$GUIBACK" = "sdl3" ]; then
+    MKARGS="$MKARGS SDL3_PREFIX=$SDL3_PREFIX"
+fi
 (
     cd "$ROOT/emu/Android"
     rm -f libemu.so jni-emu.o
-    "$ROOT/Linux/amd64/bin/mk" -f mkfile-g SYSTARG=Android OBJTYPE=arm64 libemu
+    "$ROOT/Linux/amd64/bin/mk" -f mkfile-g $MKARGS libemu
 )
 if [ ! -f "$ROOT/emu/Android/libemu.so" ]; then
     echo "ERROR: libemu.so was not produced" >&2
@@ -88,6 +110,28 @@ mkdir -p "$JNILIBS" "$ASSETS"
 
 cp "$ROOT/emu/Android/libemu.so" "$JNILIBS/libemu.so"
 echo "    -> $JNILIBS/libemu.so"
+
+# Stale libSDL3.so from a previous --gui sdl3 build would still be
+# packaged into a headless APK. Clear it out when not using SDL3.
+if [ "$GUIBACK" != "sdl3" ]; then
+    rm -f "$JNILIBS/libSDL3.so"
+fi
+
+# SDL3 GUI: libSDL3.so also has to live in jniLibs/arm64-v8a/ so
+# Android's PackageManager loads it before libemu.so resolves
+# its symbols. Without this libemu.so loads but
+# `dlopen("libSDL3.so")` fails inside System.loadLibrary("emu").
+if [ "$GUIBACK" = "sdl3" ]; then
+    # The actual file may be libSDL3.so or libSDL3.so.0 or similar
+    # depending on SDL3's CMake install. Pick whichever is there.
+    SDL3_SO=$(ls -1 "$SDL3_PREFIX/lib/"libSDL3.so* 2>/dev/null | head -1)
+    if [ -z "$SDL3_SO" ] || [ ! -f "$SDL3_SO" ]; then
+        echo "ERROR: libSDL3.so missing at $SDL3_PREFIX/lib/" >&2
+        exit 1
+    fi
+    cp "$SDL3_SO" "$JNILIBS/libSDL3.so"
+    echo "    -> $JNILIBS/libSDL3.so (from $SDL3_SO)"
+fi
 
 # Runtime tree shipped as APK assets. dis/ is the compiled bytecode
 # (sh.dis, cat.dis, the veltro suite, etc.). lib/ has shell profile +

--- a/build-android-ndk-arm64.sh
+++ b/build-android-ndk-arm64.sh
@@ -70,7 +70,25 @@ fi
 # SYSTARG / OBJTYPE must be passed to mk as COMMAND-LINE variables, not env.
 # mkconfig reassigns `SYSTARG=$SYSHOST` after auto-detect, which clobbers any
 # env value — but Plan 9 mk freezes command-line vars so they survive.
-MKARGS="SYSTARG=Android OBJTYPE=arm64"
+#
+# GUIBACK selects the GUI backend. Default headless (Phase 0–2a). Set
+# GUIBACK=sdl3 in the environment to build the Lucifer-capable variant
+# (Phase 2b.0+); that requires SDL3 cross-built for Android arm64,
+# which build-sdl3-android.sh produces.
+: "${GUIBACK:=headless}"
+MKARGS="SYSTARG=Android OBJTYPE=arm64 GUIBACK=$GUIBACK"
+
+if [ "$GUIBACK" = "sdl3" ]; then
+    : "${SDL3_PREFIX:=$HOME/sdks/SDL3-android-arm64}"
+    if [ ! -f "$SDL3_PREFIX/lib/libSDL3.so" ]; then
+        echo "ERROR: SDL3 not found at $SDL3_PREFIX/lib/libSDL3.so" >&2
+        echo "  Run ./build-sdl3-android.sh first, or set SDL3_PREFIX." >&2
+        exit 1
+    fi
+    export SDL3_PREFIX
+    MKARGS="$MKARGS SDL3_PREFIX=$SDL3_PREFIX"
+fi
+
 export PATH="$ROOT/Linux/amd64/bin:$PATH"
 
 mkdir -p "$ROOT/Android/arm64/bin" "$ROOT/Android/arm64/lib"
@@ -116,7 +134,7 @@ done
 
 # --- Cross-compile emulator -----------------------------------------------
 echo ""
-echo "=== Cross-compiling emulator (headless) ==="
+echo "=== Cross-compiling emulator (GUIBACK=$GUIBACK) ==="
 cd "$ROOT/emu/Android"
 rm -f *.o *.emu emu.root.h emu.root.c emu.root.s 2>/dev/null || true
 "$MK" -f mkfile-g $MKARGS || { echo "ERROR: emulator build failed" >&2; exit 1; }

--- a/build-sdl3-android.sh
+++ b/build-sdl3-android.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# build-sdl3-android.sh — cross-compile SDL3 for Android arm64.
+#
+# Phase 2b.0 (hellaphone GUI). The InferNode SDL3 backend
+# (emu/port/draw-sdl3.c) wants libSDL3.so on the link line. macOS and
+# Linux pick that up from Homebrew / apt. Android has no equivalent
+# system package, so we build SDL3 from source against the NDK
+# toolchain.
+#
+# Output: $SDK_HOME/SDL3-android-arm64/{include,lib,share}
+#   - lib/libSDL3.so       — shared library, packaged into the APK
+#   - include/SDL3/SDL.h   — headers, consumed by emu's mkfile-gui-sdl3
+#
+# Idempotent: skips the download + build if the install marker exists.
+# Re-run with `--force` to rebuild.
+
+set -eu
+
+VERSION=${SDL3_VERSION:-3.2.16}
+SDK_HOME=${SDK_HOME:-$HOME/sdks}
+PREFIX=$SDK_HOME/SDL3-android-arm64
+SRC=$SDK_HOME/SDL3-$VERSION-src
+NDK=${ANDROID_NDK_HOME:-$HOME/Android/Sdk/ndk/android-ndk-r29}
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+    esac
+done
+
+if [ ! -d "$NDK" ]; then
+    echo "::error::ANDROID_NDK_HOME not set or NDK not found at $NDK" >&2
+    exit 1
+fi
+
+if [ $FORCE -eq 0 ] && [ -f "$PREFIX/lib/libSDL3.so" ]; then
+    echo "::: SDL3 already installed at $PREFIX (use --force to rebuild)"
+    exit 0
+fi
+
+mkdir -p "$SDK_HOME"
+
+if [ ! -d "$SRC" ]; then
+    echo "::: Downloading SDL3 $VERSION source"
+    curl -fsSL \
+        "https://github.com/libsdl-org/SDL/releases/download/release-$VERSION/SDL3-$VERSION.tar.gz" \
+        | tar -xz -C "$SDK_HOME"
+    mv "$SDK_HOME/SDL3-$VERSION" "$SRC"
+fi
+
+BUILD="$SRC/build-android-arm64"
+rm -rf "$BUILD"
+mkdir -p "$BUILD"
+cd "$BUILD"
+
+echo "::: Configuring SDL3 for Android arm64 (NDK at $NDK)"
+cmake "$SRC" \
+    -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI=arm64-v8a \
+    -DANDROID_PLATFORM=android-28 \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSDL_SHARED=ON \
+    -DSDL_STATIC=OFF \
+    -DSDL_TEST_LIBRARY=OFF \
+    -DSDL_TESTS=OFF \
+    -DSDL_INSTALL_TESTS=OFF \
+    -DSDL_EXAMPLES=OFF \
+    > cmake-configure.log 2>&1 || {
+        echo "::error::SDL3 cmake configure failed" >&2
+        tail -50 cmake-configure.log >&2
+        exit 1
+    }
+
+echo "::: Building SDL3 (parallel)"
+cmake --build . --parallel "$(nproc 2>/dev/null || echo 4)" \
+    > cmake-build.log 2>&1 || {
+        echo "::error::SDL3 build failed" >&2
+        tail -50 cmake-build.log >&2
+        exit 1
+    }
+
+echo "::: Installing SDL3 to $PREFIX"
+cmake --install . > cmake-install.log 2>&1 || {
+    echo "::error::SDL3 install failed" >&2
+    tail -50 cmake-install.log >&2
+    exit 1
+}
+
+# Sanity check: the .so must be aarch64.
+SO="$PREFIX/lib/libSDL3.so"
+if [ ! -f "$SO" ]; then
+    # Some installs land it as libSDL3.so.0 or similar — check.
+    SO=$(ls -1 "$PREFIX/lib/"libSDL3*.so* 2>/dev/null | head -1)
+fi
+if [ -z "$SO" ] || [ ! -f "$SO" ]; then
+    echo "::error::libSDL3.so not produced under $PREFIX/lib" >&2
+    exit 1
+fi
+
+# ELF magic + EM_AARCH64 (0xb7) at byte 18.
+elfhex=$(head -c 19 "$SO" | od -An -tx1 | tr -d ' \n')
+case "$elfhex" in
+    7f454c46*b7) ;;
+    *) echo "::error::$SO is not aarch64 ELF (hex=$elfhex)" >&2; exit 1 ;;
+esac
+
+echo ""
+echo "::: SDL3 $VERSION installed at $PREFIX"
+ls -la "$PREFIX/lib/"libSDL3*.so* 2>/dev/null || true

--- a/emu/Android/mkfile-g
+++ b/emu/Android/mkfile-g
@@ -1,7 +1,14 @@
-# Headless o.emu for Android arm64, cross-compiled via NDK.
+# o.emu and libemu.so for Android arm64, cross-compiled via NDK.
 # Mirrors emu/Linux/mkfile-g but targets SYSTARG=Android so output
 # lands in Android/arm64/ and the binary links against Bionic at the
 # Android system path, not Termux's $PREFIX/lib.
+#
+# GUI backend is selectable via GUIBACK:
+#   GUIBACK=headless  (default) — Phase 0–2a, no display, stubs.
+#   GUIBACK=sdl3                — Phase 2b.0+, draw-sdl3 + libSDL3.
+#
+# The build driver (build-android-apk.sh) selects this via env var
+# before invoking mk.
 
 SYSTARG=Android
 <$ROOT/mkconfig
@@ -13,6 +20,11 @@ CONF=emu			#default configuration
 CONFLIST=emu
 CLEANCONFLIST=
 
+# GUI backend selection. Options: headless, sdl3.
+# Phase 0–2a kept everything headless; Phase 2b.0 introduces sdl3.
+# Override at invocation time: `GUIBACK=sdl3 mk libemu.so`.
+GUIBACK=headless
+
 INSTALLDIR=$ROOT/$SYSTARG/$OBJTYPE/bin	#path of directory where kernel is installed
 
 #end configurable parameters
@@ -21,13 +33,17 @@ INSTALLDIR=$ROOT/$SYSTARG/$OBJTYPE/bin	#path of directory where kernel is instal
 <| $SHELLNAME ../port/mkdevlist  $CONF	#sets $IP, $DEVS, $PORT, $LIBS
 <mkfile-$OBJTYPE	# sets $ARCHFILES
 
+# GUI backend variables (GUISRC, GUIFLAGS, GUILIBS). Pulled in here
+# so OBJ/CFLAGS/SYSLIBS below can reference them.
+<mkfile-gui-$GUIBACK
+
 OBJ=\
 	asm-$OBJTYPE.$O\
 	$ARCHFILES\
 	os.$O\
 	kproc-pthreads.$O\
 	segflush-$OBJTYPE.$O\
-	stubs-headless.$O\
+	$GUISRC\
 	$CONF.root.$O\
 	lock.$O\
 	$DEVS\
@@ -41,17 +57,13 @@ CFLAGS=\
 	-I$ROOT/$SYSTARG/$OBJTYPE/include\
 	-I$ROOT/include\
 	-I$ROOT/libinterp\
-	$CTHREADFLAGS $CFLAGS $EMUOPTIONS\
+	$CTHREADFLAGS $CFLAGS $EMUOPTIONS $GUIFLAGS\
 
 KERNDATE=`{$NDATE}
 
-# Headless build — no X11, no SDL3. AAudio backend (audio-aaudio.c)
-# replaces the Phase 0 no-op stub. -llog is the Android system log
-# library, used by jni-emu.c (Phase 1d, INFR-111) to surface emu's
-# stdio output to logcat. liblog.so is always present on every
-# Android device, so the dep is free; o.emu links against it too but
-# doesn't call it — at most a few unresolved-relocation table bytes
-# in the standalone executable.
+# Headless build links against the AAudio backend and the Android
+# system log library directly. With GUIBACK=sdl3, $GUILIBS pulls in
+# libSDL3; everything else is unchanged.
 SYSLIBS=\
 	-lm\
 	-laaudio\
@@ -71,7 +83,13 @@ $CONF.$O: $CONF.c $CONF.root.h
 	$CC $CFLAGS '-DKERNDATE='$KERNDATE $CONF.c
 
 $O.$CONF:	$OBJ $CONF.$O
-	$LD $LDFLAGS -o $target $OBJ $CONF.$O $LIBFILES $SYSLIBS
+	$LD $LDFLAGS -o $target $OBJ $CONF.$O $LIBFILES $SYSLIBS $GUILIBS
+
+# SDL3 backend source — only built when GUIBACK=sdl3.
+# Place after the default target so we don't accidentally take it
+# over as default.
+draw-sdl3.$O: ../port/draw-sdl3.c
+	$CC $CFLAGS $GUIFLAGS -I. ../port/draw-sdl3.c
 
 # Phase 1c (INFR-110) — shared library variant for the APK build.
 #
@@ -90,7 +108,7 @@ jni-emu.$O: $JNI_SRC
 	$CC $CFLAGS '-DKERNDATE='$KERNDATE -o jni-emu.$O $JNI_SRC
 
 libemu.so: $OBJ $CONF.$O jni-emu.$O
-	$LD -shared $LDFLAGS -o $target $OBJ $CONF.$O jni-emu.$O $LIBFILES $SYSLIBS
+	$LD -shared $LDFLAGS -o $target $OBJ $CONF.$O jni-emu.$O $LIBFILES $SYSLIBS $GUILIBS
 
 libemu:V: libemu.so
 

--- a/emu/Android/mkfile-gui-headless
+++ b/emu/Android/mkfile-gui-headless
@@ -1,0 +1,9 @@
+# Headless GUI backend for Android — no display.
+# Used by the Phase 0–2a headless APK build. Stub implementations of
+# attachscreen, flushmemscreen, etc. so emu links without a real GUI.
+
+GUISRC=\
+	stubs-headless.$O\
+
+GUIFLAGS=
+GUILIBS=

--- a/emu/Android/mkfile-gui-sdl3
+++ b/emu/Android/mkfile-gui-sdl3
@@ -1,0 +1,19 @@
+# SDL3 GUI backend for Android arm64 — Lucifer / wm rendering target.
+#
+# Phase 2b.0 (hellaphone GUI). SDL3 is cross-compiled from source via
+# build-sdl3-android.sh into $SDL3_PREFIX (default: $HOME/sdks/
+# SDL3-android-arm64). The build driver (build-android-apk.sh with the
+# --gui sdl3 flag) ensures that script has run before invoking mk.
+#
+# Unlike Linux/macOS, there is no pkg-config on the Inferno mk side
+# during cross-compile; paths are pinned via the SDL3_PREFIX env var.
+# Override with `SDL3_PREFIX=/path/to/sdl3 mk libemu-gui.so` if you
+# built SDL3 somewhere else.
+
+SDL3_PREFIX=$HOME/sdks/SDL3-android-arm64
+
+GUISRC=\
+	draw-sdl3.$O\
+
+GUIFLAGS=-DGUI_SDL3 -I$SDL3_PREFIX/include
+GUILIBS=-L$SDL3_PREFIX/lib -lSDL3


### PR DESCRIPTION
## Summary

Foundation for the Lucifer / wm mobile port. **No runtime change to the APK** — this PR ships only the build machinery so `libemu.so` *can* link against SDL3 when `GUIBACK=sdl3` is selected. The SDL3Activity, draw-sdl3 wiring, touch input, and IME bridge are separate sub-phases (2b.1 – 2b.4).

## What's new

- **`build-sdl3-android.sh`** — downloads SDL3 3.2.16 source, cross-compiles for Android arm64 via NDK r29 + CMake, installs to `\$SDK_HOME/SDL3-android-arm64/`. Idempotent, `--force` to rebuild, ELF-sanity-checks the output. Produces a 10.8 MB `libSDL3.so`.
- **`emu/Android/mkfile-gui-{headless,sdl3}`** — backend variable files mirroring their `emu/Linux/` siblings.
- **`emu/Android/mkfile-g`** restructured to adopt the same `GUIBACK` pattern Linux already uses. `stubs-headless.\$O` moves into `GUISRC` for headless; SDL3 backend swaps it for `draw-sdl3.\$O`.
- **`build-android-{ndk-arm64,apk}.sh`** thread `\$GUIBACK` through to mk. `--gui sdl3` flag on the APK driver triggers the SDL3 build and stages `libSDL3.so` into `jniLibs/arm64-v8a/`.

## Verified locally

| Variant | Link line | Symbols |
|---|---|---|
| `GUIBACK=sdl3` | `-DGUI_SDL3 draw-sdl3.o … -lSDL3` | exports `attachscreen`, `flushmemscreen`, `emu_run`, `Java_io_infernode_*` |
| Headless | `stubs-headless.o`, no `-lSDL3` | no `SDL_*` undefined deps |

Both `libemu.so` and `libSDL3.so` correctly staged for the SDL3 variant; libSDL3.so cleaned out when building headless.

## Next sub-phases (separate PRs)

- 2b.1: Replace headless Activity with SDL3-capable variant; render a blank SDL window; lifecycle (pause/resume/rotate).
- 2b.2: Wire `draw-sdl3.c` to the Android surface; address macOS-thread assumptions in the SDL3 backend; boot bare `wm`.
- 2b.3: Boot Lucifer (`/lib/lucifer/boot.sh`); touch → mouse remap.
- 2b.4: Soft keyboard / IME ↔ kbdfs.

## Test plan
- [ ] Existing headless CI passes (Cross-build + libemu.so + asset staging)
- [ ] APK assemble step still produces a working headless APK

Refs: INFR-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)