### PR TITLE
docs(matrix): document GUI control surface; index + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ stdout/stderr stream to the terminal; Ctrl-C exits. `-c1` enables the JIT; `-r$P
 - **JIT compiled** — native code generation on AMD64 and ARM64; interpreter fallback everywhere.
 - **AI agents** — namespace-isolated [Veltro](appl/veltro/SECURITY.md) agents with 39 tool modules, LLM integration via 9P, and formally verified containment.
 - **GUI (optional)** — three-zone tiling UI (Lucia) and an AI-native text environment ([Xenith](docs/XENITH.md)), rendered via SDL3 (Metal / Vulkan / D3D).
+- **Matrix** — compositional module runtime: Limbo `.dis` modules loaded against mounted 9P namespaces, arranged from a [text composition file](doc/matrix-architecture.md), drivable by hand (clickable picker + right-click menu in Lucifer) or by agents through `/n/matrix/ctl`.
 - **Payments** — native cryptocurrency wallet with [x402](docs/WALLET-AND-PAYMENTS.md) payment protocol, ERC-20 tokens, and budget-enforced agent spending. **Experimental — testnet only.**
 - **Go on Dis** — the [GoDis compiler](tools/godis/README.md) translates Go source to Dis bytecode; 190+ test programs pass end-to-end.
 - **Formally verified** — namespace isolation proven in TLA+ (3.17B states), SPIN, and CBMC.
@@ -107,6 +108,7 @@ Speedups are v1 suite (6 benchmarks, best-of-3). Full data: [docs/BENCHMARKS.md]
 - [docs/USER-MANUAL.md](docs/USER-MANUAL.md) — namespaces, devices, host integration
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system architecture
 - [docs/XENITH.md](docs/XENITH.md) — AI-native text environment
+- [doc/matrix-architecture.md](doc/matrix-architecture.md) — Matrix compositional module runtime
 - [docs/WALLET-AND-PAYMENTS.md](docs/WALLET-AND-PAYMENTS.md) — wallet, x402, secstore, key management
 - [appl/veltro/SECURITY.md](appl/veltro/SECURITY.md) — Veltro agent security model
 - [tools/godis/README.md](tools/godis/README.md) — Go-to-Dis compiler architecture

--- a/doc/matrix-architecture.md
+++ b/doc/matrix-architecture.md
@@ -424,6 +424,58 @@ the layout. Veltro's workflow: read the current composition, modify it,
 write it back.
 
 
+## GUI Control Surface
+
+In GUI mode under Lucifer, Matrix exposes the same `load` / `unload` /
+composition-editing operations through direct manipulation. The GUI is
+a thin shortcut over the 9P control surface above -- every click ends
+up writing the same verbs to `/n/matrix/ctl`.
+
+### Empty-state picker
+
+When Matrix opens without a composition loaded (or after `unload`), the
+pane body is a picker. The header is followed by one row per file in
+`/lib/matrix/compositions/`. Left-clicking a row issues a `load <name>`
+through the control surface; the picker is replaced by the
+composition's display modules.
+
+Click detection is edge-triggered (button-1 down transition only), so
+dragging across rows does not fire repeated loads. The right-click menu
+path resets this latch on dismiss, so a click immediately after the
+menu closes still registers.
+
+### Right-click composition menu
+
+Right-click anywhere in the Matrix pane to open a contextual menu
+(Plan 9 hold-and-release style, via `module/menu.m`). The menu is
+rebuilt on every show by listing `/lib/matrix/compositions/`, so newly
+pinned compositions appear without restarting:
+
+| Item | Action |
+|------|--------|
+| `Unload` | `unload` -- clears the current composition; returns to the picker. |
+| `Edit <current>` | Opens the current composition file in `wm/editor` as a new presentation-zone tab. Disabled when no composition is loaded. |
+| `Load <name>` | One entry per file under `/lib/matrix/compositions/`. Issues `load <name>`. |
+
+The `Edit` action is routed through Lucifer's artifact-ctl mechanism
+(`/n/ui/activity/<id>/presentation/ctl`) rather than spawning
+`wm/editor` directly. This is necessary because each presentation
+tab is a single-shot wmclient slot under Lucifer; routing through
+artifact-ctl gives `wm/editor` its own slot, its own `Draw->Context`,
+and its own wmsrv connection -- the same shape as launching it from a
+Lucifer Apps menu.
+
+### Headless equivalence
+
+The GUI surface adds no new operations: the picker is `load`, the
+right-click menu is `load` / `unload` / artifact-tab spawn. A headless
+process driving `/n/matrix/ctl` and `/n/matrix/composition` directly
+has the same reach as a user clicking through the menu. This matters
+for agents: Veltro can drive Matrix end-to-end without ever rendering
+the GUI surface, and what it does is observable in the same namespace
+the user manipulates.
+
+
 ## Proof of Concept: TBL4 Trading System
 
 The POC demonstrates the full Matrix loop using the TBL4 trading system

--- a/docs/DOCUMENTATION-INDEX.md
+++ b/docs/DOCUMENTATION-INDEX.md
@@ -22,6 +22,8 @@
 | [LUCIFER-EVALUATION.md](LUCIFER-EVALUATION.md) | Lucifer GUI production readiness evaluation (P0/P1/P2 issues) |
 | [evaluations/fractal-app-evaluation.md](evaluations/fractal-app-evaluation.md) | Fractal app production readiness evaluation |
 | [architecture-review-veltro-unification.md](architecture-review-veltro-unification.md) | Veltro architecture review |
+| [../doc/matrix-architecture.md](../doc/matrix-architecture.md) | Matrix compositional module runtime — modules, compositions, the library, 9P control namespace, and the Lucifer GUI control surface |
+| [../doc/9p-data-conventions.md](../doc/9p-data-conventions.md) | 9P data conventions Matrix modules read from and write to |
 | [RECOMMENDED-ADDITIONS.md](RECOMMENDED-ADDITIONS.md) | Recommended feature additions |
 
 ## For Developers


### PR DESCRIPTION
## Summary

Matrix shipped with a solid 704-line architecture doc but two surface features and one discoverability gap were never folded in. This PR closes them.

## Changes

* **`doc/matrix-architecture.md`** — new "GUI Control Surface" section between the 9P namespace and POC sections. Documents the empty-state picker (clickable rows for `/lib/matrix/compositions/`), the right-click composition menu (Plan 9 hold-and-release, items rebuilt on every show), the Unload / Edit / Load verbs, and the artifact-ctl routing for the Edit verb's `wm/editor` spawn. Frames the GUI as a thin shortcut over the 9P ctl surface — every click resolves to the same `load` / `unload` verbs an agent would write.
* **`docs/DOCUMENTATION-INDEX.md`** — adds entries under "Architecture & Design" for `doc/matrix-architecture.md` and `doc/9p-data-conventions.md`. Both lived in `doc/` (Inferno man-page-source convention) and were not discoverable from the canonical index — pre-PR `grep matrix-architecture` returned zero.
* **`README.md`** — Matrix bullet in Highlights; link to the architecture doc in the Documentation list. No top-level mention of Matrix existed.

## Out of scope

No composition-specific docs (`perf-dashboard`, `tbl4-overview`). Those ship as runtime data, not surface features, and shouldn't be promoted from libdata to documented APIs until they stabilise.

## Verification

* `wc -l doc/matrix-architecture.md`: 704 → 756.
* `grep -c matrix-architecture docs/DOCUMENTATION-INDEX.md`: 0 → 1.
* `grep -c Matrix README.md`: was 0 in Highlights, now 1; Documentation list gains one entry.

Refs INFR-115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)