### PR TITLE
hellaphone Phase 2: iOS port design and build scaffolding

### DIFF
--- a/build-ios-arm64.sh
+++ b/build-ios-arm64.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+#
+# Phase A build driver — InferNode for iOS arm64, cross-compiled with
+# the Xcode toolchain on a macOS host. hellaphone Phase 2.
+#
+# This is the iOS analogue of build-android-ndk-arm64.sh. It builds a
+# HEADLESS o.emu against the iphonesimulator SDK; you run it inside a
+# booted simulator with `xcrun simctl spawn`, which is the cheapest
+# possible signal that the interpreter-only (-c0) Dis VM, 9P stack, and
+# Veltro harness work under Apple's runtime before any UIKit/app-bundle
+# investment. The device build (Phase B) links the same objects into an
+# Xcode app target — see emu/iOS/README.md.
+#
+# Outputs:
+#   iOS/arm64/lib/*.a    cross-compiled Inferno C libraries
+#   emu/iOS/o.emu        the headless emulator (simulator slice)
+#
+# Prereqs (all macOS-only — you cannot build for iOS off a Mac):
+#   * Xcode + command-line tools; `xcrun` on PATH.
+#   * A host mk + limbo tree at MacOSX/arm64/bin/ — produced by
+#     ./makemk.sh + the macOS build on a fresh clone.
+#
+# Usage (from repo root, on a Mac):
+#   ./build-ios-arm64.sh                 # simulator (default)
+#   IOSSDK=iphoneos ./build-ios-arm64.sh # device slice (unsigned; for
+#                                        # the Phase B Xcode app to link)
+#
+# See:
+#   docs/IOS.md            full iOS port design plan
+#   emu/iOS/README.md      directory status and phase plan
+#   INFR-107               hellaphone tracking epic
+#
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+export ROOT
+
+echo "=== InferNode iOS build (hellaphone Phase 2, Phase A) ==="
+echo ""
+
+# --- Host must be macOS with Xcode -----------------------------------------
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "ERROR: iOS builds require a macOS host (uname -s reports $(uname -s))." >&2
+    echo "  The Xcode toolchain (xcrun/clang + iOS SDKs) exists only on macOS." >&2
+    exit 1
+fi
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "ERROR: xcrun not found. Install Xcode and its command-line tools:" >&2
+    echo "  xcode-select --install" >&2
+    exit 1
+fi
+
+# --- SDK / target selection ------------------------------------------------
+# IOSSDK picks simulator vs device; IOSTRIPLE follows it. Both are passed
+# to mk as COMMAND-LINE vars so they survive mkconfig's SYSTARG reassign
+# (same trick as the Android driver).
+: "${IOSSDK:=iphonesimulator}"
+: "${IOSMIN:=14.0}"
+case "$IOSSDK" in
+    iphonesimulator) : "${IOSTRIPLE:=arm64-apple-ios${IOSMIN}-simulator}" ;;
+    iphoneos)        : "${IOSTRIPLE:=arm64-apple-ios${IOSMIN}}" ;;
+    *) echo "ERROR: IOSSDK must be iphonesimulator or iphoneos (got $IOSSDK)." >&2; exit 1 ;;
+esac
+
+if ! xcrun --sdk "$IOSSDK" --show-sdk-path >/dev/null 2>&1; then
+    echo "ERROR: SDK '$IOSSDK' not available. Installed SDKs:" >&2
+    xcrun --show-sdk-path 2>/dev/null || true
+    exit 1
+fi
+
+# --- Host mk + limbo -------------------------------------------------------
+if [ ! -x "$ROOT/MacOSX/arm64/bin/mk" ]; then
+    echo "ERROR: host mk not built. Run ./makemk.sh + the macOS build first." >&2
+    exit 1
+fi
+if [ ! -x "$ROOT/MacOSX/arm64/bin/limbo" ]; then
+    echo "WARNING: host limbo not at MacOSX/arm64/bin/limbo." >&2
+    echo "  Some appl/ builds compiling .b -> .dis may need it." >&2
+fi
+
+MK="$ROOT/MacOSX/arm64/bin/mk"
+MKARGS="SYSTARG=iOS OBJTYPE=arm64 IOSSDK=$IOSSDK IOSTRIPLE=$IOSTRIPLE IOSMIN=$IOSMIN"
+
+export PATH="$ROOT/MacOSX/arm64/bin:$PATH"
+mkdir -p "$ROOT/iOS/arm64/bin" "$ROOT/iOS/arm64/lib"
+
+echo "ROOT=$ROOT"
+echo "IOSSDK=$IOSSDK  IOSTRIPLE=$IOSTRIPLE"
+echo "SDK path=$(xcrun --sdk "$IOSSDK" --show-sdk-path)"
+echo "host mk=$MK"
+echo ""
+
+# --- Cross-compile core C libraries ----------------------------------------
+# Same ordering and stale-.o nuke as the Android driver: Inferno mkfiles
+# drop .o next to the source, so a prior macOS-native build collides with
+# the iOS cross-build. Brute force: delete before each rebuild. (The
+# MacOSX/arm64/lib/*.a stays intact.)
+echo "=== Cross-compiling C libraries ==="
+for lib in lib9 libbio libmp libsec libmath libmemdraw libmemlayer libdraw libfreetype; do
+    [ -d "$ROOT/$lib" ] || continue
+    echo "Building $lib..."
+    cd "$ROOT/$lib"
+    find . -maxdepth 1 -name '*.o' -delete 2>/dev/null || true
+    "$MK" $MKARGS install || { echo "ERROR: $lib build failed" >&2; exit 1; }
+done
+
+for lib in libinterp libkeyring; do
+    [ -d "$ROOT/$lib" ] || continue
+    echo "Building $lib..."
+    cd "$ROOT/$lib"
+    find . -maxdepth 1 -name '*.o' -delete 2>/dev/null || true
+    "$MK" $MKARGS install || { echo "ERROR: $lib build failed" >&2; exit 1; }
+done
+
+# --- Cross-compile emulator ------------------------------------------------
+echo ""
+echo "=== Cross-compiling emulator (headless) ==="
+cd "$ROOT/emu/iOS"
+rm -f *.o *.emu emu.root.h emu.root.c emu.root.s 2>/dev/null || true
+"$MK" -f mkfile-g $MKARGS || { echo "ERROR: emulator build failed" >&2; exit 1; }
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "=== Build Summary ==="
+if [ -x "$ROOT/emu/iOS/o.emu" ]; then
+    echo "SUCCESS: emulator at $ROOT/emu/iOS/o.emu"
+    ls -la "$ROOT/emu/iOS/o.emu"
+    file "$ROOT/emu/iOS/o.emu" 2>/dev/null || true
+    echo ""
+    if [ "$IOSSDK" = "iphonesimulator" ]; then
+        echo "Run it in a booted simulator:"
+        echo "  xcrun simctl boot 'iPhone 15'   # or any installed device name"
+        echo "  xcrun simctl spawn booted $ROOT/emu/iOS/o.emu -c0 -r$ROOT sh -l"
+        echo ""
+        echo "Smoke test inside the Inferno ';' shell:"
+        echo "  ; cat /dev/sysname"
+        echo "  ; echo hello from inferno on ios"
+    else
+        echo "This is an unsigned device slice. Phase B links it into an"
+        echo "Xcode app target for code-signing + UIKit. See emu/iOS/README.md."
+    fi
+    echo ""
+else
+    echo "FAIL: o.emu not found. See errors above."
+    exit 1
+fi

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -1,0 +1,199 @@
+# InferNode on iOS — hellaphone Phase 2
+
+*Design plan. No iOS code exists yet; this doc is the spec the work
+will be built against.*
+
+This is the iOS counterpart to `docs/HELLAPHONE.md` (Android) and the
+Phase 2 referenced in `emu/Android/README.md`. The goal is the same:
+run InferNode — the Dis VM, 9P, the Veltro agent harness, and
+eventually the GUI — on a stock Apple handset. Parent tracking epic is
+the hellaphone effort (`INFR-107`); a dedicated iOS phase ticket should
+be filed when Phase A starts.
+
+## The one thing to get right first: iOS forks from macOS, not Android
+
+The Android port's cost was dominated by Bionic-vs-glibc gaps —
+`ushort`/`uint` typedefs, `rewind` collision, `getdtablesize`, OSS
+audio, `malloc_usable_size`'s `const` signature
+(`emu/Android/README.md:21-43`). **Almost none of that applies to
+iOS.** iOS ships Apple's BSD-derived libc, the same family macOS uses,
+so the natural ancestor for every iOS platform file is its
+`emu/MacOSX/` equivalent, not the Linux/Android one:
+
+| iOS file (to create) | Fork from | Why |
+| --- | --- | --- |
+| `emu/iOS/os.c` | `emu/MacOSX/os.c` | Shared Apple libc; already marshals GUI work to the main thread (AppKit → UIKit is the same constraint), uses dispatch queues, handles SIGSEGV-as-Dis-fault the Apple way. |
+| `emu/iOS/cmd.c` | `emu/MacOSX/cmd.c` | Same `getuser`/arg-handling shape; no Bionic `sysconf` substitutions needed. |
+| `$ROOT/iOS/arm64/include/*` | `$ROOT/MacOSX/arm64/include/*` | Apple headers expose the BSD shorthands and `rewind` semantics Inferno expects; the Android lib9.h patches are unnecessary here. |
+| `emu/iOS/mkfile`, `mkfile-gui-sdl3` | `emu/Linux/mkfile{,-gui-sdl3}` | Build wiring is OS-shaped, not libc-shaped; the SDL3 backend is identical. |
+| `emu/iOS/asm-arm64.S`, `segflush-arm64.c` | `emu/Linux/` | ARM64 ISA + cache-flush are the same; thin reuse, same as Android Phase 1 plans. |
+
+Two things are also *cheaper* on iOS than they were on Android:
+
+- **Root filesystem.** An iOS `.app` bundle is a real readable POSIX
+  directory, so the Inferno root ships as bundle resources and
+  `emu -r <bundle>/inferno` + the existing `devfs-posix.c` just work.
+  Android Phase 1 needs an AAsset bridge because its assets are zipped;
+  iOS needs nothing equivalent. Writable state goes in the app's
+  `Documents`/`Library` container.
+- **Audio.** iOS uses the same CoreAudio/AVAudioEngine family as macOS,
+  so the macOS audio path is a starting point, not a rewrite. (Phase A
+  is headless; defer this to Phase B.)
+
+## The four hard iOS constraints
+
+1. **No JIT — interpreter only.** Apple's W^X policy denies stock apps
+   the executable `mmap`/`mprotect` the JIT needs, so `comp-arm64.c` is
+   unusable on-device. emu must boot `-c0` (pure interpreter). The
+   `cflag` switch already exists in `emu/port/main.c`, so this is a
+   launch/build default, not new code. Expect a perf hit: the repo's
+   note cites ~9× worst case; Android's measured `-c1` vs `-c0` delta is
+   ~3× (`docs/HELLAPHONE.md:380`). Acceptable for a UI/agent workload;
+   benchmark early so we know the real number on Apple silicon.
+
+2. **No Termux escape hatch — Phase 0 isn't free.** Android got a
+   near-zero-cost proof of life by piggybacking `o.emu` on
+   `emu/Linux/` inside Termux (`docs/HELLAPHONE.md:13-20`). iOS has no
+   general-purpose userspace that will host a hand-built binary, so the
+   first signal requires an Xcode project and a static-lib build of emu.
+   We make that as cheap as possible by targeting the **iOS Simulator**
+   first (see Phase A) — no code-signing, no provisioning, CI-able.
+
+3. **Single process — no `fork`/`exec` of separate binaries.** emu
+   already runs Dis "processes" as host pthreads (`kproc-pthreads.c`),
+   so the VM is unaffected. What breaks is host-command exec via the
+   `os` device — the same `setuid`/`setgid`-after-fork path that bit
+   Android (`emu/Android/README.md:447-458`). On iOS we don't gate it,
+   we compile it out: there is no host shell to exec into.
+
+4. **GUI is UIKit + Metal, on the main thread.** SDL3 has a UIKit/Metal
+   backend, and `emu/port/draw-sdl3.c` already carries the touch and
+   HiDPI logical-vs-pixel fixes done *for Android*
+   (`emu/port/draw-sdl3.c:85-100`) — that work transfers directly to
+   iOS, which is also a touch + Metal target. macOS already marshals
+   draw calls to the main thread; iOS keeps that requirement.
+
+## Build approach (decided): mk cross-compile + thin Xcode wrapper
+
+There is no `mk` on-device for iOS, so the C side is cross-compiled
+from a macOS host using the Xcode toolchain, exactly mirroring the
+Android NDK pattern. An Xcode app target then links the resulting
+`libemu` and provides the bundle, entitlements, and UIKit entry point.
+A hand-maintained Xcode project listing every emu source was rejected:
+it diverges from the repo's mk build and is painful to keep in sync as
+`emu/port/` changes.
+
+The host is macOS, so `mkconfig` already resolves `SYSHOST=MacOSX`; we
+drive the target explicitly, just like Android does:
+
+```sh
+# Device build
+mk SYSTARG=iOS OBJTYPE=arm64 IOSSDK=iphoneos
+# Simulator build (Apple-silicon host; arm64 sim slice)
+mk SYSTARG=iOS OBJTYPE=arm64 IOSSDK=iphonesimulator
+```
+
+`mkconfig:20-21` then pulls `mkfiles/mkhost-MacOSX` (host tools) and
+`mkfiles/mkfile-iOS-arm64` (target flags). That target mkfile is a fork
+of `mkfiles/mkfile-Android-arm64`, swapping the NDK toolchain for
+`xcrun`:
+
+```
+TARGMODEL=  Posix
+TARGSHTYPE= sh
+CPUS=       arm64
+O=          o
+
+# IOSSDK selects device vs simulator: iphoneos | iphonesimulator
+SDKPATH=    `{xcrun --sdk $IOSSDK --show-sdk-path}
+CC=         `{xcrun --sdk $IOSSDK -f clang} -c
+# Triple gets the -simulator suffix for the sim SDK; mk picks one of
+# the two CFLAGS blocks on $IOSSDK. Device:
+#   -target arm64-apple-ios14.0
+# Simulator:
+#   -target arm64-apple-ios14.0-simulator
+CFLAGS=     -g -O -fno-strict-aliasing -fstack-protector-strong \
+            -isysroot $SDKPATH -arch arm64 \
+            -I$ROOT/iOS/arm64/include -I$ROOT/include -fcommon
+AR=         `{xcrun --sdk $IOSSDK -f ar}
+LD=         `{xcrun --sdk $IOSSDK -f clang}
+```
+
+Output objects land under `$ROOT/iOS/arm64/` and are archived into
+`libemu.a`, which the Xcode target links. (Unlike Android there is no
+`o.emu` executable on-device — iOS apps are a bundle whose `main()`
+lives in the app target and calls into libemu.)
+
+## Phase plan
+
+**Phase A — Simulator headless proof of life.** The iOS analog of
+Android Phase 0, and the cheapest path to "does interpreter-only Dis
+actually run under Apple's sandbox."
+
+- Add `mkfiles/mkfile-iOS-arm64` and a `build-ios-arm64.sh` driver
+  (model on `build-android-ndk-arm64.sh`).
+- Cross-compile emu to `libemu.a` for `iphonesimulator`, GUIBACK
+  headless (`emu/Linux/stubs-headless.c` is platform-independent).
+- Minimal app/XCTest target whose entry boots emu `-c0 -r<bundle>` and
+  runs `tests/runner.dis`; logs to stderr/`NSLog`.
+- CI via `xcodebuild test` on a macOS runner. This is the load-bearing
+  milestone: it proves the VM, 9P, and Veltro work without the JIT
+  before any UI investment.
+
+**Phase B — Device build + SDL3 GUI.**
+
+- `emu/iOS/{os.c, cmd.c, mkfile, mkfile-gui-sdl3}` forked from the
+  ancestors in the table above; compile out host `fork`/`exec`.
+- SDL3 iOS framework wired to `emu/port/draw-sdl3.c` (reusing the
+  Android touch/HiDPI logic); Metal renderer.
+- Real app target: Inferno root bundled read-only, writable state in
+  the container, dev-cert signing, run Lucia/Xenith on hardware.
+- Force `-c0` at launch; confirm W^X — no `PROT_EXEC` mappings.
+
+**Phase C — on-device `/n/llm` + polish.** Same retarget Android Phase
+1 plans (`emu/Android/README.md:62-65`): the 9P surface at `/n/llm`
+stays put, the backend swaps from Ollama-over-HTTP to something
+on-device. iOS-native options are stronger than Android's here —
+MLX or CoreML alongside `llama.cpp`. App Store/TestFlight
+considerations (entitlements, no downloaded executable code) live in
+this phase.
+
+## Open questions
+
+- **Simulator vs device for first GUI signal.** The Apple-silicon
+  simulator is more permissive about W+X than a device; do we want a
+  device-only smoke test gating Phase B so we never accidentally rely
+  on JIT-ish behavior the simulator tolerates?
+- **One mkfile with `IOSSDK`, or two mkfiles** (`mkfile-iOS-arm64` +
+  `mkfile-iOSsim-arm64`)? The `IOSSDK` variable keeps it to one file
+  but the `-simulator` triple suffix makes the CFLAGS branch slightly
+  ugly. Lean toward one file unless it gets unreadable.
+- **GUI long game: SDL3 vs native UIKit.** Phase B uses SDL3 to reach
+  pixels fastest and reuse Android's work. A native UIKit front-end
+  over a headless + 9P core is more iOS-idiomatic (better text input,
+  share sheet, multitasking) but much more work. Revisit after Phase B
+  ships.
+- **Minimum iOS version.** Pick the floor once we know which APIs
+  `os.c` actually needs; start at iOS 14 and raise only if forced.
+- **App Store posture.** A self-contained OS demo that runs no
+  downloaded executable code is generally reviewable, but "terminal /
+  runs code" apps draw scrutiny. Decide TestFlight-only vs. store
+  submission before Phase C polish.
+
+## What this is NOT (yet)
+
+- Not an app you can install today — no Xcode project exists.
+- Not JIT-accelerated, and won't be on stock devices — `-c0` is the
+  contract.
+- Not on-device inference — `/n/llm` retarget is Phase C.
+
+## References
+
+- `docs/HELLAPHONE.md` — Android Phase 0, the sibling effort.
+- `emu/Android/README.md` — Phase 2 scoping note and the Bionic-gap
+  catalogue iOS mostly sidesteps.
+- `emu/MacOSX/os.c`, `emu/MacOSX/cmd.c` — the iOS ancestors.
+- `emu/port/draw-sdl3.c` — cross-platform GUI backend with touch/HiDPI.
+- `emu/port/main.c` — the `-c[0-9]` JIT-level flag.
+- `mkfiles/mkfile-Android-arm64`, `mkconfig` — the cross-compile pattern.
+- `INFR-107` — hellaphone tracking epic.

