### PR TITLE
android: mobile parity pickup — INFR-141 + INFR-121 + x86_64 NDK + asset re-extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,9 @@ android-app/.gradle/
 android-app/build/
 android-app/app/build/
 android-app/local.properties
+
+# Multi-arch APK build artefacts (INFR-67 x86_64 NDK target).
+android-app/app/src/main/jniLibs/x86_64/libemu.so
+android-app/app/src/main/jniLibs/x86_64/libSDL3.so
+build-android-apk.ndk-arm64-v8a.log
+build-android-apk.ndk-x86_64.log

--- a/Android/amd64/include/emu.h
+++ b/Android/amd64/include/emu.h
@@ -3,25 +3,36 @@
  * floating-point save and restore, signal handling primitive, and
  * implementation of the current-process variable `up'.
  *
- * Android x86_64 version. Bionic always provides pthreads on Android,
+ * Android x86_64 version.  Bionic always provides pthreads on Android,
  * so we don't carry the no-pthreads stack-pointer asm path that
  * Linux/amd64/include/emu.h has — getup() is always external (from
- * emu/Linux/os-Linux-pthreads.c at link time). The FPU save area
- * matches x86_64 FXSAVE: 512 bytes, 16-byte aligned.
+ * emu/Linux/os-Linux-pthreads.c at link time).
  */
 
 extern Proc *getup(void);
 #define	up	(getup())
 
 /*
- * This structure must agree with FPsave and FPrestore asm routines.
- * x86_64 FP/SSE state is 512 bytes (FXSAVE area); requires 16-byte alignment.
+ * Stub FPU state.  emu/Android/asm-amd64.S's FPsave / FPrestore are
+ * no-ops (Bionic + the host kernel save FP context on thread switch),
+ * so we DO NOT need the 16-byte alignment that FXSAVE would require.
+ *
+ * Why this matters: Osenv embeds an FPU.  newprog (emu/port/dis.c)
+ * places each new Osenv at `(uchar*)n + sizeof(Prog)` inside a single
+ * malloc — when FPU asked for aligned(16), the C standard required
+ * Osenv to be 16-aligned too.  sizeof(Prog) is not a multiple of 16
+ * in our build, so the resulting Osenv* was misaligned on x86_64;
+ * Clang inlined the memmove at dis.c:183 with MOVAPS / MOVDQA
+ * (aligned SIMD moves), which faulted on the first new process →
+ * SIGSEGV at newprog+725 during SDL_main boot in the APK.  Match
+ * arm64's stub layout (see Android/arm64/include/emu.h) and the
+ * problem goes away.
  */
 typedef struct FPU FPU;
 struct FPU
 {
-	uchar	env[512] __attribute__((aligned(16)));
-} __attribute__((aligned(16)));
+	uchar	env[32];	/* placeholder — Bionic handles FP state */
+};
 
 #define KSTACK (32 * 1024)
 

--- a/Android/amd64/include/emu.h
+++ b/Android/amd64/include/emu.h
@@ -1,0 +1,29 @@
+/*
+ * system- and machine-specific declarations for emu:
+ * floating-point save and restore, signal handling primitive, and
+ * implementation of the current-process variable `up'.
+ *
+ * Android x86_64 version. Bionic always provides pthreads on Android,
+ * so we don't carry the no-pthreads stack-pointer asm path that
+ * Linux/amd64/include/emu.h has — getup() is always external (from
+ * emu/Linux/os-Linux-pthreads.c at link time). The FPU save area
+ * matches x86_64 FXSAVE: 512 bytes, 16-byte aligned.
+ */
+
+extern Proc *getup(void);
+#define	up	(getup())
+
+/*
+ * This structure must agree with FPsave and FPrestore asm routines.
+ * x86_64 FP/SSE state is 512 bytes (FXSAVE area); requires 16-byte alignment.
+ */
+typedef struct FPU FPU;
+struct FPU
+{
+	uchar	env[512] __attribute__((aligned(16)));
+} __attribute__((aligned(16)));
+
+#define KSTACK (32 * 1024)
+
+typedef sigjmp_buf osjmpbuf;
+#define	ossetjmp(buf)	sigsetjmp(buf, 1)

--- a/Android/amd64/include/fpuctl.h
+++ b/Android/amd64/include/fpuctl.h
@@ -1,0 +1,73 @@
+/*
+ * Android x86_64 fpu support — Bionic libc + x86_64 ABI.
+ * Counterpart to Android/arm64/include/fpuctl.h, but x86 instead of arm.
+ *
+ * The instruction set is identical to Linux/amd64 x86_64; the only
+ * difference between glibc and Bionic is in libc-level wrappers we
+ * don't touch here, so reuse the same inline-asm controls.
+ * Inferno doesn't actually need precise FP-control on Android — these
+ * are kept for API symmetry with the desktop builds and to satisfy
+ * lib9.h's expectations.
+ */
+static void
+setfcr(ulong fcr)
+{
+	unsigned short cw = (unsigned short)(fcr ^ 0x3f);
+	__asm__ volatile (
+		"fldcw %0"
+		: /* no output */
+		: "m" (cw)
+	);
+}
+
+static ulong
+getfcr(void)
+{
+	unsigned short cw;
+	__asm__ volatile (
+		"fstcw %0"
+		: "=m" (cw)
+	);
+	return (ulong)(cw ^ 0x3f);
+}
+
+static ulong
+getfsr(void)
+{
+	unsigned short sw;
+	__asm__ volatile (
+		"fstsw %0"
+		: "=m" (sw)
+	);
+	return (ulong)sw;
+}
+
+static void
+setfsr(ulong fsr)
+{
+	(void)fsr;
+	__asm__ volatile ("fclex");
+}
+
+/* FCR - FPU Control Register bits */
+#define	FPINEX	(1<<5)
+#define	FPUNFL	((1<<4)|(1<<1))
+#define	FPOVFL	(1<<3)
+#define	FPZDIV	(1<<2)
+#define	FPINVAL	(1<<0)
+#define	FPRNR	(0<<10)
+#define	FPRZ	(3<<10)
+#define	FPRPINF	(2<<10)
+#define	FPRNINF	(1<<10)
+#define	FPRMASK	(3<<10)
+#define	FPPEXT	(3<<8)
+#define	FPPSGL	(0<<8)
+#define	FPPDBL	(2<<8)
+#define	FPPMASK	(3<<8)
+
+/* FSR - FPU Status Register bits (same as FCR for exceptions) */
+#define	FPAINEX	FPINEX
+#define	FPAOVFL	FPOVFL
+#define	FPAUNFL	FPUNFL
+#define	FPAZDIV	FPZDIV
+#define	FPAINVAL	FPINVAL

