### PR TITLE
devphone: /phone/contacts (CNContactStore on iOS)

### DIFF
--- a/build-ios-app.sh
+++ b/build-ios-app.sh
@@ -139,7 +139,7 @@ mkdir -p "$APPDIR"
 	-o "$APPDIR/InferNode" \
 	"$APPOBJ" $INFERNO_LIBS \
 	-framework UIKit -framework Foundation -framework CoreFoundation \
-	-framework MessageUI -framework CallKit \
+	-framework MessageUI -framework CallKit -framework Contacts \
 	$GUI_LINK -lpthread -lm || {
 		echo "ERROR: app link failed" >&2; exit 1; }
 

--- a/emu/Android/phonebridge.c
+++ b/emu/Android/phonebridge.c
@@ -95,3 +95,11 @@ phonebridge_calls(char *buf, int buflen)
 	(void)buf; (void)buflen;
 	return 0;
 }
+
+int
+phonebridge_contacts(char *buf, int buflen)
+{
+	/* INFR-182 will wire ContactsContract via the JNI surface. Same
+	 * line format as the iOS bridge: <name>\t<kind>\t<number>\n. */
+	return snprintf(buf, buflen, "# contacts: Android bridge not wired (INFR-182)\n");
+}

--- a/emu/iOS/app/Info.plist
+++ b/emu/iOS/app/Info.plist
@@ -35,6 +35,12 @@
 	     LAN 9P service) silently fails. -->
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>InferNode connects to a remote InferNode on your local network to use its LLM and 9P services.</string>
+	<!-- /phone/contacts surfaces the address book to Veltro so the agent
+	     can resolve names ("text mom") to numbers. Read-only; the
+	     contacts file is exposed through Inferno's 9P namespace under
+	     /phone/contacts. Authorization status is checked on every read. -->
+	<key>NSContactsUsageDescription</key>
+	<string>InferNode reads your contacts so the Veltro agent can resolve names like "text mom" to phone numbers for SMS and dialling.</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/emu/iOS/mkfile-g
+++ b/emu/iOS/mkfile-g
@@ -72,6 +72,7 @@ SYSLIBS=\
 	-framework UIKit\
 	-framework MessageUI\
 	-framework CallKit\
+	-framework Contacts\
 
 default:V:	$O.$CONF
 

--- a/emu/iOS/phonebridge.m
+++ b/emu/iOS/phonebridge.m
@@ -40,6 +40,7 @@
 #import <UIKit/UIKit.h>
 #import <MessageUI/MessageUI.h>
 #import <CallKit/CallKit.h>