--- a/emu/iOS/README.md
+++ b/emu/iOS/README.md
@@ -1,0 +1,121 @@
+# emu/iOS — the hellaphone iOS target
+
+This directory is the iOS half of InferNode's mobile build (*hellaphone*),
+sitting alongside `emu/Android/`, `emu/MacOSX/`, etc. It will host the
+iOS platform glue that lets `o.emu` run inside an iOS app. The design
+rationale lives in `docs/IOS.md`; this file tracks status and the
+mechanics of the directory.
+
+## Status
+
+**Phase A — Simulator headless proof of life.** Scaffolded, not yet
+built. This is the iOS analogue of Android Phase 0: instead of Termux
+(which has no iOS equivalent), the cheapest signal is a headless `o.emu`
+cross-compiled against the **iphonesimulator** SDK and run via
+`xcrun simctl spawn` inside a booted simulator. It proves the
+interpreter-only (`-c0`) Dis VM, 9P, and the Veltro harness work under
+Apple's runtime before any UIKit/app-bundle investment.
+
+> **Not yet compiled.** The scaffolding here was authored on a Linux
+> box with no Xcode/iOS SDK, so nothing in this directory has been run
+> through clang yet. The first build on a macOS host is expected to
+> surface a small set of iOS-SDK gaps the same way Android Phase 0
+> surfaced Bionic gaps — see "Expected gaps" below.
+
+### The key idea: iOS forks from macOS, not Linux/Android
+
+The Android port's cost was dominated by Bionic-vs-glibc differences.
+iOS ships Apple's BSD-derived libc — the same family as macOS — so those
+differences mostly vanish. Phase A therefore reuses `emu/MacOSX/` and
+`emu/port/` sources **unchanged**, via `:N:` rules in `mkfile-g`:
+
+| Object | Reused from |
+| --- | --- |
+| `os.c` | `../MacOSX/os.c` |
+| `cmd.c` | `../MacOSX/cmd.c` |
+| `asm-arm64.s` | `../MacOSX/asm-arm64.s` |
+| `stubs-headless.c` | `../MacOSX/stubs-headless.c` |
+| `deveia.c` | `../MacOSX/deveia.c` |
+| `ipif.c` | `../FreeBSD/ipif.c` |
+| `devfs.c` | `../port/devfs-posix.c` |
+
+The platform headers under `iOS/arm64/include/` are one-line forwards
+to their `MacOSX/arm64/include/` counterparts for the same reason
+(single source of truth). The only genuinely iOS-specific files are
+`mkfiles/mkfile-iOS-arm64` (the Xcode toolchain), this directory's
+`emu` config and `mkfile-g`, and `build-ios-arm64.sh`.
+
+Phase B forks any of the reused sources into this directory the moment
+it needs iOS-specific code (most likely `cmd.c`, whose host fork/exec is
+impossible under the iOS app sandbox).
+
+### No JIT — interpreter only
+
+Apple's W^X policy denies executable `mmap`/`mprotect` to stock apps, so
+`libinterp/comp-arm64.c` cannot run on-device. emu must be launched
+`-c0`. The `emu` config here also sets `macjit = 0`. Expect the perf hit
+the JIT benchmark predicts (~3–9×); benchmark it early.
+
+### Expected gaps (Phase A will surface these on first macOS build)
+
+These are predictions from reading `emu/MacOSX/os.c`, not confirmed:
+
+* `emu/MacOSX/os.c` includes `<architecture/ppc/cframe.h>`; the iOS SDK
+  almost certainly does not ship the PPC arch headers. Likely the first
+  failure, and the trigger to fork `os.c` into `emu/iOS/`.
+* It calls Mach VM primitives (`vm_allocate`, `vm_machine_attribute`).
+  `vm_allocate` is fine on iOS; `vm_machine_attribute` (instruction-cache
+  flush, a JIT path) may be restricted — but `-c0` should never reach it.
+* Framework link set: Phase A drops macOS's `-framework IOKit` (restricted
+  on iOS) and keeps `CoreFoundation`. The real minimal set gets nailed
+  down at first link.
+
+Each confirmed gap should be gated and noted against `INFR-107`, exactly
+as the Android Bionic gaps were.
+
+## Phase B — device build + SDL3 GUI. Not started.
+
+Will introduce:
+
+* `os.c`, `cmd.c` — iOS-specific forks (compile out host fork/exec;
+  whatever the Phase A gaps require).
+* An Xcode app target linking the emu objects as `libemu.a` plus the
+  Inferno C libs, providing `UIApplicationMain` and code-signing.
+* SDL3 (UIKit + Metal) wired to `emu/port/draw-sdl3.c`, reusing the
+  touch/HiDPI logic already added there for Android.
+* Inferno root bundled read-only in the `.app`; writable state in the
+  app container; `emu -r <bundle>/inferno`.
+
+## Phase C — on-device `/n/llm`. Not started.
+
+Same retarget Android Phase 1 plans: the 9P surface at `/n/llm` stays,
+the backend swaps from Ollama-over-HTTP to on-device inference. iOS-native
+options (MLX, CoreML) are stronger here than Android's.
+
+## Build (Phase A)
+
+On a Mac with Xcode, from the repo root, after the macOS host build has
+produced `MacOSX/arm64/bin/{mk,limbo}`:
+
+```sh
+./build-ios-arm64.sh                  # simulator slice (default)
+IOSSDK=iphoneos ./build-ios-arm64.sh  # device slice (unsigned)
+```
+
+Then, for the simulator slice:
+
+```sh
+xcrun simctl boot 'iPhone 15'
+xcrun simctl spawn booted ./emu/iOS/o.emu -c0 -r"$PWD" sh -l
+```
+
+You should land in an Inferno `;` shell. If `cat /dev/sysname` works,
+Phase A is done — capture it against `INFR-107`.
+
+## References
+
+* `docs/IOS.md` — full iOS port design plan.
+* `docs/HELLAPHONE.md`, `emu/Android/README.md` — the Android sibling.
+* `mkfiles/mkfile-iOS-arm64` — the Xcode cross-compile toolchain flags.
+* `build-ios-arm64.sh` — this phase's build driver.
+* `INFR-107` — hellaphone tracking epic.