--- a/Android/amd64/include/lib9.h
+++ b/Android/amd64/include/lib9.h
@@ -1,0 +1,484 @@
+/*
+ * lib9.h for ARM64 Linux (Jetson, etc.)
+ * Based on MacOSX/arm64/include/lib9.h
+ * Adapted for Linux environment with proper 64-bit types
+ */
+
+#define	USE_PTHREADS
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+#define _XOPEN_SOURCE  500
+#define _LARGEFILE_SOURCE	1
+#define _LARGEFILE64_SOURCE	1
+#define _FILE_OFFSET_BITS 64
+#ifdef USE_PTHREADS
+#define	_REENTRANT	1
+#endif
+
+#include <features.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#define sync __os_sync
+#include <unistd.h>
+#undef sync
+#include <errno.h>
+#define __NO_STRING_INLINES
+#include <string.h>
+#include <fcntl.h>
+#include <setjmp.h>
+#include <float.h>
+#include <time.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <endian.h>
+/* #include <math.h>  - commented out to avoid isnan macro conflict with fdlibm */
+
+#ifdef __BIONIC__
+/* Bionic does not expose the BSD shorthand types `ushort`/`uint` via
+ * <sys/types.h> the way glibc does with _BSD_SOURCE / _DEFAULT_SOURCE.
+ * `uchar` and `ulong` are already typedef'd explicitly below, but the
+ * 89-odd uses of `ushort`/`uint` across lib9/limbo/libinterp/utils rely
+ * on the implicit glibc definitions. Provide them here so Android/Termux
+ * builds compile unchanged. Phase 0 hellaphone shim. */
+typedef unsigned short ushort;
+typedef unsigned int   uint;
+#endif
+
+#define nil		((void*)0)
+
+typedef	unsigned char	uchar;
+typedef unsigned long	ulong;
+typedef	  signed char	schar;
+typedef	long long	vlong;
+typedef	unsigned long long	uvlong;
+typedef ushort		Rune;
+typedef uint32_t	u32int;
+typedef uvlong u64int;
+
+typedef uint32_t	mpdigit;	/* for /sys/include/mp.h */
+typedef uint16_t u16int;
+typedef uint8_t u8int;
+typedef uintptr_t uintptr;
+typedef intptr_t intptr;
+
+typedef int8_t	int8;
+typedef uint8_t	uint8;
+typedef int16_t	int16;
+typedef uint16_t	uint16;
+typedef int32_t	int32;
+typedef uint32_t	uint32;
+typedef int64_t	int64;
+typedef uint64_t	uint64;
+
+/* handle conflicts with host os libs */
+#define	getwd	infgetwd
+#define scalb	infscalb
+#define div 	infdiv
+#define panic	infpanic
+#define rint	infrint
+#define	rcmd	infrcmd
+#define	pow10	infpow10
+/* Bionic's <stdio.h> declares rewind(FILE*) unconditionally, colliding with
+ * limbo/typecheck.c's static rewind(Node*) for AST traversal. Rename it
+ * the same way the conflicts above are handled. Only 2 call sites
+ * (limbo/typecheck.c) and neither uses stdio's rewind. Phase 0 hellaphone. */
+#define	rewind	infrewind
+/* Bionic's <string.h> declares memrchr as an overloadable __attribute_pure__
+ * function, colliding with emu/port/chan.c's own memrchr helper. One
+ * definition and one caller, both in chan.c — rename is safe. Phase 0. */
+#define	memrchr	infmemrchr
+
+#ifndef EMU
+typedef struct Proc Proc;
+#endif
+
+/*
+ * math module dtoa - arm64 is little endian
+ * (endian.h already defines __LITTLE_ENDIAN, so we just check it)
+ */
+#ifndef __LITTLE_ENDIAN
+#define __LITTLE_ENDIAN 1234
+#endif
+
+/*
+ * arm64 has 64-bit long, so we need USE_FPdbleword
+ * to correctly access double's 32-bit halves in dtoa.c
+ */
+#define USE_FPdbleword
+
+typedef union {
+	double	x;
+	struct {
+		u32int	lo;	/* little endian: low word first */
+		u32int	hi;
+	};
+} FPdbleword;
+
+#define	USED(x)		if(x){}else{}
+#define	SET(x)
+
+#define nelem(x)	(sizeof(x)/sizeof((x)[0]))
+#undef offsetof
+#undef assert
+#define	offsetof(s, m)	(ulong)(&(((s*)0)->m))
+#define	assert(x)	if(x){}else _assert("x")
+
+extern	char*	strecpy(char*, char*, char*);
+extern	char*	strdup(const char*);
+extern	int	cistrncmp(char*, char*, int);
+extern	int	cistrcmp(char*, char*);
+extern	char*	cistrstr(char*, char*);
+extern	int	tokenize(char*, char**, int);
+extern	vlong	strtoll(const char*, char**, int);
+#define	qsort	infqsort
+extern	void	qsort(void*, long, long, int (*)(void*, void*));
+
+enum
+{
+	UTFmax		= 3,
+	Runesync	= 0x80,
+	Runeself	= 0x80,
+	Runeerror	= 0x80
+};
+
+extern	int	runetochar(char*, Rune*);
+extern	int	chartorune(Rune*, char*);
+extern	int	runelen(long);
+extern	int	runenlen(Rune*, int);
+extern	int	fullrune(char*, int);
+extern	int	utflen(char*);
+extern	int	utfnlen(char*, long);
+extern	char*	utfrune(char*, long);
+extern	char*	utfrrune(char*, long);
+extern	char*	utfutf(char*, char*);
+extern	char*	utfecpy(char*, char*, char*);
+
+extern	Rune*	runestrcat(Rune*, Rune*);
+extern	Rune*	runestrchr(Rune*, Rune);
+extern	int	runestrcmp(Rune*, Rune*);
+extern	Rune*	runestrcpy(Rune*, Rune*);
+extern	Rune*	runestrncpy(Rune*, Rune*, long);
+extern	Rune*	runestrecpy(Rune*, Rune*, Rune*);
+extern	Rune*	runestrdup(Rune*);
+extern	Rune*	runestrncat(Rune*, Rune*, long);
+extern	int	runestrncmp(Rune*, Rune*, long);
+extern	Rune*	runestrrchr(Rune*, Rune);
+extern	long	runestrlen(Rune*);
+extern	Rune*	runestrstr(Rune*, Rune*);
+
+extern	Rune	tolowerrune(Rune);
+extern	Rune	totitlerune(Rune);
+extern	Rune	toupperrune(Rune);
+extern	int	isalpharune(Rune);
+extern	int	islowerrune(Rune);
+extern	int	isspacerune(Rune);
+extern	int	istitlerune(Rune);
+extern	int	isupperrune(Rune);
+
+extern	void*	malloc(size_t);
+extern	void*	mallocz(ulong, int);
+extern	void	free(void*);
+extern	ulong	msize(void*);
+extern	void*	calloc(size_t, size_t);
+extern	void*	realloc(void*, size_t);
+extern	void		setmalloctag(void*, ulong);
+extern	void		setrealloctag(void*, ulong);
+extern	ulong	getmalloctag(void*);
+extern	ulong	getrealloctag(void*);
+extern	void*	malloctopoolblock(void*);
+
+typedef struct Fmt	Fmt;
+struct Fmt{
+	uchar	runes;
+	void	*start;
+	void	*to;
+	void	*stop;
+	int	(*flush)(Fmt *);
+	void	*farg;
+	int	nfmt;
+	va_list	args;
+	int	r;
+	int	width;
+	int	prec;
+	ulong	flags;
+};
+
+enum{
+	FmtWidth	= 1,
+	FmtLeft		= FmtWidth << 1,
+	FmtPrec		= FmtLeft << 1,
+	FmtSharp	= FmtPrec << 1,
+	FmtSpace	= FmtSharp << 1,
+	FmtSign		= FmtSpace << 1,
+	FmtZero		= FmtSign << 1,
+	FmtUnsigned	= FmtZero << 1,
+	FmtShort	= FmtUnsigned << 1,
+	FmtLong		= FmtShort << 1,
+	FmtVLong	= FmtLong << 1,
+	FmtComma	= FmtVLong << 1,
+	FmtByte	= FmtComma << 1,
+	FmtFlag		= FmtByte << 1
+};
+
+extern	int	print(char*, ...);
+extern	char*	seprint(char*, char*, char*, ...);
+extern	char*	vseprint(char*, char*, char*, va_list);
+extern	int	snprint(char*, int, char*, ...);
+extern	int	vsnprint(char*, int, char*, va_list);
+extern	char*	smprint(char*, ...);
+extern	char*	vsmprint(char*, va_list);
+extern	int	sprint(char*, char*, ...);
+extern	int	fprint(int, char*, ...);
+extern	int	vfprint(int, char*, va_list);
+
+extern	int	runesprint(Rune*, char*, ...);
+extern	int	runesnprint(Rune*, int, char*, ...);
+extern	int	runevsnprint(Rune*, int, char*, va_list);
+extern	Rune*	runeseprint(Rune*, Rune*, char*, ...);
+extern	Rune*	runevseprint(Rune*, Rune*, char*, va_list);
+extern	Rune*	runesmprint(char*, ...);
+extern	Rune*	runevsmprint(char*, va_list);
+
+extern	int	fmtfdinit(Fmt*, int, char*, int);
+extern	int	fmtfdflush(Fmt*);
+extern	int	fmtstrinit(Fmt*);
+extern	char*	fmtstrflush(Fmt*);
+extern	int	runefmtstrinit(Fmt*);
+extern	Rune*	runefmtstrflush(Fmt*);
+
+extern	int	fmtinstall(int, int (*)(Fmt*));
+extern	int	dofmt(Fmt*, char*);
+extern	int	dorfmt(Fmt*, Rune*);
+extern	int	fmtprint(Fmt*, char*, ...);
+extern	int	fmtvprint(Fmt*, char*, va_list);
+extern	int	fmtrune(Fmt*, int);
+extern	int	fmtstrcpy(Fmt*, char*);
+extern	int	fmtrunestrcpy(Fmt*, Rune*);
+extern	int	errfmt(Fmt *f);
+
+extern	char	*unquotestrdup(char*);
+extern	Rune	*unquoterunestrdup(Rune*);
+extern	char	*quotestrdup(char*);
+extern	Rune	*quoterunestrdup(Rune*);
+extern	int	quotestrfmt(Fmt*);
+extern	int	quoterunestrfmt(Fmt*);
+extern	void	quotefmtinstall(void);
+extern	int	(*doquote)(int);
+
+extern	int	nrand(int);
+extern	ulong	truerand(void);
+extern	ulong	ntruerand(ulong);
+
+extern	int	isNaN(double);
+extern	int	isInf(double, int);
+extern	double	pow(double, double);
+
+typedef struct Tm Tm;
+struct Tm {
+	int	sec;
+	int	min;
+	int	hour;
+	int	mday;
+	int	mon;
+	int	year;
+	int	wday;
+	int	yday;
+	char	zone[4];
+	int	tzoff;
+};
+extern	vlong	osnsec(void);
+#define	nsec	osnsec
+
+extern	void	_assert(char*);
+extern	double	charstod(int(*)(void*), void*);
+extern	char*	cleanname(char*);
+extern	double	frexp(double, int*);
+extern	int	getfields(char*, char**, int, int, char*);
+extern	char*	getuser(void);
+extern	char*	getwd(char*, int);
+extern	double	ipow10(int);
+extern	double	ldexp(double, int);
+extern	double	modf(double, double*);
+extern	void	perror(const char*);
+extern	double	pow10(int);
+extern	uvlong	strtoull(const char*, char**, int);
+extern	void	sysfatal(char*, ...);
+extern	int	dec64(uchar*, int, char*, int);
+extern	int	enc64(char*, int, uchar*, int);
+extern	int	dec32(uchar*, int, char*, int);
+extern	int	enc32(char*, int, uchar*, int);
+extern	int	dec16(uchar*, int, char*, int);
+extern	int	enc16(char*, int, uchar*, int);
+extern	int	encodefmt(Fmt*);
+
+/* use builtin for arm64 */
+static __inline uintptr getcallerpc(void* dummy) {
+	(void)dummy;
+	return (uintptr)__builtin_return_address(0);
+}
+
+typedef
+struct Lock {
+	int	val;
+	int	pid;
+} Lock;
+
+extern int	_tas(int*);
+
+extern	void	lock(Lock*);
+extern	void	unlock(Lock*);
+extern	int	canlock(Lock*);
+
+typedef struct QLock QLock;
+struct QLock
+{
+	Lock	use;
+	Proc	*head;
+	Proc	*tail;
+	int	locked;
+};
+
+extern	void	qlock(QLock*);
+extern	void	qunlock(QLock*);
+extern	int	canqlock(QLock*);
+extern	void	_qlockinit(ulong (*)(ulong, ulong));
+
+typedef
+struct RWLock
+{
+	Lock	l;
+	QLock	x;
+	QLock	k;
+	int	readers;
+} RWLock;
+
+extern	int	canrlock(RWLock*);
+extern	int	canwlock(RWLock*);
+extern	void	rlock(RWLock*);
+extern	void	runlock(RWLock*);
+extern	void	wlock(RWLock*);
+extern	void	wunlock(RWLock*);
+
+#define NETPATHLEN 40
+
+#define	STATMAX	65535U
+#define	DIRMAX	(sizeof(Dir)+STATMAX)
+#define	ERRMAX	128
+
+#define	MORDER	0x0003
+#define	MREPL	0x0000
+#define	MBEFORE	0x0001
+#define	MAFTER	0x0002
+#define	MCREATE	0x0004
+#define	MCACHE	0x0010
+#define	MMASK	0x0017
+
+#define	OREAD	0
+#define	OWRITE	1
+#define	ORDWR	2
+#define	OEXEC	3
+#define	OTRUNC	16
+#define	OCEXEC	32
+#define	ORCLOSE	64
+#define	OEXCL	0x1000
+
+#define	AEXIST	0
+#define	AEXEC	1
+#define	AWRITE	2
+#define	AREAD	4
+
+#define QTDIR		0x80
+#define QTAPPEND	0x40
+#define QTEXCL		0x20
+#define QTMOUNT		0x10
+#define QTAUTH		0x08
+#define QTFILE		0x00
+
+#define DMDIR		0x80000000
+#define DMAPPEND	0x40000000
+#define DMEXCL		0x20000000
+#define DMMOUNT		0x10000000
+#define DMAUTH		0x08000000
+#define DMREAD		0x4
+#define DMWRITE		0x2
+#define DMEXEC		0x1
+
+typedef
+struct Qid
+{
+	uvlong	path;
+	ulong	vers;
+	uchar	type;
+} Qid;
+
+typedef
+struct Dir {
+	ushort	type;
+	uint	dev;
+	Qid	qid;
+	ulong	mode;
+	ulong	atime;
+	ulong	mtime;
+	vlong	length;
+	char	*name;
+	char	*uid;
+	char	*gid;
+	char	*muid;
+} Dir;
+
+extern	Dir*	dirstat(char*);
+extern	Dir*	dirfstat(int);
+extern	int	dirwstat(char*, Dir*);
+extern	int	dirfwstat(int, Dir*);
+extern	long	dirread(int, Dir**);
+extern	void	nulldir(Dir*);
+extern	long	dirreadall(int, Dir**);
+
+typedef
+struct Waitmsg
+{
+	int pid;
+	ulong time[3];
+	char	*msg;
+} Waitmsg;
+
+extern	void	_exits(char*);
+extern	void	exits(char*);
+extern	int	create(char*, int, int);
+extern	int	errstr(char*, uint);
+extern	void	perror(const char*);
+extern	long	readn(int, void*, long);
+extern	int	remove(const char*);
+extern	void	rerrstr(char*, uint);
+extern	vlong	seek(int, vlong, int);
+extern	int	segflush(void*, ulong);
+extern	void	werrstr(char*, ...);
+
+extern char *argv0;
+#define	ARGBEGIN	for((argv0||(argv0=*argv)),argv++,argc--;\
+			    argv[0] && argv[0][0]=='-' && argv[0][1];\
+			    argc--, argv++) {\
+				char *_args, *_argt;\
+				Rune _argc;\
+				_args = &argv[0][1];\
+				if(_args[0]=='-' && _args[1]==0){\
+					argc--; argv++; break;\
+				}\
+				_argc = 0;\
+				while(*_args && (_args += chartorune(&_argc, _args)))\
+				switch(_argc)
+#define	ARGEND		SET(_argt);USED(_argt);USED(_argc); USED(_args);}USED(argv); USED(argc);
+#define	ARGF()		(_argt=_args, _args="",\
+			(*_argt? _argt: argv[1]? (argc--, *++argv): 0))
+#define	EARGF(x)	(_argt=_args, _args="",\
+			(*_argt? _argt: argv[1]? (argc--, *++argv): ((x), abort(), (char*)0)))
+
+#define	ARGC()		_argc
+
+#define	setbinmode()

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -25,10 +25,14 @@ android {
         versionName = "0.1.0-phase1c"
 
         ndk {
-            // Only ship the ABIs we actually cross-compile for. Adding
-            // x86_64 would let us run in Android Studio AVDs but needs a
-            // separate cross-build pass through our mkfiles.
-            abiFilters += listOf("arm64-v8a")
+            // Ship every ABI for which we have a cross-built libemu.so
+            // staged in jniLibs/. build-android-apk.sh produces these:
+            //   --abi=arm64-v8a (default)  → phone hardware
+            //   --abi=x86_64               → Android emulator on x86 hosts
+            //   --abi=both                 → multi-arch APK
+            // Listing both here is harmless when only one is built —
+            // Gradle silently skips ABIs that have no jniLibs entries.
+            abiFilters += listOf("arm64-v8a", "x86_64")
         }
     }
 

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -84,7 +84,11 @@ class InfernodeSDLActivity : SDLActivity() {
         val infernoRoot = File(filesDir, "inferno-root")
         val args = mutableListOf(
             "-s",
-            "-c1",
+            // TEMPORARY x86_64-debug: dropped to -c0 (interpreter only) to
+            // isolate a GC crash on Android x86_64 emulator. JIT for amd64
+            // is comp-amd64.c, untested in our Bionic build. Flip back to
+            // -c1 once that path is validated (task #69).
+            "-c0",
             "-pheap=1024m",
             "-pmain=1024m",
             "-pimage=1024m",

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.content.res.AssetManager
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -84,11 +85,15 @@ class InfernodeSDLActivity : SDLActivity() {
         val infernoRoot = File(filesDir, "inferno-root")
         val args = mutableListOf(
             "-s",
-            // TEMPORARY x86_64-debug: dropped to -c0 (interpreter only) to
-            // isolate a GC crash on Android x86_64 emulator. JIT for amd64
-            // is comp-amd64.c, untested in our Bionic build. Flip back to
-            // -c1 once that path is validated (task #69).
-            "-c0",
+            // JIT compile mode is ABI-aware. arm64-v8a uses -c1 (the
+            // libinterp/comp-arm64.c JIT is the validated, shipped path
+            // and is what every phone runs). x86_64 falls back to -c0
+            // (interpreter only) because libinterp/comp-amd64.c hasn't
+            // been validated against Bionic yet — without the override
+            // the APK SIGSEGVs in rungc walking partially-compiled
+            // Modlinks on the emulator. Flip x86_64 to -c1 once the
+            // amd64 JIT is validated (INFR-67 follow-up).
+            jitFlagForRuntime(),
             "-pheap=1024m",
             "-pmain=1024m",
             "-pimage=1024m",
@@ -142,16 +147,30 @@ class InfernodeSDLActivity : SDLActivity() {
         val layout = mLayout
         if (layout != null) {
             ViewCompat.setOnApplyWindowInsetsListener(layout) { v, insets ->
+                // System bars + display cutout: permanent safe-area
+                // (status bar, notch, navigation bar).
                 val bars = insets.getInsets(
                     WindowInsetsCompat.Type.systemBars()
                             or WindowInsetsCompat.Type.displayCutout()
                 )
+                // IME (soft keyboard): transient inset that grows when
+                // the keyboard opens. Lucifer's text input row lives at
+                // the very bottom of the canvas; without this inset the
+                // keyboard hides it. iOS handles the same problem in
+                // shared draw-sdl3 via SDL_SetTextInputArea (see
+                // update_text_input_area, gated TARGET_OS_IOS) — this
+                // is the Android counterpart of that fix. Same behaviour
+                // visible to the user, mechanism differs because Android
+                // soft-keyboard avoidance goes through Insets, not SDL.
+                val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+                val bottom = if (ime.bottom > bars.bottom) ime.bottom else bars.bottom
                 Log.i(
                     TAG,
-                    "applying insets: top=${bars.top} bottom=${bars.bottom} " +
-                        "left=${bars.left} right=${bars.right}"
+                    "applying insets: top=${bars.top} bottom=$bottom " +
+                        "left=${bars.left} right=${bars.right} " +
+                        "(bars.bottom=${bars.bottom} ime.bottom=${ime.bottom})"
                 )
-                v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+                v.setPadding(bars.left, bars.top, bars.right, bottom)
                 WindowInsetsCompat.CONSUMED
             }
         } else {
@@ -171,6 +190,19 @@ class InfernodeSDLActivity : SDLActivity() {
                 /* requestCode = */ 1
             )
         }
+    }
+
+    /**
+     * Pick the JIT compile-mode flag (-c0 / -c1) based on the running
+     * ABI. Returns "-c1" on arm64-v8a (the validated JIT path), "-c0"
+     * everywhere else.  Build.SUPPORTED_ABIS[0] is the preferred ABI
+     * the loader chose for this process, which is what Android's
+     * dynamic loader picked when loading libemu.so out of jniLibs/
+     * — so it matches the architecture libemu.so was compiled for.
+     */
+    private fun jitFlagForRuntime(): String {
+        val abi = Build.SUPPORTED_ABIS.firstOrNull() ?: ""
+        return if (abi == "arm64-v8a") "-c1" else "-c0"
     }
 
     private fun extractInfernoRootIfNeeded() {

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -175,9 +175,21 @@ class InfernodeSDLActivity : SDLActivity() {
         // asset staging (INFR-115). Devices that already extracted at
         // v1 won't have fonts/ unless they re-extract.
         val marker = File(root, ".extracted-v2")
-        if (marker.exists()) return
+        // Re-extract whenever the installed APK is newer than our last
+        // extraction. Without this, every `adb install -r` (and every
+        // user-side APK upgrade) would leave the previous .dis tree on
+        // disk and silently ignore the new APK's runtime — surfacing as
+        // "I rebuilt and reinstalled but my fix isn't there", and the
+        // only escape was `pm clear`. copyAssetTree overwrites in place,
+        // so user-added files outside the asset tree (e.g. anything
+        // under usr/inferno/) survive.
+        val installTime = try {
+            packageManager.getPackageInfo(packageName, 0).lastUpdateTime
+        } catch (e: Exception) { 0L }
+        if (marker.exists() && marker.lastModified() >= installTime) return
         copyAssetTree(assets, "inferno-root", root)
         marker.createNewFile()
+        marker.setLastModified(System.currentTimeMillis())
     }
 
     private fun copyAssetTree(am: AssetManager, src: String, dst: File) {

--- a/build-android-apk.sh
+++ b/build-android-apk.sh
@@ -27,14 +27,17 @@
 #     to do.
 #
 # Usage (from repo root):
-#   ./build-android-apk.sh                 # debug APK
-#   ./build-android-apk.sh --release       # release variant (unsigned)
-#   ./build-android-apk.sh --skip-gradle   # stage artefacts only
+#   ./build-android-apk.sh                       # debug APK, arm64-v8a (phone hw)
+#   ./build-android-apk.sh --release             # release variant (unsigned)
+#   ./build-android-apk.sh --skip-gradle         # stage artefacts only
+#   ./build-android-apk.sh --abi=x86_64          # build for Android emulator on x86 host
+#   ./build-android-apk.sh --abi=both            # multi-arch APK (phone + emulator)
 #
 # See:
 #   docs/HELLAPHONE.md             user-facing setup
 #   emu/Android/README.md          target tree status
-#   build-android-ndk-arm64.sh     standalone-binary driver
+#   build-android-ndk-arm64.sh     standalone-binary driver (arm64-v8a)
+#   build-android-ndk-x86_64.sh    same, x86_64 (emulator iteration)
 #   INFR-110                       Phase 1c epic
 #
 
@@ -45,93 +48,138 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 GRADLE_TASK=assembleDebug
 SKIP_GRADLE=0
 GUIBACK=${GUIBACK:-headless}
+# ABI selection. Default arm64-v8a (matches phone hardware); --abi=x86_64
+# builds for the Android emulator on an x86 host; --abi=both stages both.
+# Internally each entry maps to an NDK build script + jniLibs subdir.
+ABI=arm64-v8a
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --release)     GRADLE_TASK=assembleRelease; shift ;;
         --skip-gradle) SKIP_GRADLE=1; shift ;;
         --gui)         GUIBACK="$2"; shift 2 ;;
         --gui=*)       GUIBACK="${1#--gui=}"; shift ;;
+        --abi)         ABI="$2"; shift 2 ;;
+        --abi=*)       ABI="${1#--abi=}"; shift ;;
         *)             echo "unknown option: $1" >&2; exit 2 ;;
     esac
 done
 