+#import <Contacts/Contacts.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -370,4 +371,127 @@ phonebridge_calls(char *buf, int buflen)
 {
 	(void)buf; (void)buflen;
 	return 0;
+}
+
+/*
+ * Address book → /phone/contacts.
+ *
+ * CNContactStore is the public API; permission is gated by
+ * NSContactsUsageDescription in Info.plist. Authorisation is one of
+ * notDetermined / restricted / denied / authorized; on notDetermined
+ * we requestAccess synchronously (semaphore wait — devphone runs us
+ * on an Inferno kproc, not the UIKit main thread, so blocking is
+ * fine). Other states surface as an error string in the read so the
+ * agent can tell access from emptiness.
+ *
+ * Format per Hellaphone /phone:  <display-name>\t<kind>\t<number>\n
+ * One line per phone-number; contacts with several numbers emit
+ * several lines. Records are written into the caller's buffer until
+ * the next record would overflow, then truncation is at the last
+ * newline so the consumer never sees a partial line.
+ */
+static int
+write_contact_line(char *buf, int buflen, int off,
+                   NSString *name, NSString *kind, NSString *number)
+{
+	const char *n = name.UTF8String   ?: "";
+	const char *k = kind.UTF8String   ?: "other";
+	const char *p = number.UTF8String ?: "";
+	int written = snprintf(buf + off, (size_t)(buflen - off),
+		"%s\t%s\t%s\n", n, k, p);
+	if(written < 0)
+		return off;
+	if(written >= buflen - off)
+		return off;	/* would overflow; caller stops here */
+	return off + written;
+}
+
+static NSString *
+normalise_phone_label(NSString *raw)
+{
+	if(raw == nil)
+		return @"other";
+	if([raw isEqualToString:CNLabelPhoneNumberMobile])         return @"mobile";
+	if([raw isEqualToString:CNLabelPhoneNumberiPhone])         return @"mobile";
+	if([raw isEqualToString:CNLabelPhoneNumberMain])           return @"main";
+	if([raw isEqualToString:CNLabelHome])                       return @"home";
+	if([raw isEqualToString:CNLabelWork])                       return @"work";
+	if([raw isEqualToString:CNLabelOther])                      return @"other";
+	NSString *clean = [CNLabeledValue localizedStringForLabel:raw];
+	if(clean == nil)
+		return @"other";
+	return clean.lowercaseString;
+}
+
+int
+phonebridge_contacts(char *buf, int buflen)
+{
+	if(buf == NULL || buflen <= 1)
+		return -1;
+
+	CNAuthorizationStatus st = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+	if(st == CNAuthorizationStatusNotDetermined){
+		dispatch_semaphore_t done = dispatch_semaphore_create(0);
+		__block BOOL ok = NO;
+		CNContactStore *probe = [[CNContactStore alloc] init];
+		[probe requestAccessForEntityType:CNEntityTypeContacts
+			completionHandler:^(BOOL granted, NSError *err){
+				ok = granted;
+				if(err != nil)
+					fprintf(stderr, "phone: contacts requestAccess error: %s\n",
+						err.localizedDescription.UTF8String);
+				dispatch_semaphore_signal(done);
+			}];
+		dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+		st = ok ? CNAuthorizationStatusAuthorized : CNAuthorizationStatusDenied;
+	}
+
+	if(st == CNAuthorizationStatusDenied){
+		return snprintf(buf, buflen,
+			"# contacts: permission denied — enable in Settings > InferNode > Contacts\n");
+	}
+	if(st == CNAuthorizationStatusRestricted){
+		return snprintf(buf, buflen,
+			"# contacts: restricted by device policy\n");
+	}
+	if(st != CNAuthorizationStatusAuthorized)
+		return 0;
+
+	CNContactStore *store = [[CNContactStore alloc] init];
+	NSArray *keys = @[
+		CNContactGivenNameKey,
+		CNContactFamilyNameKey,
+		CNContactOrganizationNameKey,
+		CNContactPhoneNumbersKey,
+	];
+	CNContactFetchRequest *req = [[CNContactFetchRequest alloc]
+		initWithKeysToFetch:keys];
+
+	__block int off = 0;
+	NSError *err = nil;
+	BOOL fetched = [store enumerateContactsWithFetchRequest:req
+		error:&err
+		usingBlock:^(CNContact *c, BOOL *stop){
+			if(c.phoneNumbers.count == 0) return;
+			NSString *name = [CNContactFormatter
+				stringFromContact:c style:CNContactFormatterStyleFullName];
+			if(name.length == 0) name = c.organizationName;
+			if(name.length == 0) name = @"(no name)";
+			for(CNLabeledValue<CNPhoneNumber *> *pn in c.phoneNumbers){
+				NSString *kind = normalise_phone_label(pn.label);
+				NSString *num  = pn.value.stringValue;
+				int nextoff = write_contact_line(buf, buflen, off,
+					name, kind, num);
+				if(nextoff == off){	/* no space; stop cleanly */
+					*stop = YES;
+					return;
+				}
+				off = nextoff;
+			}
+		}];
+	if(!fetched){
+		const char *msg = err.localizedDescription.UTF8String ?: "fetch failed";
+		return snprintf(buf, buflen, "# contacts: %s\n", msg);
+	}
+	return off;
 }

--- a/emu/port/devphone.c
+++ b/emu/port/devphone.c
@@ -51,7 +51,13 @@ enum
 	Qsignal,
 	Qstatus,
 	Qcalls,
+	Qcontacts,
 };
+
+/* Max contacts snapshot we'll cache per open (single phoneopen / read /
+ * close cycle); ample for typical address books. Allocated lazily so
+ * a /phone/sms or /phone/ctl session doesn't pay for it. */
+#define	CONTACTS_BUFSZ	(64 * 1024)
 
 /*
  * Per-open-channel listener nodes. phoneopen of /phone/sms or
@@ -135,7 +141,8 @@ Dirtab phonetab[] =
 	"phone",  {Qphone,  0, 0},   0,  0666,
 	"signal", {Qsignal, 0, 0},   0,  0444,
 	"status", {Qstatus, 0, 0},   0,  0444,
-	"calls",  {Qcalls,  0, 0},   0,  0444,
+	"calls",    {Qcalls,    0, 0}, 0, 0444,
+	"contacts", {Qcontacts, 0, 0}, 0, 0444,
 };
 
 static void
@@ -177,6 +184,27 @@ phoneopen(Chan *c, int omode)
 		if(c->aux != nil)
 			add_listener(&phone_listeners, c->aux);
 		break;
+	case Qcontacts:
+		/* Snapshot the address book once per open. Bridge can be
+		 * expensive (CNContactStore on iOS prompts and walks); we
+		 * pay it on the open, then paginate from c->aux via
+		 * readstr with the caller's offset. */
+		{
+			char *buf = malloc(CONTACTS_BUFSZ);
+			int got;
+			if(buf == nil)
+				break;
+			got = phonebridge_contacts(buf, CONTACTS_BUFSZ);
+			if(got <= 0){
+				free(buf);
+				break;
+			}
+			if(got > CONTACTS_BUFSZ - 1)
+				got = CONTACTS_BUFSZ - 1;
+			buf[got] = 0;
+			c->aux = buf;
+		}
+		break;
 	}
 	return c;
 }