--- a/emu/iOS/emu
+++ b/emu/iOS/emu
@@ -1,0 +1,98 @@
+dev
+	root
+	cons
+	env
+	mnt
+	pipe
+	prog
+	prof
+	srv
+	dup
+	ssl
+	cap
+	fs
+	cmd	cmd
+	indir
+
+	draw
+	pointer
+	snarf
+	wmsz
+
+	ip	ipif6-posix ipaux
+	eia
+#	audio	audio
+	mem
+
+lib
+	interp
+#	tk
+#	freetype
+	math
+	draw
+
+	memlayer
+	memdraw
+	keyring
+	sec
+	mp
+
+	9
+
+link
+
+mod
+	sys
+	draw
+
+#	tk
+	math
+	srv	srv
+	keyring
+#	loader
+#	freetype
+
+port
+	alloc
+	cache
+	chan
+	dev
+	devtab
+	dial
+	dis
+	discall
+	env
+	error
+	errstr
+	exception
+	exportfs
+	inferno
+	latin1
+	main
+	parse
+	pgrp
+	print
+	proc
+	qio
+	random
+	sysfile
+	uqid
+
+code
+	int	dontcompile = 0;
+# iOS: no JIT. Apple W^X forbids executable mmap, so the ARM64 JIT
+# cannot run on stock devices; emu must be launched -c0 (interpreter).
+	int	macjit = 0;
+
+init
+	emuinit
+
+root
+	/dev	/
+	/fd	/
+	/prog	/
+	/net	/
+	/net.alt	/
+	/chan	/
+	/nvfs	/
+	/env	/