-# GUIBACK is exported so both the inner NDK cross-build (which runs
-# build-android-ndk-arm64.sh in a subshell) and the direct mk invocation
-# below pick it up. For sdl3, ensure SDL3 is built and stage libSDL3.so
-# into jniLibs alongside libemu.so so the APK has both at runtime.
+# Expand the ABI selector into the list of architectures we'll loop over.
+case "$ABI" in
+    arm64-v8a) ABIS="arm64-v8a" ;;
+    x86_64)    ABIS="x86_64" ;;
+    both)      ABIS="arm64-v8a x86_64" ;;
+    *)
+        echo "unknown --abi value '$ABI' (expected arm64-v8a, x86_64, or both)" >&2
+        exit 2
+        ;;
+esac
+
+# Internal helpers: ABI → NDK driver script + Inferno OBJTYPE + SDL3 prefix.
+ndk_script_for_abi() {
+    case "$1" in
+        arm64-v8a) echo "$ROOT/build-android-ndk-arm64.sh" ;;
+        x86_64)    echo "$ROOT/build-android-ndk-x86_64.sh" ;;
+    esac
+}
+objtype_for_abi() {
+    case "$1" in
+        arm64-v8a) echo arm64 ;;
+        x86_64)    echo amd64 ;;
+    esac
+}
+sdl3_prefix_for_abi() {
+    case "$1" in
+        arm64-v8a) echo "$HOME/sdks/SDL3-android-arm64" ;;
+        x86_64)    echo "$HOME/sdks/SDL3-android-x86_64" ;;
+    esac
+}
+
+# GUIBACK is exported so both the inner NDK cross-build (which runs the
+# ABI-specific NDK driver in a subshell) and the direct mk invocation
+# below pick it up. For sdl3, ensure SDL3 is built per-ABI and stage
+# libSDL3.so into the matching jniLibs subdir alongside libemu.so so
+# the APK has both at runtime.
 export GUIBACK
 if [ "$GUIBACK" = "sdl3" ]; then