@@ -203,6 +231,12 @@ phoneclose(Chan *c)
 			del_listener(&phone_listeners, q);
 			qhangup(q, nil);
 			qfree(q);
+			c->aux = nil;
+		}
+		break;
+	case Qcontacts:
+		if(c->aux != nil){
+			free(c->aux);
 			c->aux = nil;
 		}
 		break;
@@ -255,6 +289,13 @@ phoneread(Chan *c, void *va, long n, vlong offset)
 		if(got < 0)
 			return 0;
 		return readstr(offset, va, n, buf);
+
+	case Qcontacts:
+		/* Cached snapshot allocated in phoneopen; nil on permission
+		 * deny / framework unavailable. EOF in that case. */
+		if(c->aux == nil)
+			return 0;
+		return readstr(offset, va, n, (char *)c->aux);
 	}
 	return 0;
 }

--- a/emu/port/phonebridge.h
+++ b/emu/port/phonebridge.h
@@ -56,6 +56,24 @@ int	phonebridge_status(char *buf, int buflen);
 int	phonebridge_calls(char *buf, int buflen);
 
 /*
+ * /phone/contacts — synchronous read of the platform address book.
+ * Format on success: one record per line, tab-separated columns:
+ *
+ *     <display-name>\t<kind>\t<number>\n
+ *
+ * `kind` is the platform label normalised to lower-case (mobile, work,
+ * home, main, other). Contacts with multiple numbers emit multiple
+ * lines. The bridge writes up to buflen bytes (truncating at a line
+ * boundary if it has to) and returns the byte count; -1 on error
+ * (permission denied, framework unavailable); 0 means "no contacts".
+ *
+ * devphone reads this once per open via phoneopen and caches the
+ * snapshot on the Chan, so successive reads paginate without
+ * re-querying the OS. close() drops the cache.
+ */
+int	phonebridge_contacts(char *buf, int buflen);
+
+/*
  * Bridge -> userspace push entry points (defined in emu/port/devphone.c).
  * Each call fans the record out to every currently-open reader of the
  * corresponding /phone file via qproduce. Non-blocking; safe from any


### PR DESCRIPTION
## Summary

Adds `Qcontacts` to the cross-platform `/phone` device. iOS implementation reads `CNContactStore` on first open via `phonebridge_contacts()`, caches the snapshot on the Chan in `c->aux`, and lets `readstr()` paginate it across consecutive reads with the caller's offset. `phoneclose` frees the cache.

Same Hellaphone-style tab-separated wire as `/phone/calls`:

```
<display-name>\t<kind>\t<number>\n
```

Contacts with multiple numbers emit one line per number. `kind` is normalised to lower-case via the `CNLabelPhoneNumberMobile` / `CNLabel*` constants → `mobile`, `work`, `home`, `main`, `other`. Records that would overflow the caller's buffer are dropped cleanly at the last newline boundary so the consumer never sees a partial line.

### Permission

`NSContactsUsageDescription` added to `Info.plist`. On `notDetermined` the bridge dispatches `CNContactStore.requestAccess` and blocks a semaphore (devphone runs us on an Inferno kproc, not the UIKit main queue — blocking is fine here). Denied / restricted states surface as a single `# contacts: …` comment line rather than empty output so the agent can distinguish "user said no" from "address book is empty".

### Why a per-Chan cached snapshot

Contacts is a query, not a stream — the listener / qproduce machinery that backs `/phone/sms` and `/phone/phone` would be overkill. `CNContactStore` enumeration prompts the user and walks the whole address book; we pay it once on open, paginate cheaply on read.

### Wiring

- `emu/port/phonebridge.h` declares `phonebridge_contacts()`.
- `emu/port/devphone.c` adds `Qcontacts` to enum + `phonetab`, allocates `CONTACTS_BUFSZ` on open, frees on close, paginates on read.
- `emu/iOS/phonebridge.m` real `CNContactStore` impl with `normalise_phone_label()` for clean kinds.
- `emu/Android/phonebridge.c` stub returns `# contacts: Android bridge not wired (INFR-182)` so reads aren't silently empty.
- `Contacts.framework` added to `emu/iOS/mkfile-g` (headless slice) and `build-ios-app.sh`'s GUI link line — same shape we used for CallKit.

### Agent usage (no new tool needed)

`cat /phone/contacts | grep -i <name>` via the existing `read` tool — the agent grabs the snapshot and resolves names locally. A dedicated Veltro `contacts` tool can land later if pattern-matching becomes a hot path.

## Test plan

- [x] Sim build links cleanly against `Contacts.framework`; boot stays clean (`phone: bridge=iOS …`, `phone: CXCallObserver installed`, `msg9p: registered source 'sms' …`).
- [ ] On Ba'al: first `cat /phone/contacts` triggers the system permission prompt; user taps Allow; output is one TSV line per number.
- [ ] Subsequent reads of `/phone/contacts` return the same snapshot without re-prompting.
- [ ] Tapping Don't Allow yields `# contacts: permission denied — enable in Settings > InferNode > Contacts` instead of an empty file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)