### PR TITLE
Voice v1: iOS audio backend with AVAudioSession .voiceChat (INFR-186)

### DIFF
--- a/emu/MacOSX/audio-sdl3.c
+++ b/emu/MacOSX/audio-sdl3.c
@@ -69,6 +69,24 @@
 
 #ifdef GUI_SDL3
 
+/*
+ * Platform-specific audio session setup, called once before
+ * SDL_InitSubSystem(SDL_INIT_AUDIO). Today this matters on iOS, where
+ * AVAudioSession must be configured to .playAndRecord with .voiceChat
+ * mode for the SDL3 audio device to (a) get the recording category
+ * (.soloAmbient is the default and silently disables capture) and
+ * (b) route through Apple's hardware AEC so two phones in the same
+ * room don't feed back. The iOS shim (emu/iOS/audio-sdl3.c) defines
+ * AUDIO_PLATFORM_INIT_EXTERN before including this file, so the
+ * external symbol below is linked in from emu/iOS/audiosession.m.
+ * macOS / Linux desktop builds get the no-op static stub. INFR-186.
+ */
+#ifdef AUDIO_PLATFORM_INIT_EXTERN
+extern void audio_platform_init(void);
+#else
+static void audio_platform_init(void) { }
+#endif
+
 static int sdl_audio_inited;		/* SDL_InitSubSystem(SDL_INIT_AUDIO) done? */
 static SDL_AudioStream *in_stream;	/* mic capture */
 static SDL_AudioStream *out_stream;	/* speaker playback */