-    : "${SDL3_PREFIX:=$HOME/sdks/SDL3-android-arm64}"
-    if [ ! -f "$SDL3_PREFIX/lib/libSDL3.so" ]; then
-        echo "::: SDL3 not at $SDL3_PREFIX — building via build-sdl3-android.sh"
-        "$ROOT/build-sdl3-android.sh" || {
-            echo "ERROR: SDL3 cross-build failed" >&2; exit 1; }
-    fi
-    export SDL3_PREFIX
+    for abi in $ABIS; do
+        sdl3_prefix=$(sdl3_prefix_for_abi "$abi")
+        if [ ! -f "$sdl3_prefix/lib/libSDL3.so" ]; then
+            echo "::: SDL3 not at $sdl3_prefix — building via build-sdl3-android.sh --abi=$abi"
+            "$ROOT/build-sdl3-android.sh" --abi="$abi" || {
+                echo "ERROR: SDL3 cross-build failed for $abi" >&2; exit 1; }
+        fi
+    done
 fi
 
-echo "=== InferNode APK build (Phase 1c) ==="
+echo "=== InferNode APK build (Phase 1c) — ABIs: $ABIS ==="
 echo ""
 
-# --- Step 1: NDK cross-build (libs + standalone o.emu) -------------------
-echo "::: 1/4  Cross-compile libs + emu via build-android-ndk-arm64.sh"
-"$ROOT/build-android-ndk-arm64.sh" > "$ROOT/build-android-apk.ndk.log" 2>&1 || {
-    echo "ERROR: NDK cross-build failed. See build-android-apk.ndk.log" >&2
-    tail -20 "$ROOT/build-android-apk.ndk.log" >&2
-    exit 1
-}
-echo "    -> emu/Android/o.emu produced"
-
-# --- Step 2: libemu.so (JNI shared library) ------------------------------
-echo "::: 2/4  Link libemu.so (shared variant for JNI)"
-export ROOT
-export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-${HOME}/Android/Sdk/ndk/android-ndk-r29}"
-export PATH="$ROOT/Linux/amd64/bin:$PATH"
-MKARGS="SYSTARG=Android OBJTYPE=arm64 GUIBACK=$GUIBACK"
-if [ "$GUIBACK" = "sdl3" ]; then
-    MKARGS="$MKARGS SDL3_PREFIX=$SDL3_PREFIX"
-fi
-(
-    cd "$ROOT/emu/Android"
-    rm -f libemu.so jni-emu.o
-    "$ROOT/Linux/amd64/bin/mk" -f mkfile-g $MKARGS libemu
-)
-if [ ! -f "$ROOT/emu/Android/libemu.so" ]; then
-    echo "ERROR: libemu.so was not produced" >&2
-    exit 1
-fi
-echo "    -> emu/Android/libemu.so produced"
-
-# --- Step 3: Stage native lib + runtime assets into the APK tree ---------
-echo "::: 3/4  Stage libemu.so + dis/ runtime into android-app/"
-JNILIBS="$ROOT/android-app/app/src/main/jniLibs/arm64-v8a"
 ASSETS="$ROOT/android-app/app/src/main/assets/inferno-root"
-mkdir -p "$JNILIBS" "$ASSETS"
+mkdir -p "$ASSETS"
 
-cp "$ROOT/emu/Android/libemu.so" "$JNILIBS/libemu.so"
-echo "    -> $JNILIBS/libemu.so"
+# Per-ABI loop: NDK cross-build → libemu.so link → stage into jniLibs/$ABI/.
+step=1
+for abi in $ABIS; do
+    objtype=$(objtype_for_abi "$abi")
+    ndk_script=$(ndk_script_for_abi "$abi")
+    sdl3_prefix=$(sdl3_prefix_for_abi "$abi")
 
-# Stale libSDL3.so from a previous --gui sdl3 build would still be
-# packaged into a headless APK. Clear it out when not using SDL3.
-if [ "$GUIBACK" != "sdl3" ]; then
-    rm -f "$JNILIBS/libSDL3.so"
-fi
+    # --- Step 1.x: NDK cross-build for this ABI --------------------------
+    echo "::: ${step}/4  [$abi] Cross-compile libs + emu via $(basename "$ndk_script")"
+    log="$ROOT/build-android-apk.ndk-${abi}.log"
+    "$ndk_script" > "$log" 2>&1 || {
+        echo "ERROR: NDK cross-build failed for $abi. See $log" >&2
+        tail -20 "$log" >&2
+        exit 1
+    }
+    echo "    -> emu/Android/o.emu ($abi) produced"
 
-# SDL3 GUI: libSDL3.so also has to live in jniLibs/arm64-v8a/ so
-# Android's PackageManager loads it before libemu.so resolves
-# its symbols. Without this libemu.so loads but
-# `dlopen("libSDL3.so")` fails inside System.loadLibrary("emu").
-if [ "$GUIBACK" = "sdl3" ]; then
-    # The actual file may be libSDL3.so or libSDL3.so.0 or similar
-    # depending on SDL3's CMake install. Pick whichever is there.
-    SDL3_SO=$(ls -1 "$SDL3_PREFIX/lib/"libSDL3.so* 2>/dev/null | head -1)
-    if [ -z "$SDL3_SO" ] || [ ! -f "$SDL3_SO" ]; then
-        echo "ERROR: libSDL3.so missing at $SDL3_PREFIX/lib/" >&2
+    # --- Step 2.x: libemu.so for this ABI --------------------------------
+    echo "::: ${step}/4  [$abi] Link libemu.so (shared variant for JNI)"
+    export ROOT
+    export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-${HOME}/Android/Sdk/ndk/android-ndk-r29}"
+    export PATH="$ROOT/Linux/amd64/bin:$PATH"
+    MKARGS="SYSTARG=Android OBJTYPE=$objtype GUIBACK=$GUIBACK"
+    if [ "$GUIBACK" = "sdl3" ]; then
+        MKARGS="$MKARGS SDL3_PREFIX=$sdl3_prefix"
+    fi
+    (
+        cd "$ROOT/emu/Android"
+        rm -f libemu.so jni-emu.o
+        "$ROOT/Linux/amd64/bin/mk" -f mkfile-g $MKARGS libemu
+    )
+    if [ ! -f "$ROOT/emu/Android/libemu.so" ]; then
+        echo "ERROR: libemu.so was not produced for $abi" >&2
         exit 1
     fi
-    cp "$SDL3_SO" "$JNILIBS/libSDL3.so"
-    echo "    -> $JNILIBS/libSDL3.so (from $SDL3_SO)"
-fi
+
+    # --- Step 3.x: Stage into jniLibs/$abi/ ------------------------------
+    JNILIBS="$ROOT/android-app/app/src/main/jniLibs/$abi"
+    mkdir -p "$JNILIBS"
+    cp "$ROOT/emu/Android/libemu.so" "$JNILIBS/libemu.so"
+    echo "    -> $JNILIBS/libemu.so"
+
+    # Stale libSDL3.so from a previous --gui sdl3 build would still be
+    # packaged into a headless APK. Clear it out when not using SDL3.
+    if [ "$GUIBACK" != "sdl3" ]; then
+        rm -f "$JNILIBS/libSDL3.so"
+    fi
+
+    # SDL3 GUI: stage libSDL3.so next to libemu.so so Android's
+    # PackageManager loads it before libemu.so resolves its symbols.
+    # Without this libemu.so loads but `dlopen("libSDL3.so")` fails
+    # inside System.loadLibrary("emu").
+    if [ "$GUIBACK" = "sdl3" ]; then
+        SDL3_SO=$(ls -1 "$sdl3_prefix/lib/"libSDL3.so* 2>/dev/null | head -1)
+        if [ -z "$SDL3_SO" ] || [ ! -f "$SDL3_SO" ]; then
+            echo "ERROR: libSDL3.so missing at $sdl3_prefix/lib/ for $abi" >&2
+            exit 1
+        fi
+        cp "$SDL3_SO" "$JNILIBS/libSDL3.so"
+        echo "    -> $JNILIBS/libSDL3.so (from $SDL3_SO)"
+    fi
+done
 
 # Runtime tree shipped as APK assets. dis/ is the compiled bytecode
 # (sh.dis, cat.dis, the veltro suite, etc.). lib/ has shell profile +

