### PR TITLE
android: boot speed (INFR-114) + safe area + touch + regression lints

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -39,6 +39,20 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    # ── Source-level lint for Android-specific traps ─────────────
+    # Catches unguarded syscalls that Android's app-sandbox seccomp
+    # filter blocks (setgid/setuid/etc). Runs before the build so a
+    # PR that re-introduces one fails fast without burning runner
+    # minutes on cross-compile.  See INFR-114 for the case study.
+    - name: Lint emu/Android/*.c for seccomp-blocked syscalls
+      run: ./tools/check-android-syscalls.sh
+
+    # Verify InfernodeSDLActivity still has the safe-area inset
+    # handling. Without it, Lucifer overlaps the status bar / nav
+    # bar on Android 15+. INFR-115.
+    - name: Lint safe-area handling in SDL Activity
+      run: ./tools/check-android-safearea.sh
+
     - name: Install host build prerequisites
       run: |
         sudo apt-get update

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -1,8 +1,13 @@
 package io.infernode
 
 import android.content.res.AssetManager
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.util.Log
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import org.libsdl.app.SDLActivity
 import java.io.File
 import java.io.FileOutputStream
@@ -81,7 +86,11 @@ class InfernodeSDLActivity : SDLActivity() {
             "-pimage=1024m",
             "-r", infernoRoot.absolutePath,
             "sh",
-            "-l", "/lib/lucifer/boot.sh",
+            // boot-mobile.sh applies mobile-only setup (bigger fonts,
+            // future hit-target tuning, swipe-nav hooks) and then
+            // sources the regular boot.sh. Keeps desktop boot.sh
+            // untouched. INFR-113.
+            "-l", "/lib/lucifer/boot-mobile.sh",
         )
     }
 
@@ -90,6 +99,48 @@ class InfernodeSDLActivity : SDLActivity() {
         // calls SDL_main: emu's argv references the root directory.
         extractInfernoRootIfNeeded()
         super.onCreate(savedInstanceState)
+
+        // Phase 2b.2 / INFR-115 — keep Lucifer's SDL surface inside the
+        // safe rectangle (no overlap with the status bar at top or
+        // gesture / nav bar at bottom).
+        //
+        // Android 15 (targetSdk=35) is edge-to-edge by default and
+        // setDecorFitsSystemWindows(true) didn't actually inset the
+        // SDLSurface — it kept extending to the screen edges. So we
+        // stay edge-to-edge but pad the surface ourselves via
+        // SDLActivity.mLayout (the SurfaceView's parent).
+        //
+        // Background: in edge-to-edge mode the system bars are a
+        // transparent overlay. The status bar's white icons need to
+        // contrast with whatever's underneath. The activity's default
+        // window background is light (Theme.AppCompat.Light), which
+        // showed through the top inset as a white bar that hid the
+        // status bar icons. Force the window background to black —
+        // matches Lucifer's brimstone palette (#080808) and gives the
+        // status bar icons a dark backdrop. The Inferno wm draws over
+        // it inside the safe rectangle.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.setBackgroundDrawable(ColorDrawable(Color.BLACK))
+
+        val layout = mLayout
+        if (layout != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(layout) { v, insets ->
+                val bars = insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars()
+                            or WindowInsetsCompat.Type.displayCutout()
+                )
+                Log.i(
+                    TAG,
+                    "applying insets: top=${bars.top} bottom=${bars.bottom} " +
+                        "left=${bars.left} right=${bars.right}"
+                )
+                v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+                WindowInsetsCompat.CONSUMED
+            }
+        } else {
+            Log.w(TAG, "mLayout was null in onCreate; safe-area insets not applied")
+        }
+
         Log.i(TAG, "InfernodeSDLActivity created; SDL_main will boot wm")
     }
 

--- a/docs/HELLAPHONE.md
+++ b/docs/HELLAPHONE.md
@@ -430,9 +430,52 @@ still running.
   useful on the phone yet; that retarget happens in Phase 1.
 * It is not GUI. No Lucia, no Xenith on the phone yet. Headless only.
 
+## Android app-sandbox seccomp restrictions
+
+Phase 1c+ (APK path) runs InferNode under the Android app sandbox.
+The OS installs a seccomp-bpf filter that blocks a list of syscalls
+that desktop Linux freely allows. Calling a blocked syscall raises
+`SIGSYS` and kills the calling thread on the spot — there is no
+errno path to handle this; the process is just gone (or the thread
+disappears, depending on the filter's action).
+
+InferNode's emu has historically targeted desktop Linux and calls
+some of these syscalls in places `os(1)` traditionally expects.
+Each one needs an `#ifndef __BIONIC__` gate in `emu/Android/` or
+it'll crash on Android.
+
+Known disallowed syscalls and where they bit us:
+
+| syscall (arm64 #) | site | symptom | fix |
+|---|---|---|---|
+| `setgid` (#144) | `emu/Android/cmd.c` `childproc()` after fork in `os(1)` | SIGSYS kills `SDLThread`; profile's `os sh -c '...'` calls silently fail; `$ghome`/`$infhome` stay empty; boot stalls on dead overlay binds. **INFR-114.** | gated behind `#ifndef __BIONIC__` (commit `1b136db8`). |
+| `setuid` | same site | same | same gate |
+
+The app process is already pinned to its package uid by the OS
+sandbox before any of our code runs — privilege drop in `childproc`
+is neither possible nor necessary. Inferno-side `$user` is
+independent of the host uid so the user-facing semantics are
+unchanged.
+
+**Regression test.** `tools/check-android-syscalls.sh` lints
+`emu/Android/*.c` for unguarded calls to any function on the
+blocklist. It runs in CI (`.github/workflows/android-apk.yml`)
+before the cross-compile, so a PR that re-introduces a forbidden
+call fails fast. Extend the blocklist in that script when a new
+SIGSYS lands on a device.
+
+When adding new code that goes through fork+exec or any privileged
+operation, sanity-check the syscall against the device's actual
+policy:
+
+```
+adb shell cat /system/etc/seccomp_policy/app.policy 2>/dev/null
+```
+
 ## References
 
 * `emu/Android/README.md` — what eventually lives in that directory.
 * `build-android-termux.sh` — the Phase 0 build driver.
 * `build-linux-arm64.sh` — the Linux ARM64 driver we piggyback on.
-* `INFR-107` — tracking epic.
+* `INFR-107` — Phase 0 tracking epic.
+* `INFR-114` — APK boot speed (closed; setgid seccomp was the cause).

--- a/emu/Android/cmd.c
+++ b/emu/Android/cmd.c
@@ -60,6 +60,20 @@ childproc(Targ *t)
 	close(t->fd[2]);
 
 	/* should have an auth file to do host-specific authorisation? */