--- a/emu/iOS/mkfile-g
+++ b/emu/iOS/mkfile-g
@@ -1,0 +1,84 @@
+# Headless o.emu for iOS arm64 — hellaphone Phase 2, Phase A.
+#
+# Built against the iphonesimulator SDK and run via `xcrun simctl spawn`
+# (the iOS analogue of Android Phase 0's "just run the binary" smoke
+# test). Device builds (Phase B) link the same objects as libemu.a into
+# an Xcode app target instead — see emu/iOS/README.md.
+#
+# iOS shares Apple's libc with macOS, so Phase A reuses emu/MacOSX/ and
+# emu/port/ sources UNCHANGED: the :N: rules at the bottom point each
+# object at its origin. Only mkfiles/mkfile-iOS-arm64 (the toolchain)
+# and this directory's config differ. Phase B forks any source that has
+# to diverge (e.g. cmd.c, which fork/execs host commands — impossible
+# under the iOS app sandbox).
+#
+# Host is always macOS for an iOS cross-build, so the host tools come
+# from mkhost-MacOSX and the target flags from mkfile-iOS-arm64. We do
+# NOT go through mkconfig here: its auto-detect would load the native
+# MacOSX target flags instead of the iOS ones.
+
+SYSTARG=iOS
+OBJTYPE=arm64
+SHELLTYPE=sh
+OBJDIR=$SYSTARG/$OBJTYPE
+<$ROOT/mkfiles/mkhost-MacOSX
+<$ROOT/mkfiles/mkfile-iOS-arm64
+
+#Configurable parameters
+
+CONF=emu			#default configuration
+CONFLIST=emu
+CLEANCONFLIST=
+
+INSTALLDIR=$ROOT/$SYSTARG/$OBJTYPE/bin	#path of directory where kernel is installed
+
+#end configurable parameters
+
+<| AWK=$AWK sh ../port/mkdevlist < $CONF	#sets $IP, $DEVS, $PORT, $LIBS
+
+OBJ=\
+	asm-$OBJTYPE.$O\
+	os.$O\
+	stubs-headless.$O\
+	$CONF.root.$O\
+	lock.$O\
+	$DEVS\
+	$PORT\
+
+HFILES=\
+
+CFLAGS=\
+	'-DROOT="'$ROOT'"'\
+	-DEMU -I. -I../port\
+	-I$ROOT/$SYSTARG/$OBJTYPE/include\
+	-I$ROOT/include\
+	-I$ROOT/libinterp\
+	$CTHREADFLAGS $CFLAGS $EMUOPTIONS\
+
+KERNDATE=0
+
+SYSLIBS=\
+	-lm\
+	-lpthread\
+	-framework CoreFoundation\
+
+default:V:	$O.$CONF
+
+$O.$CONF:	$OBJ $CONF.c $CONF.root.h
+	$CC $CFLAGS -DKERNDATE=$KERNDATE $CONF.c
+	$LD $LDFLAGS -o $target $OBJ $CONF.$O $LIBFILES $SYSLIBS
+
+install:V: $O.$CONF
+	cp $O.$CONF $INSTALLDIR/$CONF
+
+<../port/portmkfile
+
+# Phase A source reuse — iOS == macOS libc. Fork any of these into
+# emu/iOS/ in Phase B if it needs iOS-specific code.
+os.c:N:			../MacOSX/os.c
+cmd.c:N:		../MacOSX/cmd.c
+asm-arm64.s:N:		../MacOSX/asm-arm64.s
+stubs-headless.c:N:	../MacOSX/stubs-headless.c
+deveia.c:N:		../MacOSX/deveia.c
+ipif.c:N:		../FreeBSD/ipif.c
+devfs.c:N:		../port/devfs-posix.c

