### PR TITLE
android: bind /dev/audio at boot and request RECORD_AUDIO in Lucifer

### DIFF
--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -1,10 +1,14 @@
 package io.infernode
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.content.res.AssetManager
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -98,6 +102,11 @@ class InfernodeSDLActivity : SDLActivity() {
         // Asset extraction has to happen *before* SDLActivity.onCreate
         // calls SDL_main: emu's argv references the root directory.
         extractInfernoRootIfNeeded()
+        // Mic permission has to be requested at runtime — manifest
+        // declaration alone is not enough on API >= 23. Kick the
+        // dialog off before SDL takes the surface; AAudio capture in
+        // /dev/audio would silently return zeros otherwise.
+        ensureRecordAudioPermission()
         super.onCreate(savedInstanceState)
 
         // Phase 2b.2 / INFR-115 — keep Lucifer's SDL surface inside the
@@ -142,6 +151,18 @@ class InfernodeSDLActivity : SDLActivity() {
         }
 
         Log.i(TAG, "InfernodeSDLActivity created; SDL_main will boot wm")
+    }
+
+    private fun ensureRecordAudioPermission() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.RECORD_AUDIO),
+                /* requestCode = */ 1
+            )
+        }
     }
 
     private fun extractInfernoRootIfNeeded() {

--- a/emu/port/main.c
+++ b/emu/port/main.c
@@ -338,6 +338,7 @@ emuinit(void *imod)
 	kbind("#^", "/chan", MBEFORE);
 	kbind("#m", "/dev", MBEFORE);	/* pointer */
 	kbind("#c", "/dev", MBEFORE);
+	kbind("#A", "/dev", MBEFORE);	/* audio; no-op on hosts without devaudio */
 	kbind("#p", "/prog", MREPL);
 	kbind("#d", "/fd", MREPL);
 	kbind("#I", "/net", MAFTER);	/* will fail on Plan 9 */


### PR DESCRIPTION
## Summary

Two small wires to make `/dev/audio` actually usable end-to-end on Android. The AAudio backend (`emu/Android/audio-aaudio.c`) and `devaudio` were already linked into the Android emu, but two gaps meant the device was unreachable from Limbo:

- **`emu/port/main.c`** — bind `#A` into `/dev` alongside `#m`, `#c`, `#^`. Previously hosted emu (macOS / Linux / Android) never bound the audio device, so `/dev/audio` simply did not exist in the namespace, even though the backend was wired. `emu/Plan9/os.c:191` has always done this bind; lifting it into port gives every host with devaudio linked `/dev/audio` for free, and no-ops cleanly on hosts where devaudio is absent.

- **`InfernodeSDLActivity.kt`** — request `RECORD_AUDIO` at runtime, mirroring `InfernodeActivity`. Manifest declaration alone is not enough on API ≥ 23; without the request, AAudio capture silently returns zeros. The SDL activity is the primary Lucifer launcher, so the mic was effectively dead from the GUI side.

This unblocks `appl/veltro/speech9p.b`'s `api` engine on Android (TTS/STT round-trip via OpenAI-compatible endpoints), and any other consumer that opens `/dev/audio` or `/dev/audioctl`.

## Test plan

- [ ] APK builds (`./build-android-apk.sh --gui sdl3`) — verified locally, `app-debug.apk` produced
- [ ] On-device: launch "InferNode (Lucifer)" — Android prompts for microphone access on first launch
- [ ] On-device: in Inferno shell, `ls /dev/audio /dev/audioctl` shows both files present
- [ ] On-device: `cat /dev/audio > /tmp/rec.raw &` for a few seconds, then `cat /tmp/rec.raw > /dev/audio` — hear yourself played back
- [ ] On-device: `echo 'rate 16000 chan 1 bits 16' > /dev/audioctl; cat /dev/audioctl` reflects the new format
- [ ] Desktop builds unaffected — macOS / Linux emu still boot and run Lucifer normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)