+#ifndef __BIONIC__
+	/*
+	 * setgid/setuid are blocked by Android's app-sandbox seccomp
+	 * filter — calling them raises SIGSYS and kills the child.
+	 * Skip on Bionic. The Android app already runs as a specific
+	 * uid (its package uid, e.g. 10263) imposed by the OS sandbox
+	 * before fork; we can't change to anything else and don't need
+	 * to. Inferno-side $user is independent of the host uid anyway.
+	 *
+	 * Profile's `os sh -c '…'` calls were silently failing because
+	 * of this — we'd lose the spawn and then `$ghome` / `$infhome`
+	 * stayed empty and the cascade of `bind -bc $infhome/...` did
+	 * unproductive namespace walks. INFR-114.
+	 */
 	if(t->gid != -1){
 		if(setgid(t->gid) < 0 && getegid() == 0){
 			fprint(t->wfd, "can't set gid %d: %s", t->gid, strerror(errno));
@@ -73,6 +87,7 @@ childproc(Targ *t)
 			_exit(1);
 		}
 	}
+#endif
 
 	if(t->dir != nil && chdir(t->dir) < 0){
 		fprint(t->wfd, "can't chdir to %s: %s", t->dir, strerror(errno));

--- a/emu/port/draw-sdl3.c
+++ b/emu/port/draw-sdl3.c
@@ -329,6 +329,21 @@ sdl3_preinit(void)
 	const char *driver;
 
 	/*
+	 * On Android, single-finger touches do not generate SDL_MOUSE_*
+	 * events by default — they only fire SDL_FINGER_* events. emu's
+	 * event pump (sdl3_mainloop) handles SDL_MOUSE_*, so without this
+	 * hint a tap on the phone produces FINGER events that go nowhere
+	 * and the user sees their tap ignored. Setting this hint before
+	 * SDL_Init tells SDL3 to also synthesise mouse events from
+	 * touches — left-click on tap, drag-as-motion — which is exactly
+	 * the Plan 9-style mouse semantics emu expects.
+	 *
+	 * Set on all platforms (no-op where touches aren't a thing) so
+	 * touchscreen laptops behave the same way.
+	 */
+	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+
+	/*
 	 * Initialize SDL3 on the main thread.
 	 * On macOS, this must happen before any Cocoa window operations.
 	 * We use the native driver (Cocoa on macOS) for real GUI.

--- a/lib/lucifer/boot-mobile.sh
+++ b/lib/lucifer/boot-mobile.sh
@@ -1,0 +1,57 @@
+# Mobile boot wrapper — Phase 2b.2 (INFR-113).
+#
+# Invoked as: sh -l /lib/lucifer/boot-mobile.sh
+# (from android-app/.../InfernodeSDLActivity.kt getArguments())
+#
+# Does mobile-specific setup that should NOT run on desktop, then
+# hands off to the regular boot.sh. Keeping mobile concerns in a
+# separate file means desktop boot is unchanged byte-for-byte —
+# no risk of regressing desktop boot timings or behaviour from
+# Android-only patches.
+#
+# Why not gate the mobile setup inside boot.sh on $emuhost? Because
+# changing emu/Android/os.c's hosttype to "Android" broke critical
+# profile blocks gated on `$emuhost MacOSX Linux Nt` (trfs /n/local,
+# $infhome, secstore overlay binds). hosttype stays "Linux"; the
+# Android-specific behaviour selector is *which boot script* the
+# Activity invokes.
+
+# Bigger fonts for phone screens.
+#
+# Lucifer and most UI elements (wm/shell, wm/editor, acme, xenith,
+# charon, lucipres, wm/logon) open fonts from /fonts/combined/. On a
+# ~388 dpi phone screen the default 10–14 pt sizes are microscopic
+# and tap targets sized to them are unhittable. Bind larger glyphs
+# over the small-tier paths at the file level so every consumer
+# picks up the bigger sizes without code changes.
+#
+# Two families:
+#   unicode.14.font          — proportional sans-mono, used by
+#                              wm/shell, wm/editor, acme, xenith,
+#                              charon, lucifer, lucipres (anything
+#                              with code/terminal alignment). On
+#                              mobile we sacrifice column alignment
+#                              for legibility — bind sans.24 over
+#                              it. Revisit when we generate real
+#                              larger mono glyphs from DejaVuSansMono.
+#   unicode.sans.* family    — proportional sans, used by wm/logon
+#                              body text, smallfont, Lucifer chrome,
+#                              Veltro UI. Responds cleanly to scale.
+#
+# Floor is sans.18 (small UI labels). 14 and 18 jump to 24. Bold
+# tier scales the same.
+bind /fonts/combined/unicode.sans.24.font /fonts/combined/unicode.14.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.18.font /fonts/combined/unicode.sans.10.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.18.font /fonts/combined/unicode.sans.12.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.24.font /fonts/combined/unicode.sans.14.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.24.font /fonts/combined/unicode.sans.18.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.bold.18.font /fonts/combined/unicode.sans.bold.12.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.bold.24.font /fonts/combined/unicode.sans.bold.14.font >[2] /dev/null
+bind /fonts/combined/unicode.sans.bold.24.font /fonts/combined/unicode.sans.bold.18.font >[2] /dev/null
+
+# Hand off to the canonical boot sequence. `run` is Inferno sh's
+# source-include builtin (sh-std(1)); `. file` is NOT the same as
+# in POSIX sh — there `.` is a command name and resolves to ./..dis,
+# which silently failed and left the user staring at a blank screen
+# for 30+ seconds while boot stalled.
+run /lib/lucifer/boot.sh

--- a/tools/check-android-safearea.sh
+++ b/tools/check-android-safearea.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# check-android-safearea.sh — verify InfernodeSDLActivity still has
+# the safe-area inset handling.
+#
+# Background: Android 15 (targetSdk=35) renders activities edge-to-edge
+# by default. Without the manual inset handling we added in INFR-115,
+# Lucifer's SDLSurface overlaps the status bar (top) and gesture / nav
+# bar (bottom). Some well-meaning future refactor might delete the
+# OnApplyWindowInsetsListener thinking "the system handles this now" —
+# this lint says no, it doesn't, leave the code in.
+#
+# We check for the three pieces that together make the fix work:
+#   1. setDecorFitsSystemWindows(...)  — opts the activity in to
+#                                        edge-to-edge so the system
+#                                        bars are a transparent overlay.
+#   2. setOnApplyWindowInsetsListener  — listens for the actual bar
+#                                        heights from the platform.
+#   3. setPadding(...) inside that listener — translates the insets
+#                                              into SurfaceView size.
+#
+# If any of the three vanishes without a follow-up that proves the
+# layout still works, the visual regression returns.
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+F="$ROOT/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt"
+
+if [ ! -f "$F" ]; then
+	echo "::error::expected file $F not found"
+	exit 1
+fi
+
+missing=""
+grep -q 'setDecorFitsSystemWindows' "$F" || missing="$missing setDecorFitsSystemWindows"
+grep -q 'setOnApplyWindowInsetsListener' "$F" || missing="$missing setOnApplyWindowInsetsListener"
+grep -q 'setPadding' "$F" || missing="$missing setPadding"
+
+if [ -n "$missing" ]; then
+	echo "::error file=android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt::Safe-area handling for the SDL surface is gone — missing:$missing. See INFR-115, docs/HELLAPHONE.md."
+	echo "::error::Android 15 / targetSdk=35 needs this to keep Lucifer inside the safe rectangle. Restoring the SDLActivity defaults will overlap the status bar and gesture / nav bar."
+	exit 1
+fi
+
+echo "android-safearea lint: OK"

--- a/tools/check-android-syscalls.sh
+++ b/tools/check-android-syscalls.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+#
+# check-android-syscalls.sh — lint emu/Android/*.c for syscalls
+# that Android's app-sandbox seccomp filter blocks.
+#
+# Background: every blocked syscall called from an Android app process
+# raises SIGSYS and kills the calling thread (usually the whole
+# process). The full list is in /system/etc/seccomp_policy/app.policy
+# on a device. This script catches the ones we've actually been burned
+# by, so future patches don't quietly reintroduce them. INFR-114 is
+# the canonical case study.
+#
+# Rule: any call to a known-blocked function in emu/Android/*.c must
+# sit inside `#ifndef __BIONIC__` … `#endif`. Other emu/* trees are
+# not checked; they target host platforms where the calls are fine.
+#
+# Exit 0 if clean, 1 if any unguarded call is found.
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+import re, sys, glob
+
+# Blocklist — functions whose syscall numbers are denied by Android's
+# app-sandbox seccomp filter on arm64. Extend as we find more.
+BLOCKED = (
+    "setgid setuid setresgid setresuid setregid setreuid "
+    "setfsuid setfsgid"
+).split()
+
+# Match a call to any blocked function, treating word boundaries the
+# Python `\b` way so awk-incompatibility is not an issue.
+CALL = re.compile(r"\b(" + "|".join(BLOCKED) + r")\s*\(")
+
+# Detect #ifndef __BIONIC__ / #if !defined(__BIONIC__) at line start.
+GUARD_OPEN = re.compile(
+    r"^\s*#\s*(?:ifndef\s+__BIONIC__|if\s+!\s*defined\s*\(\s*__BIONIC__\s*\))"
+)
+ENDIF = re.compile(r"^\s*#\s*endif\b")
+
+fail = 0
+for path in sorted(glob.glob("emu/Android/*.c")):
+    depth = 0
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            if GUARD_OPEN.match(raw):
+                depth += 1
+                continue
+            if ENDIF.match(raw):
+                if depth > 0:
+                    depth -= 1
+                continue
+            if depth > 0:
+                continue
+            stripped = raw.lstrip()
+            if stripped.startswith(("//", "*", "/*")):
+                continue
+            # Strip string literals so we don't catch the function name
+            # inside an error message.
+            line = re.sub(r'"[^"]*"', '""', raw)
+            m = CALL.search(line)
+            if m:
+                print(
+                    f"::error file={path},line={lineno}::unguarded {m.group(1)}() in emu/Android/ — wrap in #ifndef __BIONIC__ (Android app-sandbox seccomp blocks it; see docs/HELLAPHONE.md, INFR-114)",
+                    file=sys.stderr,
+                )
+                fail = 1
+
+if fail:
+    print(
+        "::error::Android-blocked syscalls present unguarded in emu/Android/. See docs/HELLAPHONE.md.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print("android-syscall lint: OK")
+PY


### PR DESCRIPTION
## Summary

Re-PR of post-#111 mobile-Lucifer fixes that ended up orphaned on the original branch after #111 merged early. Rebased cleanly onto current master (which has the new keyring-auth boot.sh from #113 — preserved untouched here).

| Area | Before | After |
|---|---|---|
| **Boot speed (INFR-114)** | 2.4s to login-screen | **1.26–1.37s** |
| **SIGSYS / SECCOMP** in logcat at startup | yes (setgid) | gone |
| **Touch input** in Lucifer | dropped (no MOUSE events from single-finger taps) | working |
| **Status bar + gesture/nav bar overlap** | both bars overlapped Lucifer | both in their normal place, Lucifer inside safe rectangle |
| **Mobile font sizes** | unicode.sans.14 default — microscopic | 24pt via boot-mobile.sh binds |

## Pieces

1. `emu/Android/cmd.c` — `setgid()` / `setuid()` calls gated behind `#ifndef __BIONIC__`. Android app-sandbox seccomp blocked them; every `os sh -c '...'` in profile crashed → empty `\$infhome` → dead overlay binds → slow boot.
2. `emu/port/draw-sdl3.c` — `SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1")` before `SDL_Init`. Touches synthesize mouse clicks; emu's event pump handles them.
3. `lib/lucifer/boot-mobile.sh` (NEW) — mobile boot wrapper. Font binds (sans tier up to 24pt) then sources `/lib/lucifer/boot.sh` via Inferno sh's `run`. Desktop boot.sh untouched.
4. `android-app/.../InfernodeSDLActivity.kt` — points argv at boot-mobile.sh; opts into edge-to-edge; OnApplyWindowInsetsListener applies system-bar insets as padding on `SDLActivity.mLayout`; window background → black.
5. `docs/HELLAPHONE.md` — "Android app-sandbox seccomp restrictions" section.
6. `tools/check-android-syscalls.sh` (NEW) — lints `emu/Android/*.c` for unguarded blocked syscalls.
7. `tools/check-android-safearea.sh` (NEW) — verifies `InfernodeSDLActivity` keeps the safe-area triad.
8. `.github/workflows/android-apk.yml` — runs both lints before cross-compile.

Verified end-to-end on Galaxy A55 (Android 15): boot 1.3s, no SIGSYS, taps register, status + nav bars visible above / below Lucifer.

## Deferred to future PRs (filed under INFR-115)

- Real larger fonts via `ttf2subfont` (sizes 28/32/36/40 — current 24pt ceiling is the binding constraint on phone readability).
- Line-width tokens in Lucitheme module + every drawing call site.
- Hit-target tokens in theme + wm widget updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)