--- a/iOS/arm64/include/emu.h
+++ b/iOS/arm64/include/emu.h
@@ -1,0 +1,6 @@
+/*
+ * iOS arm64 — emu machine-specific declarations (FPU save/restore,
+ * `up`, osjmpbuf). Identical to macOS arm64. Forward to the macOS
+ * header; fork only on divergence.
+ */
+#include "../../../MacOSX/arm64/include/emu.h"

--- a/iOS/arm64/include/fpuctl.h
+++ b/iOS/arm64/include/fpuctl.h
@@ -1,0 +1,5 @@
+/*
+ * iOS arm64 — fpu control. Identical to macOS arm64 (same FPCR/fenv
+ * abstraction). Forward to the macOS header; fork only on divergence.
+ */
+#include "../../../MacOSX/arm64/include/fpuctl.h"

--- a/iOS/arm64/include/lib9.h
+++ b/iOS/arm64/include/lib9.h
@@ -1,0 +1,10 @@
+/*
+ * iOS arm64 — lib9 definitions.
+ *
+ * iOS ships Apple's BSD-derived libc, identical to macOS for everything
+ * lib9 cares about (types, ABI, endianness, the host-conflict renames).
+ * Rather than duplicate the 400-line macOS header and let the two drift,
+ * forward to it. Fork into a real file here only if iOS ever needs to
+ * diverge (hellaphone Phase 2; see emu/iOS/README.md).
+ */
+#include "../../../MacOSX/arm64/include/lib9.h"