--- a/build-android-ndk-x86_64.sh
+++ b/build-android-ndk-x86_64.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+#
+# Phase 1a-x86_64 build driver — InferNode for Android x86_64, cross-compiled
+# via the Android NDK r29 on a Linux host.
+#
+# Unlike Phase 0 (build-android-termux.sh, which runs ON a Termux phone
+# and links against Termux's $PREFIX/lib), this script runs on the
+# desktop / CI host with the NDK toolchain installed, and produces an
+# o.emu that links against Android's system Bionic at /system/lib64/.
+# The binary can be pushed via adb and run as `adb shell /data/local/tmp/o.emu`
+# — no Termux required.
+#
+# Outputs:
+#   Android/amd64/lib/*.a        cross-compiled libs
+#   emu/Android/o.emu            the emulator binary
+#
+# Prereqs:
+#   * Android NDK r29 installed.  Default location:
+#       $HOME/Android/Sdk/ndk/android-ndk-r29
+#     Override with ANDROID_NDK_HOME if it lives elsewhere.
+#   * A host mk + limbo binary tree at Linux/amd64/bin/ — produced
+#     by ./makemk.sh + build-linux-amd64.sh on a fresh clone.
+#
+# Usage (from repo root):
+#   ./build-android-ndk-x86_64.sh
+#
+# See:
+#   docs/HELLAPHONE.md             user-facing setup and 9P daemon recipe
+#   emu/Android/README.md          directory status and phase plan
+#   build-android-termux.sh        Phase 0 piggyback build driver
+#   INFR-107                       tracking epic
+#
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+export ROOT
+
+echo "=== InferNode Android NDK build (Phase 1a-x86_64) ==="
+echo ""
+
+# --- NDK + toolchain sanity ------------------------------------------------
+: "${ANDROID_NDK_HOME:=${HOME}/Android/Sdk/ndk/android-ndk-r29}"
+if [ ! -d "$ANDROID_NDK_HOME" ]; then
+    echo "ERROR: Android NDK not found at $ANDROID_NDK_HOME" >&2
+    echo "  Install r29 from https://developer.android.com/ndk/downloads" >&2
+    echo "  or set ANDROID_NDK_HOME to point at an existing install." >&2
+    exit 1
+fi
+export ANDROID_NDK_HOME
+
+CROSS_PREFIX="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+if [ ! -x "$CROSS_PREFIX/x86_64-linux-android24-clang" ]; then
+    echo "ERROR: NDK clang wrapper missing at $CROSS_PREFIX/x86_64-linux-android24-clang" >&2
+    echo "  NDK install at $ANDROID_NDK_HOME may be incomplete." >&2
+    exit 1
+fi
+
+# --- Host mk + limbo ------------------------------------------------------
+if [ ! -x "$ROOT/Linux/amd64/bin/mk" ]; then
+    echo "ERROR: host mk not built. Run ./makemk.sh + build-linux-amd64.sh first." >&2
+    exit 1
+fi
+if [ ! -x "$ROOT/Linux/amd64/bin/limbo" ]; then
+    echo "WARNING: host limbo not at Linux/amd64/bin/limbo." >&2
+    echo "  Some appl/ builds compiling .b -> .dis may need it." >&2
+fi
+
+# --- Cross-compile environment --------------------------------------------
+# SYSTARG / OBJTYPE must be passed to mk as COMMAND-LINE variables, not env.
+# mkconfig reassigns `SYSTARG=$SYSHOST` after auto-detect, which clobbers any
+# env value — but Plan 9 mk freezes command-line vars so they survive.
+#
+# GUIBACK selects the GUI backend. Default headless (Phase 0–2a). Set
+# GUIBACK=sdl3 in the environment to build the Lucifer-capable variant
+# (Phase 2b.0+); that requires SDL3 cross-built for Android x86_64,
+# which build-sdl3-android.sh produces.
+: "${GUIBACK:=headless}"
+MKARGS="SYSTARG=Android OBJTYPE=amd64 GUIBACK=$GUIBACK"
+
+if [ "$GUIBACK" = "sdl3" ]; then
+    : "${SDL3_PREFIX:=$HOME/sdks/SDL3-android-x86_64}"
+    if [ ! -f "$SDL3_PREFIX/lib/libSDL3.so" ]; then
+        echo "ERROR: SDL3 not found at $SDL3_PREFIX/lib/libSDL3.so" >&2
+        echo "  Run ./build-sdl3-android.sh first, or set SDL3_PREFIX." >&2
+        exit 1
+    fi
+    export SDL3_PREFIX
+    MKARGS="$MKARGS SDL3_PREFIX=$SDL3_PREFIX"
+fi
+
+export PATH="$ROOT/Linux/amd64/bin:$PATH"
+
+mkdir -p "$ROOT/Android/amd64/bin" "$ROOT/Android/amd64/lib"
+
+echo "ROOT=$ROOT"
+echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"
+echo "host mk=$ROOT/Linux/amd64/bin/mk"
+echo "cross CC=$CROSS_PREFIX/x86_64-linux-android24-clang"
+echo ""
+
+MK="$ROOT/Linux/amd64/bin/mk"
+
+# --- Cross-compile core C libraries ---------------------------------------
+# Order matters: lib9 first (everything depends on it), then libs that
+# only need libc + lib9, then libs that need other libs.
+echo "=== Cross-compiling C libraries ==="
+for lib in lib9 libbio libmp libsec libmath libmemdraw libmemlayer libdraw libfreetype; do
+    if [ ! -d "$ROOT/$lib" ]; then
+        continue
+    fi
+    echo "Building $lib..."
+    cd "$ROOT/$lib"
+    # Strip any host-built .o files from a previous Linux/amd64 build.
+    # Inferno's mkfiles put .o next to the .c source rather than under
+    # $OBJDIR, so cross-compile and host-compile collide and stale .o
+    # files get archived into Android/amd64/lib/lib%.a unchanged. Brute
+    # force: nuke before each rebuild. (The lib*.a in
+    # Linux/amd64/lib/ stays intact.)
+    find . -maxdepth 1 -name '*.o' -delete 2>/dev/null || true
+    "$MK" $MKARGS install || { echo "ERROR: $lib build failed" >&2; exit 1; }
+done
+
+# libinterp + libkeyring need limbo to compile some .m → .c modules,
+# but we use the host limbo for that. The output objects are x86_64.
+for lib in libinterp libkeyring; do
+    if [ -d "$ROOT/$lib" ]; then
+        echo "Building $lib..."
+        cd "$ROOT/$lib"
+        find . -maxdepth 1 -name '*.o' -delete 2>/dev/null || true
+        "$MK" $MKARGS install || { echo "ERROR: $lib build failed" >&2; exit 1; }
+    fi
+done
+
+# --- Cross-compile emulator -----------------------------------------------
+echo ""
+echo "=== Cross-compiling emulator (GUIBACK=$GUIBACK) ==="
+cd "$ROOT/emu/Android"
+rm -f *.o *.emu emu.root.h emu.root.c emu.root.s 2>/dev/null || true
+"$MK" -f mkfile-g $MKARGS || { echo "ERROR: emulator build failed" >&2; exit 1; }
+
+# --- Summary --------------------------------------------------------------
+echo ""
+echo "=== Build Summary ==="
+if [ -x "$ROOT/emu/Android/o.emu" ]; then
+    echo "SUCCESS: emulator at $ROOT/emu/Android/o.emu"
+    ls -la "$ROOT/emu/Android/o.emu"
+    file "$ROOT/emu/Android/o.emu" 2>/dev/null || true
+    echo ""
+    echo "Push to device:"
+    echo "  adb push $ROOT/emu/Android/o.emu /data/local/tmp/o.emu"
+    echo "  adb shell chmod +x /data/local/tmp/o.emu"
+    echo "  adb shell /data/local/tmp/o.emu -h    # or pass root with -r ..."
+    echo ""
+else
+    echo "FAIL: o.emu not found. See errors above."
+    exit 1
+fi

--- a/build-sdl3-android.sh
+++ b/build-sdl3-android.sh
@@ -18,16 +18,29 @@ set -eu
 
 VERSION=${SDL3_VERSION:-3.2.16}
 SDK_HOME=${SDK_HOME:-$HOME/sdks}
-PREFIX=$SDK_HOME/SDL3-android-arm64
 SRC=$SDK_HOME/SDL3-$VERSION-src
 NDK=${ANDROID_NDK_HOME:-$HOME/Android/Sdk/ndk/android-ndk-r29}
 
+# ABI selection: arm64-v8a (default, for phone hardware) or x86_64 (for
+# emulator iteration on x86_64 hosts now that the Android emulator no
+# longer translates arm64 → x86). Pass --abi=<name> or set SDL3_ABI.
+ABI=${SDL3_ABI:-arm64-v8a}
 FORCE=0
 for arg in "$@"; do
     case "$arg" in
-        --force) FORCE=1 ;;
+        --force)   FORCE=1 ;;
+        --abi=*)   ABI="${arg#--abi=}" ;;
     esac
 done
+
+case "$ABI" in
+    arm64-v8a)  PREFIX=$SDK_HOME/SDL3-android-arm64 ;;
+    x86_64)     PREFIX=$SDK_HOME/SDL3-android-x86_64 ;;
+    *)
+        echo "::error::unsupported ABI '$ABI' (expected arm64-v8a or x86_64)" >&2
+        exit 2
+        ;;
+esac
 
 if [ ! -d "$NDK" ]; then
     echo "::error::ANDROID_NDK_HOME not set or NDK not found at $NDK" >&2
@@ -49,15 +62,15 @@ if [ ! -d "$SRC" ]; then
     mv "$SDK_HOME/SDL3-$VERSION" "$SRC"
 fi
 
-BUILD="$SRC/build-android-arm64"
+BUILD="$SRC/build-android-${ABI}"
 rm -rf "$BUILD"
 mkdir -p "$BUILD"
 cd "$BUILD"
 
-echo "::: Configuring SDL3 for Android arm64 (NDK at $NDK)"
+echo "::: Configuring SDL3 for Android $ABI (NDK at $NDK)"
 cmake "$SRC" \
     -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
-    -DANDROID_ABI=arm64-v8a \
+    -DANDROID_ABI="$ABI" \
     -DANDROID_PLATFORM=android-28 \
     -DCMAKE_INSTALL_PREFIX="$PREFIX" \
     -DCMAKE_BUILD_TYPE=Release \
@@ -88,7 +101,7 @@ cmake --install . > cmake-install.log 2>&1 || {
     exit 1
 }
 
-# Sanity check: the .so must be aarch64.
+# Sanity check: the .so must match the requested ABI's ELF e_machine.
 SO="$PREFIX/lib/libSDL3.so"
 if [ ! -f "$SO" ]; then
     # Some installs land it as libSDL3.so.0 or similar — check.
@@ -99,11 +112,16 @@ if [ -z "$SO" ] || [ ! -f "$SO" ]; then
     exit 1
 fi
 