@@ -92,6 +110,10 @@ ensure_sdl_audio(void)
 {
 	if(sdl_audio_inited)
 		return 1;
+	/* Configure AVAudioSession (or platform equivalent) before SDL
+	 * touches CoreAudio — no-op on macOS/Linux desktop, real impl on
+	 * iOS. INFR-186. */
+	audio_platform_init();
 	/* SDL_InitSubSystem is idempotent and safe to call after SDL_Init
 	 * (the GUI backend calls SDL_Init(SDL_INIT_VIDEO) at startup). */
 	if(!SDL_InitSubSystem(SDL_INIT_AUDIO)) {

--- a/emu/iOS/app/Info.plist
+++ b/emu/iOS/app/Info.plist
@@ -46,6 +46,16 @@
 	     under the Face ID prompt. -->
 	<key>NSFaceIDUsageDescription</key>
 	<string>InferNode uses Face ID to unlock signed keys (LLM mount, secstore) without prompting for a password every launch.</string>
+	<!-- Voice over 9P (INFR-186). 'audio' keeps the AVAudioSession alive
+	     after the screen locks so an in-progress call survives lock; 'voip'
+	     gives iOS a hint to wake the app for incoming voice events without
+	     it being killed in the background. Without either, the SDL3 audio
+	     stream is torn down on lock and the call drops. -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/emu/iOS/audio-sdl3.c
+++ b/emu/iOS/audio-sdl3.c
@@ -1,0 +1,8 @@
+/*
+ * iOS audio backend (INFR-186). Same SDL3 implementation as macOS — just
+ * tell the included source to expect an external audio_platform_init()
+ * symbol (provided by emu/iOS/audiosession.m, which configures
+ * AVAudioSession with .playAndRecord + .voiceChat for AEC).
+ */
+#define AUDIO_PLATFORM_INIT_EXTERN
+#include "../MacOSX/audio-sdl3.c"

--- a/emu/iOS/audiosession.m
+++ b/emu/iOS/audiosession.m
@@ -1,0 +1,61 @@
+/*
+ * audiosession.m — configure AVAudioSession for the InferNode voice
+ * stack (INFR-186). Called once from audio-sdl3.c's ensure_sdl_audio
+ * before SDL_InitSubSystem(SDL_INIT_AUDIO).
+ *
+ * Required category/mode for what we actually do (mic capture + speaker
+ * playback + hardware AEC):
+ *
+ *   category .playAndRecord    — without this, .soloAmbient (the
+ *                                default) silently makes capture
+ *                                return zero samples on device.
+ *   mode .voiceChat            — turns on Apple's voice-processing IO
+ *                                unit. Hardware AEC + noise suppression
+ *                                + voice-isolation in one switch. This
+ *                                is the difference between two phones
+ *                                in the same room having a normal
+ *                                conversation and the v0 "Forbidden
+ *                                Planet" feedback loop.
+ *   .defaultToSpeaker          — route playback to the loudspeaker by
+ *                                default (otherwise it goes to the
+ *                                ear-piece, which is the right call
+ *                                for a phone-up-to-the-ear UX but
+ *                                wrong for handset-on-table testing).
+ *   .allowBluetooth            — let bluetooth headsets be used.
+ *
+ * If anything fails we log and continue: SDL will still try to open
+ * the device with whatever session config exists; .playAndRecord
+ * without .voiceChat is at least audible (no AEC, but no silence).
+ */
+#import <AVFoundation/AVFoundation.h>
+
+#include <stdio.h>
+
+void
+audio_platform_init(void)
+{
+	static int configured = 0;
+	if (configured)
+		return;
+	configured = 1;
+
+	AVAudioSession *session = [AVAudioSession sharedInstance];
+	NSError *err = nil;
+
+	BOOL ok = [session setCategory:AVAudioSessionCategoryPlayAndRecord
+				mode:AVAudioSessionModeVoiceChat
+				options:(AVAudioSessionCategoryOptionDefaultToSpeaker |
+				         AVAudioSessionCategoryOptionAllowBluetooth)
+				error:&err];
+	if (!ok) {
+		fprintf(stderr, "audiosession: setCategory failed: %s\n",
+			err ? [[err localizedDescription] UTF8String] : "(nil)");
+	}
+
+	err = nil;
+	ok = [session setActive:YES error:&err];
+	if (!ok) {
+		fprintf(stderr, "audiosession: setActive failed: %s\n",
+			err ? [[err localizedDescription] UTF8String] : "(nil)");
+	}
+}

--- a/emu/iOS/emu
+++ b/emu/iOS/emu
@@ -21,7 +21,7 @@ dev
 
 	ip	ipif6-posix ipaux
 	eia
-#	audio	audio
+	audio	audio-sdl3
 	mem
 	phone	phonebridge
 

--- a/emu/iOS/mkfile-g
+++ b/emu/iOS/mkfile-g
@@ -47,6 +47,7 @@ OBJ=\
 	asm-$OBJTYPE.$O\
 	os.$O\
 	$GUISRC\
+	audiosession.$O\
 	$CONF.root.$O\
 	lock.$O\
 	$DEVS\
@@ -127,3 +128,10 @@ asm-arm64.s:N:		../MacOSX/asm-arm64.s
 stubs-headless.c:N:	../MacOSX/stubs-headless.c
 ipif.c:N:		../port/ipif6-posix.c
 devfs.c:N:		../MacOSX/devfs.c
+
+# Audio backend (INFR-186). audio-sdl3.c here is a forwarder around
+# emu/MacOSX/audio-sdl3.c that defines AUDIO_PLATFORM_INIT_EXTERN so
+# audio_platform_init is an external symbol satisfied by audiosession.m
+# (AVAudioSession configuration). Record the macOS dep so iOS picks up
+# upstream changes; the OBJ list above already has audiosession.$O.
+audio-sdl3.c:N:		../MacOSX/audio-sdl3.c


### PR DESCRIPTION
## Summary

Extends the INFR-185 voice spike to iOS so two phones can actually talk. The path is shorter than expected — SDL3 is already linked into the iOS GUI build, so the same `audio-sdl3.c` from v0 drives the iOS device too. The iOS-specific pieces are AVAudioSession configuration (for capture + AEC) and `UIBackgroundModes` (so a call survives a screen lock).

## Changes

- `emu/iOS/emu` — un-comments `audio audio-sdl3` so `/dev/audio` is registered in the device table.
- `emu/iOS/audio-sdl3.c` — one-line forwarder around `emu/MacOSX/audio-sdl3.c`, with `AUDIO_PLATFORM_INIT_EXTERN` predefined so the included source declares `audio_platform_init` as an extern.
- `emu/MacOSX/audio-sdl3.c` — calls `audio_platform_init()` in `ensure_sdl_audio` before `SDL_InitSubSystem(SDL_INIT_AUDIO)`. Default is a static no-op (macOS, Linux desktop unchanged); the iOS shim flips it to extern.
- `emu/iOS/audiosession.m` — configures `AVAudioSession`:
  - category `.playAndRecord` (without this `.soloAmbient` is the default and capture silently returns zero samples)
  - mode `.voiceChat` (hardware AEC + noise suppression + voice isolation — the difference between two phones in the same room having a conversation and v0's "Forbidden Planet" feedback)
  - `.defaultToSpeaker` + `.allowBluetooth`
- `emu/iOS/mkfile-g` — `:N:` rule for the macOS dep + `audiosession.$O` in `OBJ`.
- `emu/iOS/app/Info.plist` — `UIBackgroundModes`: `audio`, `voip`. Without these iOS suspends the app on lock, the SDL stream is torn down, and the bridge cats EOF.

## Test plan

- [x] `./build-macos-sdl3.sh` — o.emu links, audiotone plays (no regression to v0)
- [x] `./build-macos-headless.sh` — o.emu links, no SDL deps (stub branch still good)
- [x] `IOSSDK=iphonesimulator ./build-ios-app.sh --gui` — sim app launches, SDL3/Metal up, no missing-symbol link error
- [ ] `audiotone` from a sim shell plays (sim audio routes through Mac speakers)
- [ ] `voice/test-tone` (single-shell loopback) plays through the 9P export inside the sim
- [ ] Device install on Ba'al + TCC mic prompt accepted; `voice/listen` accepts a connection; mic capture returns non-zero samples
- [ ] Two devices on the same ZeroTier network: `voice/dial peer` → two-way voice with AEC; no feedback when both phones share a room
- [ ] Screen lock during a call doesn't drop it (UIBackgroundModes verified)

Hardware-only items I can't verify from here — over to the user on Ba'al for the device side.

Refs: INFR-186, INFR-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)