--- a/mkfiles/mkfile-iOS-arm64
+++ b/mkfiles/mkfile-iOS-arm64
@@ -1,0 +1,65 @@
+# Target flags for iOS arm64, cross-compiled with the Xcode toolchain
+# from a macOS host (you can only build for iOS on a Mac). This is the
+# Apple-toolchain analogue of mkfiles/mkfile-Android-arm64 — it forks
+# from mkfile-MacOSX-arm64 and swaps native `cc` for `xcrun`-resolved
+# clang with an -isysroot and an iOS target triple.
+#
+# hellaphone Phase 2. Phase A builds a headless o.emu against the
+# iphonesimulator SDK and runs it via `xcrun simctl spawn` — the iOS
+# analogue of Android Phase 0's "just run the binary" smoke test.
+#
+# SDK + triple are selectable so the same file serves both targets;
+# the build driver (build-ios-arm64.sh) overrides on the mk command
+# line, and Plan 9 mk freezes command-line vars so they win:
+#   simulator (Phase A, default): IOSSDK=iphonesimulator
+#                                 IOSTRIPLE=arm64-apple-ios$IOSMIN-simulator
+#   device    (Phase B):          IOSSDK=iphoneos
+#                                 IOSTRIPLE=arm64-apple-ios$IOSMIN
+#
+# No JIT. Apple's W^X policy denies executable mmap/mprotect to stock
+# apps, so libinterp/comp-arm64.c is unusable on-device and emu must run
+# -c0 (pure interpreter). Nothing here enables the ARM64 JIT.
+
+TARGMODEL=	Posix
+TARGSHTYPE=	sh
+CPUS=		arm64
+
+O=		o
+OS=		o
+
+# minimum iOS version. Start at 14; raise only if an API forces it.
+IOSMIN=		14.0
+IOSSDK=		iphonesimulator
+IOSTRIPLE=	arm64-apple-ios$IOSMIN-simulator
+
+SDKPATH=	`{xcrun --sdk $IOSSDK --show-sdk-path}
+XCLANG=		`{xcrun --sdk $IOSSDK -f clang}
+
+AR=		`{xcrun --sdk $IOSSDK -f ar}
+ARFLAGS=	rcs
+
+AS=		$XCLANG -c -target $IOSTRIPLE -isysroot $SDKPATH
+ASFLAGS=
+
+CC=		$XCLANG -c -target $IOSTRIPLE -isysroot $SDKPATH
+CFLAGS=		-g\
+		-O\
+		-fno-strict-aliasing\
+		-fstack-protector-strong\
+		-Wuninitialized -Wunused-variable -Wreturn-type -Wimplicit\
+		-Werror=return-type -Werror=implicit-function-declaration\
+		-I$ROOT/iOS/arm64/include\
+		-I$ROOT/include\
+		-DIOS_ARM64\
+		-DMACOSX_ARM64
+
+ANSICPP=
+LD=		$XCLANG -target $IOSTRIPLE -isysroot $SDKPATH
+LDFLAGS=
+
+SYSLIBS=
+
+YACC=		yacc
+YFLAGS=		-d
+
+MACOSINF=caseinsensitive	# nobble .S rules


### PR DESCRIPTION
## Summary

This PR introduces the design specification and build scaffolding for InferNode on iOS (hellaphone Phase 2). It establishes the iOS port as a fork of macOS rather than Android, leveraging Apple's BSD-derived libc to avoid the Bionic compatibility gaps that dominated the Android port. Phase A targets the iOS Simulator with a headless interpreter-only build (`-c0`) to prove the Dis VM, 9P, and Veltro harness work under Apple's W^X runtime constraints before any UIKit investment.

## Changes

- **`docs/IOS.md`** — Complete design specification for the iOS port, covering:
  - Why iOS forks from macOS (shared libc), not Android
  - The four hard iOS constraints (no JIT, no Termux, no fork/exec, UIKit on main thread)
  - Build approach (mk cross-compile + Xcode wrapper)
  - Three-phase rollout (A: simulator headless, B: device + SDL3 GUI, C: on-device inference)
  - Open questions and non-goals

- **`build-ios-arm64.sh`** — Cross-compile driver for iOS arm64, modeled on `build-android-ndk-arm64.sh`:
  - Validates macOS host + Xcode toolchain
  - Selects SDK (iphonesimulator vs iphoneos) and target triple via `IOSSDK` env var
  - Cross-compiles C libraries and headless emulator against the Xcode toolchain
  - Outputs `emu/iOS/o.emu` for simulator or unsigned device slice for Phase B

- **`emu/iOS/README.md`** — Directory status and mechanics:
  - Phase A scaffolding (not yet compiled)
  - Key insight: iOS reuses `emu/MacOSX/` and `emu/port/` sources unchanged via `:N:` rules
  - Expected SDK gaps (PPC headers, Mach VM restrictions) to surface on first build
  - Phase B/C roadmap

- **`emu/iOS/emu`** — Emulator configuration for iOS:
  - Headless device set (no audio, no GUI in Phase A)
  - `macjit = 0` — enforces interpreter-only (`-c0`) due to W^X policy

- **`emu/iOS/mkfile-g`** — Headless build rules:
  - Reuses `emu/MacOSX/os.c`, `cmd.c`, `asm-arm64.s`, `stubs-headless.c`, etc. via `:N:` rules
  - Includes only Phase A dependencies (no SDL3, no audio)
  - Explicitly does NOT go through mkconfig (would load native macOS flags instead of iOS)

- **`mkfiles/mkfile-iOS-arm64`** — Target flags for iOS arm64 cross-compile:
  - Uses `xcrun` to resolve Xcode clang, ar, ld with `-isysroot` and iOS target triple
  - Supports both simulator (`-simulator` suffix) and device via `IOSSDK` and `IOSTRIPLE` vars
  - Minimum iOS 14.0; no JIT flags
  - Defines `-DIOS_ARM64` and `-DMACOSX_ARM64` for conditional compilation

- **`iOS/arm64/include/{lib9.h, emu.h, fpuctl.h}`** — Platform headers:
  - One-line forwards to `MacOSX/arm64/include/` equivalents (single source of truth)
  - Will be forked into real files only if iOS diverges from macOS

## Testing

No testing needed for this PR. This is design documentation and build scaffolding; the first actual compilation will occur on a macOS host with Xcode when Phase A begins. The build driver and mkfiles are structured to surface iOS SDK gaps (e.g., missing PPC headers, Mach VM restrictions) on that first build, which will be captured against INFR-107.

## Checklist

- [x] Code follows the existing style of the file(s) modified
- [

https://claude.ai/code/session_01YD3K9QZWZ3GNJYNvdfUcfs