-# ELF magic + EM_AARCH64 (0xb7) at byte 18.
+# ELF magic at bytes 0-3 + EM_* at byte 18 (e_machine little-endian).
+# arm64 → EM_AARCH64 = 0xb7;  x86_64 → EM_X86_64 = 0x3e.
+case "$ABI" in
+    arm64-v8a) want=b7 ;;
+    x86_64)    want=3e ;;
+esac
 elfhex=$(head -c 19 "$SO" | od -An -tx1 | tr -d ' \n')
 case "$elfhex" in
-    7f454c46*b7) ;;
-    *) echo "::error::$SO is not aarch64 ELF (hex=$elfhex)" >&2; exit 1 ;;
+    7f454c46*${want}) ;;
+    *) echo "::error::$SO is not $ABI ELF (hex=$elfhex, want e_machine=$want)" >&2; exit 1 ;;
 esac
 
 echo ""

--- a/docs/INFR-119-design.md
+++ b/docs/INFR-119-design.md
@@ -1,0 +1,261 @@
+# INFR-119 — Split Lucifer mobile zones into wm windows + generic pager
+
+**Status:** design / proposal — pre-implementation. Replaces the
+`KLUDGE-MOBILE-ACCORDION-INFR-119` annotations across `appl/cmd/lucifer.b`,
+`appl/cmd/luciconv.b`, `appl/cmd/lucipres.b`, `appl/cmd/lucictx.b`.
+
+**Author:** initial draft, May 2026. Subject to revision before any
+code lands.
+
+## Why the accordion exists
+
+Mobile Lucifer (`infmobile=1`) shows Chat, Workspace, and Context
+stacked as three title-bar accordions instead of the desktop's
+three-column layout. The three zones live in the same window — they
+share one bodyr — and a z-order toggle (`topexpandedzone`) raises the
+selected zone's sub-image to the front. The three zone modules
+(`luciconv`, `lucipres`, `lucictx`) each draw into their own
+sub-image and run their own input loop, but they:
+
+  * receive their sub-image, font, and channels from `lucifer.b`,
+  * have no idea they're inside a "zone" — they think they own
+    the whole window they were handed,
+  * depend on `lucifer.b` to repaint title bars, route taps, and
+    keep their sub-images sized correctly.
+
+That worked for shipping mobile fast, but it has cost two rounds of
+debugging already (PR #125's name-leak / sentinel / blocking-send
+round, then PR #139's `appreaper` + `preswmloop` + `1×1 segv` round)
+because the zone modules and `lucifer.b` are tightly coupled through
+shared state and ad-hoc resize signalling.
+
+## What this proposal replaces it with
+
+Two things, both reusable by anything that wants to be a top-level wm
+client on a phone:
+
+### 1. The three zone modules become normal `wmclient` apps
+
+Each of `luciconv`, `lucipres`, `lucictx` becomes a self-contained
+wm app:
+
+  * Takes a `ref Draw->Context` and `args` exactly like every other
+    `/dis/wm/*` module (`wm/acme`, `wm/charon`).
+  * Calls `wmclient->window(ctxt, "Chat" | "Workspace" | "Context",
+    Wmclient->Plain)` to ask the window manager for its window —
+    same call `wm/acme` uses.
+  * Owns its own mainloop and gets resize / mouse / keyboard events
+    through standard `wm` channels (`wmctl`, `wmcursor`, etc.).
+  * Knows nothing about the other two zones, about the Lucifer
+    header, or about "mobile" vs "desktop". It just draws to whatever
+    rectangle `wm` gives it.
+
+The net effect: each zone is just another wm window. Lucifer doesn't
+have to layout-route-redraw it.
+
+### 2. A generic `/dis/wm/pager.dis`
+
+A new wm app — *not* mobile-specific in API, just useful on phones —
+that:
+
+  * Hosts a set of child wm windows in a single visible-at-a-time
+    stack.
+  * Renders a row of tappable title bars (the "tabs") at the top.
+  * Lets you swipe horizontally to switch (uses
+    `mousetrack(8/16/32/64)` from INFR-121's swipe synth).
+  * Forwards mouse / keyboard to the active child only; other
+    children stay live (so e.g. an inbound LLM response keeps
+    accumulating in Chat even while you're looking at Workspace).
+  * Emits a `wm` event whenever the focus changes, so the host can
+    react if it wants (Lucifer might raise an inbound-message badge
+    on Chat's tab, for instance).
+
+The pager is a `/dis/wm/*` app on the same footing as `wm/acme` or
+`wm/charon` — so it can be used by anyone, not just Lucifer. It's
+the mobile equivalent of "tile three columns side-by-side" on
+desktop: a layout primitive, not a UI feature.
+
+### 3. Lucifer becomes a thin orchestrator on mobile
+
+`lucifer.b`'s mobile path collapses to roughly:
+
+```
+if(mobile) {
+    pager := load Pager Pager->PATH;  # /dis/wm/pager.dis
+    pager->init(ctxt, "Lucifer");
+    pager->addchild("Chat",      "/dis/luciconv.dis");
+    pager->addchild("Workspace", "/dis/lucipres.dis");
+    pager->addchild("Context",   "/dis/lucictx.dis");
+    # Lucifer owns the header strip + task tiles only.
+    # Pager owns layout, focus, swipe, repaint.
+}
+```
+
+All the `KLUDGE-MOBILE-ACCORDION-INFR-119`-tagged code in `lucifer.b`
+goes away: `zonerects()` mobile branch, `setexpandedzone`,
+`drawmobiletitle`, `topexpandedzone`, the special mouse-routing in
+mobile mode, the body-rect overlap trick, the title-bar-tap → switch
+plumbing — all replaced by pager-internal mechanics.
+
+Desktop Lucifer is unchanged: `mobile=0` still uses `zonerects()`'s
+three-column layout and the existing wmsrv plumbing. The pager
+exists but isn't loaded.
+
+## Migration plan
+
+This is a real refactor and wants to land in stages, each shippable on
+its own (so we don't leave master broken for days).
+
+### Stage A — Pager scaffold
+
+  * Write `appl/wm/pager.b` with a placeholder UI: addchild() just
+    keeps a list, the active child is drawn at the body rect with the
+    others' sub-images hidden, tabs are drawn at the top.
+  * Add `appl/wm/pager.m`, `mkfile`. Bundle in
+    `build-android-apk.sh`'s asset staging.
+  * Test on macOS desktop (since pager is platform-neutral): load
+    pager → addchild ftree + clock + about → swipe tabs.
+  * No Lucifer changes yet. Zero risk to mobile UX.
+
+### Stage B — Make luciconv a wmclient
+
+  * Convert `luciconv.b` from "load + spawn init with image" to
+    "module called as a wm app with ctxt". Use `wmclient->window`
+    and the standard wm channels.
+  * Keep the existing direct-load entry point (the desktop path
+    Lucifer uses now) behind a flag, so desktop continues working
+    bit-for-bit.
+  * Verify on desktop: Chat zone still works when loaded the old way;
+    and now also works when loaded as a standalone wm app
+    (`wm/luciconv` from the shell).
+
+Repeat for `lucipres` then `lucictx`. After Stage B, each zone module
+runs in two modes: legacy (Lucifer loads it as a library) and
+standalone (any caller can `wm/luciconv` it).
+
+### Stage C — Mobile Lucifer uses the pager
+
+  * `lucifer.b`'s mobile branch instantiates the pager and asks it to
+    host the three zone modules as standalone wm apps.
+  * Remove the accordion code paths and the
+    `KLUDGE-MOBILE-ACCORDION-INFR-119` markers. Mobile Lucifer
+    becomes ~100 lines shorter.
+  * Verify on Android + iOS that Chat / Workspace / Context all work
+    as before, with smoother swipe transitions because the pager is
+    a real wm primitive instead of a z-order kludge.
+
+### Stage D — Legacy load path retired
+
+  * Drop the dual-mode flag from Stage B. Both desktop and mobile
+    Lucifer load the zone modules as standalone wm apps; the host
+    differs only in *which layout it asks wm for* (three columns on
+    desktop, pager on mobile).
+  * Eventually the same machinery serves Acme + tile-three-ways on
+    a desktop, but that's not part of this ticket.
+
+## Risks and call-outs
+
+  * **Wm churn on every swipe.** Pager has to ensure that hiding a
+    child's sub-image doesn't cause its `presscr` (or equivalent) to
+    shrink to 1×1 — exactly the bug PR #125's sentinels worked
+    around, and PR #139 properly fixed in the iOS work. Pager keeps
+    children at full body size, hidden by raise-other-to-top, not by
+    resize. Carry the comment.
+
+  * **Focus + IME.** On Android the soft keyboard depends on
+    `SDL_StartTextInput`; today every tap re-arms it (also from PR
+    #139's window of fixes). The pager must keep that semantics —
+    forwarding mouse-down to the active child should trigger
+    `SDL_StartTextInput` indirectly. Probably already fine, but
+    worth a smoke test.
+
+  * **wmclient's expectation of `wm` daemon.** `wmclient` talks to
+    a `wm` process via the `wm` namespace; mobile Lucifer doesn't
+    currently run a `wm` daemon — it manages sub-images directly.
+    Stage A needs to verify that `wm` is running (or starts one)
+    when the pager loads. If a `wm` process is too heavy for the
+    phone, a leaner alternative is to have the pager itself BE a
+    minimal wm-equivalent for its children (Stage A actually
+    already does this).
+
+  * **iOS parity.** If iOS picks up the pager via the same shared
+    code (it will — pager is in shared appl/wm/), the iOS port
+    benefits for free. But it needs the same swipe support — which
+    iOS already has via INFR-121's shared draw-sdl3.c change.
+    Verify two-finger swipe → pager switch on the iOS simulator at
+    Stage C.
+
+  * **Desktop regression.** Stage D is where desktop changes.
+    Stage A-C explicitly preserve the desktop path bit-for-bit. The
+    risk is concentrated at the Stage-D switchover; gate behind a
+    fallback flag for one release cycle.
+
+## What this proposal explicitly does NOT do
+
+  * It does not change the Lucifer protocol (`/n/ui/activity/*` etc).
+    The agent surface to Lucifer is unchanged.
+
+  * It does not introduce per-child window decorations on mobile.
+    The pager owns the tabs; children draw to their full body rect
+    and never see a title bar of their own.
+
+  * It does not block on the LLM/Veltro work (INFR-117). Pager + zones
+    work without an LLM connected, same as today.
+
+  * It does not replace `wmclient` or `wm` — it builds on them.
+
+## Estimated work
+
+  * Stage A — 1-2 days, mostly pager UX.
+  * Stage B — 1-2 days per zone module, three zones, so 3-6 days.
+  * Stage C — 1 day to wire Lucifer + remove kludge code.
+  * Stage D — 1 day to retire the legacy load path + cleanup.
+
+So ~6-10 working days for full INFR-119 completion. Probably wants to
+be split across several PRs (one per stage), with the kludge code only
+removed at Stage C.
+
+## What's already in place that this builds on
+
+  * **INFR-121 (PR #142):** swipe → wheel events in shared
+    `draw-sdl3.c`. The pager's swipe-to-switch is the natural
+    consumer of those wheel events on a horizontal track.
+  * **INFR-138/139/140 (PR #139):** the resize-and-z-order bug fixes
+    in `appl/cmd/lucifer.b` that made the current accordion stable
+    enough to live with. Those make Stage A-C low-risk by removing
+    the existing-app-window-loss class of failure.
+  * **`wmclient` is already used by every wm app.** The Stage-B
+    refactor of zone modules is well-trodden ground — `wm/acme`,
+    `wm/charon`, `wm/ftree`, `wm/editor` are all reference
+    implementations.
+
+## Open questions for review
+
+  1. **Pager-as-wm-daemon or pager-as-host-only?** Option A: pager
+     spawns a real `wm` daemon and adopts standard wm/wmclient
+     semantics. Option B: pager is itself the wm for its children
+     (lighter, but less reusable outside Lucifer). Lean toward B for
+     Stage A, with the understanding that promoting to A is a
+     migration if we ever want a full wm on the phone.
+
+  2. **Tab UI density.** With three children today, two-finger swipe
+     +  tappable tabs both work. If/when a fourth zone appears, do
+     we go to a hamburger? Pre-decide so the tab strip's layout
+     budget is clear.
+
+  3. **Should the pager be mobile-only at first?** Limiting the
+     scope of Stage A. The desktop has its own column layout and
+     doesn't need pager UX. Counter-argument: writing the pager so
+     it works on desktop too (via the existing `wmsrv` mounts and
+     the same `mousetrack` semantics) means desktop developers can
+     test it locally without an Android device. Lean toward
+     platform-neutral from the start.
+
+## Out of scope but worth noting
+
+  * Acme / Charon could eventually adopt the pager when running on a
+    phone, getting tab-switch and swipe for free. Pager as a layout
+    primitive enables that.
+  * If a future iteration wants per-window animations (slide-in,
+    fade), the pager is the right place to host them — children are
+    unaffected.

--- a/emu/Android/asm-amd64.S
+++ b/emu/Android/asm-amd64.S
@@ -1,0 +1,120 @@
+/*
+ * amd64 (x86_64) assembly routines for Linux
+ *
+ * System V AMD64 ABI:
+ *   Arguments: rdi, rsi, rdx, rcx, r8, r9
+ *   Return: rax (and rdx for 128-bit)
+ *   Caller-saved: rax, rcx, rdx, rsi, rdi, r8-r11
+ *   Callee-saved: rbx, rbp, r12-r15
+ *   Stack: 16-byte aligned before call
+ */
+
+	.file	"asm-amd64.S"
+	.text
+
+/*
+ * int _tas(int *p)
+ *
+ * Test-and-set: atomically exchange *p with 1, return old value.
+ * rdi = pointer to int
+ */
+	.globl	_tas
+	.type	_tas, @function
+_tas:
+	movl	$1, %eax
+	xchgl	%eax, (%rdi)
+	ret
+	.size	_tas, .-_tas
+
+/*
+ * ulong umult(ulong m1, ulong m2, ulong *hi)
+ *
+ * 64-bit multiply returning 128-bit result.
+ * rdi = m1, rsi = m2, rdx = pointer to store high 64 bits
+ * Returns: low 64 bits in rax
+ */
+	.globl	umult
+	.type	umult, @function
+umult:
+	movq	%rdx, %r8	/* save hi pointer (rdx will be clobbered) */
+	movq	%rdi, %rax	/* m1 */
+	mulq	%rsi		/* rdx:rax = rax * rsi */
+	movq	%rdx, (%r8)	/* store high bits */
+	ret			/* low bits already in rax */
+	.size	umult, .-umult
+
+/*
+ * void FPsave(void *p)
+ *
+ * Save floating-point state.
+ * On x86_64 Linux with pthreads, FP context is handled automatically
+ * by the OS. We provide no-op stubs for compatibility.
+ * rdi = pointer to save area (unused)
+ */
+	.globl	FPsave
+	.type	FPsave, @function
+FPsave:
+	ret
+	.size	FPsave, .-FPsave
+
+/*
+ * void FPrestore(void *p)
+ *
+ * Restore floating-point state.
+ * rdi = pointer to save area (unused)
+ */
+	.globl	FPrestore
+	.type	FPrestore, @function
+FPrestore:
+	ret
+	.size	FPrestore, .-FPrestore
+
+/*
+ * uintptr getcallerpc(void *dummy)
+ *
+ * Return the return address of the caller.
+ * On amd64, return address is at 8(%rbp) if frame pointer is used,
+ * but we use the more reliable approach of reading from stack.
+ */
+	.globl	getcallerpc
+	.type	getcallerpc, @function
+getcallerpc:
+	movq	8(%rbp), %rax
+	ret
+	.size	getcallerpc, .-getcallerpc
+
+/*
+ * void executeonnewstack(void *tos, void (*tramp)(void *arg), void *arg)
+ *
+ * Switch to a new stack and call the trampoline function.
+ * rdi = new stack top
+ * rsi = trampoline function
+ * rdx = argument to pass
+ */
+	.globl	executeonnewstack
+	.type	executeonnewstack, @function
+executeonnewstack:
+	movq	%rdi, %rsp	/* switch to new stack */
+	movq	%rdx, %rdi	/* arg becomes first argument to tramp */
+	xorq	%rbp, %rbp	/* clear frame pointer to stop backtrace */
+	call	*%rsi		/* call tramp(arg) */
+	/* if we return, exit */
+	movq	$60, %rax	/* sys_exit */
+	xorq	%rdi, %rdi	/* status = 0 */
+	syscall
+	.size	executeonnewstack, .-executeonnewstack
+
+/*
+ * void unlockandexit(int *key)
+ *
+ * Unlock the key and exit the thread.
+ * rdi = pointer to lock
+ */
+	.globl	unlockandexit
+	.type	unlockandexit, @function
+unlockandexit:
+	movl	$0, (%rdi)	/* unlock */
+	movq	$60, %rax	/* sys_exit */
+	xorq	%rdi, %rdi	/* status = 0 */
+	syscall
+	.size	unlockandexit, .-unlockandexit

--- a/emu/Android/segflush-amd64.c
+++ b/emu/Android/segflush-amd64.c
@@ -1,0 +1,16 @@
+/*
+ * Cache flush for x86_64 Linux
+ *
+ * x86_64 has hardware cache coherency, so no explicit flush needed.
+ * This is a no-op like on 386.
+ */
+
+#include "dat.h"
+
+int
+segflush(void *a, ulong n)
+{
+	USED(a);
+	USED(n);
+	return 0;
+}

--- a/emu/port/draw-sdl3.c
+++ b/emu/port/draw-sdl3.c
@@ -116,6 +116,42 @@ static float display_scale = 1.0f;
 static volatile int sdl_quit_requested = 0;
 
 /*
+ * Touch / multi-finger gesture state.  INFR-121.
+ *
+ * Touchscreen SDL_VIDEO platforms (Android, iOS) send SDL_EVENT_FINGER_*
+ * for every touch and ALSO synthesise SDL_EVENT_MOUSE_* for the first
+ * finger by default — single-finger touches keep working as clicks/drags
+ * through the existing mouse path unchanged.  Here we track the active
+ * finger set and turn TWO-FINGER drags into scroll-wheel events, the
+ * conventional mobile gesture for "scroll content".  Lands once in
+ * shared code, benefits iOS + Android + (any touch-capable) desktop.
+ *
+ *   one finger:   existing mouse semantics (select, drag)
+ *   two fingers:  swipe → wheel ticks (buttons 8/16/32/64)
+ *
+ * Multi-finger gesture starts when finger #2 lands; ends when finger
+ * count drops below 2.  While in gesture, mouse motion is suppressed
+ * (SDL keeps synthesising mouse motion from the first finger even
+ * while the second is down, which would otherwise fight the scroll).
+ */
+#define TOUCH_MAX_FINGERS	10
+/* 50 physical pixels ≈ a finger's width swipe per wheel tick.  On a 450dpi
+ * screen that's ~3mm — flick-sensitive without being twitchy.  Each
+ * mousetrack(8/16) call is one wheel tick (3-5 lines in most wm apps),
+ * so a 500px swipe ≈ 10 ticks ≈ half a screen.  Tune if needed. */
+#define TOUCH_SCROLL_TICK_PX	50.0f
+struct touch_finger {
+	SDL_FingerID	id;
+	float		last_x;	/* physical pixels (matches mouse path's space) */
+	float		last_y;
+};
+static struct touch_finger touch_fingers[TOUCH_MAX_FINGERS];
+static int touch_finger_count = 0;
+static float touch_scroll_accum_x = 0.0f;
+static float touch_scroll_accum_y = 0.0f;
+static int touch_in_multi_gesture = 0;
+
+/*
  * Dirty rectangle accumulator for batched updates.
  *
  * CRITICAL PERFORMANCE FIX:
@@ -413,6 +449,52 @@ button_event_mask(Uint8 button)
 /* Forward declarations */
 static void sdl_atexit_handler(void);
 void sdl_shutdown(void);
+
+/*
+ * Find an active finger by SDL_FingerID. Returns -1 if not tracked.
+ * INFR-121.
+ */
+static int
+touch_finger_index(SDL_FingerID id)
+{
+	int i;
+	for (i = 0; i < touch_finger_count; i++)
+		if (touch_fingers[i].id == id)
+			return i;
+	return -1;
+}
+
+/*
+ * Remove an active finger from the tracked set, compacting the array.
+ * INFR-121.
+ */
+static void
+touch_finger_remove_at(int idx)
+{
+	int j;
+	if (idx < 0 || idx >= touch_finger_count)
+		return;
+	for (j = idx; j < touch_finger_count - 1; j++)
+		touch_fingers[j] = touch_fingers[j + 1];
+	touch_finger_count--;
+}
+
+/*
+ * Convert SDL_TouchFingerEvent normalised coords (0..1 relative to the
+ * window's logical size) to physical-pixel coords matching the rest of
+ * the mouse path. On Android logical == pixels so display_scale is 1.0
+ * and the multiplication is a no-op. INFR-121.
+ */
+static void
+touch_finger_to_pixels(const SDL_TouchFingerEvent *ev, float *px, float *py)
+{
+	int lw = 0, lh = 0;
+	SDL_GetWindowSize(sdl_window, &lw, &lh);
+	if (lw <= 0 && display_scale > 0.0f) lw = (int)(window_width / display_scale);
+	if (lh <= 0 && display_scale > 0.0f) lh = (int)(window_height / display_scale);
+	*px = ev->x * (float)lw * display_scale;
+	*py = ev->y * (float)lh * display_scale;
+}
 
 /*
  * Pre-initialize SDL3 on main thread
@@ -1092,6 +1174,90 @@ sdl3_mainloop(void)
 					mousetrack(64, mouse_x, mouse_y, 0);  /* scroll right */
 				else if (wx2 < 0)
 					mousetrack(32, mouse_x, mouse_y, 0);  /* scroll left */
+				break;
+			}
+
+			/*
+			 * INFR-121: two-finger swipe → scroll-wheel synthesis.
+			 * Track active fingers; when two or more are down, route
+			 * finger motion into wheel-tick events so every wm app
+			 * scrolls without per-app changes.  Single-finger touches
+			 * continue to flow through SDL's synthesised mouse events
+			 * (SDL_HINT_TOUCH_MOUSE_EVENTS=1, set in sdl3_preinit).
+			 */
+			case SDL_EVENT_FINGER_DOWN: {
+				float px, py;
+				touch_finger_to_pixels(&event.tfinger, &px, &py);
+				if (touch_finger_count < TOUCH_MAX_FINGERS) {
+					touch_fingers[touch_finger_count].id = event.tfinger.fingerID;
+					touch_fingers[touch_finger_count].last_x = px;
+					touch_fingers[touch_finger_count].last_y = py;
+					touch_finger_count++;
+				}
+				if (touch_finger_count == 2) {
+					/*
+					 * Entering two-finger gesture.  Release any
+					 * synthesised mouse button so we don't leave a
+					 * click-drag in flight under the scroll; reset
+					 * the scroll accumulators so a slow-drag-then-
+					 * second-finger doesn't immediately flush a tick.
+					 */
+					if (sdl_button_state) {
+						sdl_button_state = 0;
+						mousetrack(0, mouse_x, mouse_y, 0);
+					}
+					touch_scroll_accum_x = 0.0f;
+					touch_scroll_accum_y = 0.0f;
+					touch_in_multi_gesture = 1;
+				}
+				break;
+			}
+
+			case SDL_EVENT_FINGER_UP: {
+				int idx = touch_finger_index(event.tfinger.fingerID);
+				touch_finger_remove_at(idx);
+				if (touch_finger_count < 2)
+					touch_in_multi_gesture = 0;
+				break;
+			}
+
+			case SDL_EVENT_FINGER_MOTION: {
+				int idx = touch_finger_index(event.tfinger.fingerID);
+				float px, py, dx, dy;
+				if (idx < 0)
+					break;
+				touch_finger_to_pixels(&event.tfinger, &px, &py);
+				dx = px - touch_fingers[idx].last_x;
+				dy = py - touch_fingers[idx].last_y;
+				touch_fingers[idx].last_x = px;
+				touch_fingers[idx].last_y = py;
+				if (!touch_in_multi_gesture)
+					break;
+				touch_scroll_accum_x += dx;
+				touch_scroll_accum_y += dy;
+				/*
+				 * Natural scroll direction: drag finger UP (dy < 0)
+				 * means user wants to see content BELOW (viewport
+				 * moves down) → wheel "scroll down" = button 16.
+				 * Drag finger DOWN (dy > 0) → "scroll up" = button 8.
+				 * Same for horizontal.
+				 */
+				while (touch_scroll_accum_y <= -TOUCH_SCROLL_TICK_PX) {
+					mousetrack(16, mouse_x, mouse_y, 0);
+					touch_scroll_accum_y += TOUCH_SCROLL_TICK_PX;
+				}
+				while (touch_scroll_accum_y >= TOUCH_SCROLL_TICK_PX) {
+					mousetrack(8, mouse_x, mouse_y, 0);
+					touch_scroll_accum_y -= TOUCH_SCROLL_TICK_PX;
+				}
+				while (touch_scroll_accum_x <= -TOUCH_SCROLL_TICK_PX) {
+					mousetrack(32, mouse_x, mouse_y, 0);
+					touch_scroll_accum_x += TOUCH_SCROLL_TICK_PX;
+				}
+				while (touch_scroll_accum_x >= TOUCH_SCROLL_TICK_PX) {
+					mousetrack(64, mouse_x, mouse_y, 0);
+					touch_scroll_accum_x -= TOUCH_SCROLL_TICK_PX;
+				}
 				break;
 			}
 

--- a/lib9/getcallerpc-Android-amd64.S
+++ b/lib9/getcallerpc-Android-amd64.S
@@ -1,0 +1,7 @@
+	.file	"getcallerpc-Linux-amd64.S"
+	.text
+	.type	getcallerpc,@function
+	.global	getcallerpc
+getcallerpc:
+	movq	8(%rbp), %rax
+	ret

--- a/mkfiles/mkfile-Android-amd64
+++ b/mkfiles/mkfile-Android-amd64
@@ -1,0 +1,51 @@
+# Target flags for Android x86_64 (Bionic), cross-compiled via NDK r29+.
+# Counterpart to mkfile-Android-arm64 — same toolchain, x86_64 ABI.
+#
+# Motivation: modern Android emulator (36.x) dropped arm-translation on
+# x86_64 hosts, so to iterate visually on a Linux/x86_64 host with the
+# emulator AVDs we have to ship native x86_64 .so files alongside the
+# arm64-v8a ones. Same Bionic, same Inferno emu, just the other ABI.
+# Selected by `OBJTYPE=amd64 SYSTARG=Android`.
+
+TARGMODEL=	Posix
+TARGSHTYPE=	sh
+CPUS=		amd64
+
+O=		o
+OS=		o
+
+# NDK location: same scheme as mkfile-Android-arm64 — the driver script
+# sets ANDROID_NDK_HOME, with a fallback to $HOME/Android/Sdk/ndk/android-ndk-r29
+# at the shell level. mk has no `${VAR:-default}` expansion.
+NDK=		$ANDROID_NDK_HOME
+TOOLCHAIN=	$NDK/toolchains/llvm/prebuilt/linux-x86_64
+TARGET=		x86_64-linux-android
+# API floor matches arm64: getrandom() and friends, Android 9+ devices.
+API=		28
+
+AR=		$TOOLCHAIN/bin/llvm-ar
+ARFLAGS=	ruvs
+
+AS=		$TOOLCHAIN/bin/${TARGET}${API}-clang -c
+ASFLAGS=
+
+CC=		$TOOLCHAIN/bin/${TARGET}${API}-clang -c
+# -fPIC matches the arm64 mkfile and is required for the libemu.so target
+# (Phase 1c JNI / APK packaging). On x86_64 -fPIC has slight overhead but
+# it's free in practice and lets the same .o set link into both o.emu
+# (PIE exec) and libemu.so (shared library).
+CFLAGS=		-g\
+		-O\
+		-fno-strict-aliasing\
+		-fstack-protector-strong\
+		-fPIC\
+		-Wuninitialized -Wunused-variable -Wreturn-type -Wimplicit\
+		-Werror=return-type -Werror=implicit-function-declaration\
+		-I$ROOT/Android/amd64/include\
+		-I$ROOT/include\
+		-DANDROID_X86_64\
+		-fcommon
+
+ANSICPP=
+LD=		$TOOLCHAIN/bin/${TARGET}${API}-clang
+LDFLAGS=	-fcommon


### PR DESCRIPTION
Picks up the Android side of the iOS GUI-polish work, adds one shared-code feature, and fixes a related Android-only iteration bug.

## Changes (3 commits)

### `lucifer(mobile): stack dialogue option buttons as full-width tap targets` — INFR-141
Cherry-picked from `feat/ios-gui-polish` (`c1c74efc`). Shared `appl/cmd/luciconv.b` change, mobile-gated. The LLM-setup wizard's option buttons stack vertically as full-width finger-sized rows on mobile instead of horizontally cramped on a single row. Desktop unchanged.

### `android: re-extract inferno-root assets whenever APK is reinstalled` — Android-only iteration fix
Android-specific bug uncovered during INFR-141 verification (`291bb7e1`). `InfernodeSDLActivity.extractInfernoRootIfNeeded` gated on a fixed marker filename, so every `adb install -r` (and every user-side APK upgrade) left the previous `dis/` tree on disk and silently ignored the new APK's runtime — surfaced as "I rebuilt and reinstalled but my fix isn't there", escape was `pm clear` which also nukes factotum keys.

Now re-extract when the marker is older than `packageManager.getPackageInfo(...).lastUpdateTime`. `copyAssetTree` overwrites in place, so user-added files outside the asset tree survive.

### `feat(draw-sdl3): two-finger swipe → scroll-wheel events` — INFR-121
New shared-code feature in `emu/port/draw-sdl3.c` (`9f19250c`). Tracks the active SDL touch-finger set; when a second finger lands, routes subsequent finger motion into `mousetrack(8/16/32/64)` wheel-tick events — the standard mobile gesture for "scroll content". Lands once in shared C, benefits iOS + Android + (any touch-capable) desktop simultaneously. Single-finger touches continue to flow through SDL's synthesized mouse-event path unchanged.

Mechanics: `touch_fingers[]` tracks up to 10 fingers; entering 2-finger gesture force-releases any pending mouse button; each `TOUCH_SCROLL_TICK_PX` (50px ≈ 3mm at 450dpi) of accumulated motion flushes one wheel tick; natural scroll direction. `display_scale` math is correct on all platforms.

## Verification on A55 (SM-A556E, Android 16, 1080x2340@450dpi)

- ✅ **INFR-141 — full-width dialogue buttons**: confirmed stacking after the auto-re-extract fix.
- ✅ **INFR-142 — draw-sdl3 fixes (PR #139)**: top safe-area inset, no shear, HiDPI sharp text.
- ✅ **INFR-143 — mobile UI polish**: logo prominently sized via `biglogo()`, disclosure chevrons render as filled triangles, `Main · active` task tile thumb-sized.
- ✅ **INFR-138/139/140 — Lucifer Workspace / z-order / accordion preserve**: code-level review confirms fixes are in the bundled `dis/lucifer.dis`; deep behavioural verification needs an LLM connection.
- ⚠️ **INFR-121 — two-finger swipe scroll**: build clean, no regression in single-finger touch. Multi-touch verification requires physical pinch/swipe (adb shell input is single-finger only); will validate manually.

## Scope notes

- Per direction: omnibus PR for the Android-side parity pickup.
- The auto-re-extract change is Android-only. Same defect class affects iOS bundle-extraction; tracked separately for the iOS port.
- INFR-121's swipe-synth is shared C code — it benefits iOS too with zero porting.
- Follow-ups: INFR-119 (accordion → split-zones + wm/pager refactor), x86_64 NDK target for emulator iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
