### PR TITLE
Voice v2: /dev/opus codec device (INFR-187)

### DIFF
--- a/emu/MacOSX/emu
+++ b/emu/MacOSX/emu
@@ -22,6 +22,7 @@ dev
 	ip	ipif6-posix ipaux
 	eia
 	audio	audio-sdl3
+	opus
 	mem
 
 lib

--- a/emu/MacOSX/emu.c
+++ b/emu/MacOSX/emu.c
@@ -6,7 +6,7 @@
 
 #include "emu.root.h"
 
-ulong ndevs = 30;
+ulong ndevs = 31;
 
 extern Dev rootdevtab;
 extern Dev consdevtab;
@@ -29,6 +29,7 @@ extern Dev wmszdevtab;
 extern Dev ipdevtab;
 extern Dev eiadevtab;
 extern Dev audiodevtab;
+extern Dev opusdevtab;
 extern Dev memdevtab;
 Dev* devtab[]={
 	&rootdevtab,
@@ -52,6 +53,7 @@ Dev* devtab[]={
 	&ipdevtab,
 	&eiadevtab,
 	&audiodevtab,
+	&opusdevtab,
 	&memdevtab,
 	nil,
 	nil,

--- a/emu/MacOSX/mkfile-gui-sdl3
+++ b/emu/MacOSX/mkfile-gui-sdl3
@@ -9,5 +9,10 @@ GUISRC=\
 SDL3_CFLAGS=`pkg-config --cflags sdl3 2>/dev/null || echo "-I/opt/homebrew/include"`
 SDL3_LIBS=`pkg-config --libs sdl3 2>/dev/null || echo "-L/opt/homebrew/lib -lSDL3"`
 
-GUIFLAGS=-DGUI_SDL3 $SDL3_CFLAGS
-GUILIBS=$SDL3_LIBS
+# Opus codec for /dev/opus (INFR-187). pkg-config search path needs the
+# Homebrew prefix so brew-installed opus is found on a stock zsh.
+OPUS_CFLAGS=`PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --cflags opus 2>/dev/null || echo "-I/opt/homebrew/include"`
+OPUS_LIBS=`PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --libs opus 2>/dev/null || echo "-L/opt/homebrew/lib -lopus"`
+
+GUIFLAGS=-DGUI_SDL3 -DHAVE_OPUS $SDL3_CFLAGS $OPUS_CFLAGS
+GUILIBS=$SDL3_LIBS $OPUS_LIBS

--- a/emu/port/devopus.c
+++ b/emu/port/devopus.c
@@ -1,0 +1,392 @@
+/*
+ * devopus.c — Opus codec as a Plan 9 device. INFR-187.
+ *
+ * Exposes /dev/opus/ with four files:
+ *
+ *   ctl     — write config verbs: "rate N", "chans N", "frame_ms N",
+ *             "bitrate N". Read returns the current config.
+ *   enc     — write PCM (S16 native), read Opus frames. Encoder
+ *             accumulates the incoming PCM into frame_ms chunks,
+ *             encodes each chunk, and queues the result; readers pull
+ *             one complete Opus frame per read(2) (each prefixed with
+ *             a 2-byte big-endian length so a 9P-mounted reader can
+ *             still reassemble frames after Styx may have re-chunked).
+ *   dec     — write Opus frames (with 2-byte length prefix), read
+ *             decoded PCM. Symmetric to enc.
+ *   status  — counters + current config.
+ *
+ * Single global encoder + decoder for v0 — voice/dial-opus runs at
+ * most one pipeline per call so contention isn't real yet. Multi-call
+ * support follows in v3.
+ *
+ * Lifetime: encoder/decoder are lazily created on first open(enc) /
+ * open(dec); recreated on any ctl change that affects opus state
+ * (rate, chans). Frame-size + bitrate changes are applied in-place
+ * via opus_encoder_ctl without a recreate.
+ */
+
+#include "dat.h"
+#include "fns.h"
+#include "error.h"
+
+#ifdef HAVE_OPUS
+#include <opus/opus.h>
+#endif
+
+enum {
+	Qdir = 0,
+	Qctl,
+	Qenc,
+	Qdec,
+	Qstatus,
+
+	/* Opus accepts frames of 2.5/5/10/20/40/60 ms at 8/12/16/24/48 kHz.
+	 * 20 ms at 48 kHz = 960 frames per channel = the WebRTC default
+	 * and a good battery/latency point. */
+	Default_Rate	= 48000,
+	Default_Chans	= 1,
+	Default_FrameMs	= 20,
+	Default_Bitrate	= 24000,
+
+	/* Big enough for the largest opus packet at the highest bitrate
+	 * (~1500 bytes for 60ms @ 510 kbps stereo). */
+	Max_Enc_Frame	= 4000,
+};
+
+static
+Dirtab opustab[] = {
+	".",		{Qdir, 0, QTDIR},	0,	0555,
+	"ctl",		{Qctl},			0,	0666,
+	"enc",		{Qenc},			0,	0666,
+	"dec",		{Qdec},			0,	0666,
+	"status",	{Qstatus},		0,	0444,
+};
+
+static struct {
+	QLock	l;
+	int	rate;
+	int	chans;
+	int	frame_ms;
+	int	bitrate;
+#ifdef HAVE_OPUS
+	OpusEncoder	*enc;
+	OpusDecoder	*dec;
+#endif
+	Queue	*enc_q;		/* encoded frames waiting for a reader */
+	Queue	*dec_q;		/* decoded PCM waiting for a reader */
+	uchar	enc_pcm[8192];	/* PCM bytes accumulated between encodes */
+	int	enc_pcm_len;
+	uchar	dec_in[8192];	/* opus bytes accumulated between decodes */
+	int	dec_in_len;
+	uvlong	enc_pcm_bytes;	/* total PCM bytes written into enc */
+	uvlong	enc_out_frames;	/* total opus frames produced */
+	uvlong	dec_in_frames;	/* total opus frames written into dec */
+	uvlong	dec_pcm_bytes;	/* total PCM bytes produced from dec */
+} opus_state;
+
+static int frame_pcm_bytes(void)
+{
+	return opus_state.rate * opus_state.frame_ms / 1000
+		* opus_state.chans * 2;	/* S16 */
+}
+
+static void
+opusinit(void)
+{
+	opus_state.rate = Default_Rate;
+	opus_state.chans = Default_Chans;
+	opus_state.frame_ms = Default_FrameMs;
+	opus_state.bitrate = Default_Bitrate;
+}
+
+static Chan*
+opusattach(char *spec)
+{
+	return devattach('Z', spec);
+}
+
+static Walkqid*
+opuswalk(Chan *c, Chan *nc, char **name, int nname)
+{
+	return devwalk(c, nc, name, nname, opustab, nelem(opustab), devgen);
+}
+
+static int
+opusstat(Chan *c, uchar *db, int n)
+{
+	return devstat(c, db, n, opustab, nelem(opustab), devgen);
+}
+
+#ifdef HAVE_OPUS
+static int
+ensure_encoder(void)
+{
+	int err;
+	if(opus_state.enc != nil)
+		return 1;
+	opus_state.enc = opus_encoder_create(opus_state.rate, opus_state.chans,
+					     OPUS_APPLICATION_VOIP, &err);
+	if(err != OPUS_OK || opus_state.enc == nil) {
+		print("devopus: opus_encoder_create failed: %d\n", err);
+		return 0;
+	}
+	opus_encoder_ctl(opus_state.enc, OPUS_SET_BITRATE(opus_state.bitrate));
+	return 1;
+}
+
+static int
+ensure_decoder(void)
+{
+	int err;
+	if(opus_state.dec != nil)
+		return 1;
+	opus_state.dec = opus_decoder_create(opus_state.rate, opus_state.chans,
+					     &err);
+	if(err != OPUS_OK || opus_state.dec == nil) {
+		print("devopus: opus_decoder_create failed: %d\n", err);
+		return 0;
+	}
+	return 1;
+}
+#endif /* HAVE_OPUS */
+
+static Chan*
+opusopen(Chan *c, int omode)
+{
+	c = devopen(c, omode, opustab, nelem(opustab), devgen);
+#ifdef HAVE_OPUS
+	switch((ulong)c->qid.path) {
+	case Qenc:
+		qlock(&opus_state.l);
+		if(!ensure_encoder()) {
+			qunlock(&opus_state.l);
+			error("opus encoder unavailable");
+		}
+		if(opus_state.enc_q == nil)
+			opus_state.enc_q = qopen(64*1024, 0, nil, nil);
+		qunlock(&opus_state.l);
+		break;
+	case Qdec:
+		qlock(&opus_state.l);
+		if(!ensure_decoder()) {
+			qunlock(&opus_state.l);
+			error("opus decoder unavailable");
+		}
+		if(opus_state.dec_q == nil)
+			opus_state.dec_q = qopen(64*1024, 0, nil, nil);
+		qunlock(&opus_state.l);
+		break;
+	}
+#else
+	USED(omode);
+#endif
+	return c;
+}
+
+static void
+opusclose(Chan *c)
+{
+	USED(c);
+}
+
+static long
+opusread(Chan *c, void *va, long n, vlong off)
+{
+	char buf[256];
+	int len;
+
+	switch((ulong)c->qid.path) {
+	case Qdir:
+		return devdirread(c, va, n, opustab, nelem(opustab), devgen);
+
+	case Qctl:
+	case Qstatus:
+		qlock(&opus_state.l);
+		len = snprint(buf, sizeof buf,
+			"rate %d\nchans %d\nframe_ms %d\nbitrate %d\n"
+			"enc_pcm_bytes %lld\nenc_out_frames %lld\n"
+			"dec_in_frames %lld\ndec_pcm_bytes %lld\n",
+			opus_state.rate, opus_state.chans,
+			opus_state.frame_ms, opus_state.bitrate,
+			opus_state.enc_pcm_bytes, opus_state.enc_out_frames,
+			opus_state.dec_in_frames, opus_state.dec_pcm_bytes);
+		qunlock(&opus_state.l);
+		return readstr(off, va, n, buf);
+
+	case Qenc:
+		/* block until a complete encoded frame is available */
+		if(opus_state.enc_q == nil)
+			return 0;
+		return qread(opus_state.enc_q, va, n);
+
+	case Qdec:
+		if(opus_state.dec_q == nil)
+			return 0;
+		return qread(opus_state.dec_q, va, n);
+	}
+	return 0;
+}
+
+static long
+opuswrite(Chan *c, void *va, long n, vlong off)
+{
+#ifdef HAVE_OPUS
+	uchar *p = va;
+	int fpb;	/* frame pcm bytes */
+	int got;
+
+	USED(off);
+	switch((ulong)c->qid.path) {
+	case Qctl: {
+		char *cmd = malloc(n + 1);
+		int v;
+		if(cmd == nil)
+			error(Enomem);
+		memmove(cmd, va, n);
+		cmd[n] = 0;
+		qlock(&opus_state.l);
+		if(memcmp(cmd, "rate ", 5) == 0 && (v = atoi(cmd+5)) > 0) {
+			opus_state.rate = v;
+			if(opus_state.enc) {
+				opus_encoder_destroy(opus_state.enc);
+				opus_state.enc = nil;
+			}
+			if(opus_state.dec) {
+				opus_decoder_destroy(opus_state.dec);
+				opus_state.dec = nil;
+			}
+		} else if(memcmp(cmd, "chans ", 6) == 0 && (v = atoi(cmd+6)) > 0) {
+			opus_state.chans = v;
+			if(opus_state.enc) {
+				opus_encoder_destroy(opus_state.enc);
+				opus_state.enc = nil;
+			}
+			if(opus_state.dec) {
+				opus_decoder_destroy(opus_state.dec);
+				opus_state.dec = nil;
+			}
+		} else if(memcmp(cmd, "frame_ms ", 9) == 0 && (v = atoi(cmd+9)) > 0) {
+			opus_state.frame_ms = v;
+		} else if(memcmp(cmd, "bitrate ", 8) == 0 && (v = atoi(cmd+8)) > 0) {
+			opus_state.bitrate = v;
+			if(opus_state.enc)
+				opus_encoder_ctl(opus_state.enc, OPUS_SET_BITRATE(v));
+		}
+		qunlock(&opus_state.l);
+		free(cmd);
+		return n;
+	}
+
+	case Qenc:
+		/* Accumulate PCM in opus_state.enc_pcm; when we have a full
+		 * frame, encode it and push the bytes (with a 2-byte big-
+		 * endian length prefix) onto enc_q. */
+		qlock(&opus_state.l);
+		fpb = frame_pcm_bytes();
+		got = 0;
+		while(got < n) {
+			int take = sizeof opus_state.enc_pcm - opus_state.enc_pcm_len;
+			if(take > n - got) take = n - got;
+			memmove(opus_state.enc_pcm + opus_state.enc_pcm_len,
+				p + got, take);
+			opus_state.enc_pcm_len += take;
+			got += take;
+			opus_state.enc_pcm_bytes += take;
+			while(opus_state.enc_pcm_len >= fpb) {
+				uchar pkt[Max_Enc_Frame + 2];
+				int enc_n;
+				enc_n = opus_encode(opus_state.enc,
+					(const opus_int16*)opus_state.enc_pcm,
+					opus_state.rate * opus_state.frame_ms / 1000,
+					pkt + 2,
+					Max_Enc_Frame);
+				if(enc_n < 0) {
+					qunlock(&opus_state.l);
+					error("opus_encode failed");
+				}
+				pkt[0] = (enc_n >> 8) & 0xff;
+				pkt[1] = enc_n & 0xff;
+				qproduce(opus_state.enc_q, pkt, enc_n + 2);
+				opus_state.enc_out_frames++;
+				/* shift remainder down */
+				memmove(opus_state.enc_pcm,
+					opus_state.enc_pcm + fpb,
+					opus_state.enc_pcm_len - fpb);
+				opus_state.enc_pcm_len -= fpb;
+			}
+		}
+		qunlock(&opus_state.l);
+		return n;
+
+	case Qdec:
+		/* Accumulate opus bytes; consume one length-prefixed frame
+		 * at a time, decode it, push PCM onto dec_q. */
+		qlock(&opus_state.l);
+		got = 0;
+		while(got < n) {
+			int take = sizeof opus_state.dec_in - opus_state.dec_in_len;
+			if(take > n - got) take = n - got;
+			memmove(opus_state.dec_in + opus_state.dec_in_len,
+				p + got, take);
+			opus_state.dec_in_len += take;
+			got += take;
+			for(;;) {
+				int flen, dec_n;
+				short pcm[48000/1000*120*2];	/* worst case 120ms @ 48k stereo */
+				if(opus_state.dec_in_len < 2)
+					break;
+				flen = (opus_state.dec_in[0] << 8) | opus_state.dec_in[1];
+				if(flen > Max_Enc_Frame) {
+					qunlock(&opus_state.l);
+					error("opus frame length absurd");
+				}
+				if(opus_state.dec_in_len < 2 + flen)
+					break;
+				dec_n = opus_decode(opus_state.dec,
+					opus_state.dec_in + 2, flen,
+					pcm,
+					opus_state.rate * 120 / 1000,
+					0);
+				if(dec_n < 0) {
+					qunlock(&opus_state.l);
+					error("opus_decode failed");
+				}
+				qproduce(opus_state.dec_q, pcm,
+					dec_n * opus_state.chans * 2);
+				opus_state.dec_pcm_bytes += dec_n * opus_state.chans * 2;
+				opus_state.dec_in_frames++;
+				memmove(opus_state.dec_in,
+					opus_state.dec_in + 2 + flen,
+					opus_state.dec_in_len - 2 - flen);
+				opus_state.dec_in_len -= 2 + flen;
+			}
+		}
+		qunlock(&opus_state.l);
+		return n;
+	}
+	return 0;
+#else  /* !HAVE_OPUS */
+	USED(c); USED(va); USED(n); USED(off);
+	error("devopus: built without libopus");
+	return 0;
+#endif
+}
+
+Dev opusdevtab = {
+	'Z',
+	"opus",
+
+	opusinit,
+	opusattach,
+	opuswalk,
+	opusstat,
+	opusopen,
+	devcreate,
+	opusclose,
+	opusread,
+	devbread,
+	opuswrite,
+	devbwrite,
+	devremove,
+	devwstat
+};

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -100,6 +100,7 @@ TARG=\
 	lucibridge_test.dis\
 	lucifer_helpers_test.dis\
 	matrix_perfdashboard_test.dis\
+	opus_test.dis\
 	keyringinst_test.dis\
 	contacts_tool_test.dis\
 	sms_msgsrc_test.dis\

--- a/tests/opus_test.b
+++ b/tests/opus_test.b
@@ -1,0 +1,286 @@
+implement OpusTest;
+
+#
+# opus_test — Unit tests for /dev/opus (devopus.c). INFR-187.
+#
+# Covers the v0 device contract:
+#   - bind exposes /n/opus with ctl, enc, dec, status files.
+#   - ctl read returns the current config; status read returns counters.
+#   - ctl writes are parsed and update counters (rate, chans, frame_ms,
+#     bitrate).
+#   - Encoder: write N x frame_ms-worth of PCM, expect N opus frames
+#     to appear (status counters advance correctly).
+#   - Round-trip: PCM -> enc -> dec -> PCM and check the decoded byte
+#     count roughly matches what we encoded (lossy, frame-aligned).
+#
+# We push synthetic silence (all-zero PCM) rather than driving the SDL3
+# audio device — that keeps the test deterministic and CI-runnable
+# without any TCC mic prompt.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+OpusTest: module {
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/opus_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	* =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# True if /n/opus is already mounted. We do the bind once in init() so
+# every test sees the same namespace.
+opus_mounted(): int
+{
+	(ok, nil) := sys->stat("/n/opus/status");
+	return ok >= 0;
+}
+
+read_all(path: string, max: int): array of byte
+{
+	fd := sys->open(path, Sys->OREAD);
+	if(fd == nil)
+		return nil;
+	buf := array[max] of byte;
+	n := sys->read(fd, buf, max);
+	if(n <= 0)
+		return nil;
+	return buf[:n];
+}
+
+read_status(): string
+{
+	b := read_all("/n/opus/status", 4096);
+	if(b == nil)
+		return "";
+	return string b;
+}
+
+# Extract `key value` line from status text; return value or "".
+extract(s: string, key: string): string
+{
+	# walk lines
+	i := 0;
+	while(i < len s) {
+		j := i;
+		while(j < len s && s[j] != '\n')
+			j++;
+		line := s[i:j];
+		if(len line > len key && line[:len key] == key && line[len key] == ' ')
+			return line[len key + 1:];
+		i = j + 1;
+	}
+	return "";
+}
+
+ctl_set(verb: string): int
+{
+	fd := sys->open("/n/opus/ctl", Sys->OWRITE);
+	if(fd == nil)
+		return 0;
+	b := array of byte verb;
+	return sys->write(fd, b, len b);
+}
+
+testStatusInitial(t: ref T)
+{
+	s := read_status();
+	t.assertnotnil(s, "status non-empty");
+	t.assertseq(extract(s, "rate"), "48000",
+		"default rate is 48000");
+	t.assertseq(extract(s, "chans"), "1",
+		"default chans is 1 (mono — voice)");
+	t.assertseq(extract(s, "frame_ms"), "20",
+		"default frame_ms is 20 (WebRTC baseline)");
+	t.assertseq(extract(s, "bitrate"), "24000",
+		"default bitrate is 24000");
+}
+
+testCtlSetsValues(t: ref T)
+{
+	ctl_set("bitrate 32000");
+	s := read_status();
+	t.assertseq(extract(s, "bitrate"), "32000",
+		"bitrate verb takes effect");
+	# restore
+	ctl_set("bitrate 24000");
+}
+
+testCtlSetsFrameMs(t: ref T)
+{
+	ctl_set("frame_ms 40");
+	s := read_status();
+	t.assertseq(extract(s, "frame_ms"), "40",
+		"frame_ms verb takes effect");
+	# restore
+	ctl_set("frame_ms 20");
+}
+
+# Push N frames worth of silent PCM into the encoder and check the
+# counters track correctly. With rate=48000, chans=1, frame_ms=20,
+# one frame = 48000 * 0.020 * 1 * 2 = 1920 PCM bytes.
+testEncoderFramesAdvance(t: ref T)
+{
+	ctl_set("rate 48000");
+	ctl_set("chans 1");
+	ctl_set("frame_ms 20");
+
+	# Snapshot initial counters
+	s0 := read_status();
+	f0 := int extract(s0, "enc_out_frames");
+
+	fd := sys->open("/n/opus/enc", Sys->OWRITE);
+	t.assert(fd != nil, "open enc OWRITE");
+	if(fd == nil) return;
+
+	# 10 frames worth of silence
+	NFRAMES := 10;
+	FRAME_BYTES := 1920;
+	buf := array[NFRAMES * FRAME_BYTES] of byte;
+	# array of byte zero-initialised already
+
+	n := sys->write(fd, buf, len buf);
+	t.asserteq(n, len buf, "wrote all 10 frames worth of PCM");
+	fd = nil;	# close
+
+	s1 := read_status();
+	f1 := int extract(s1, "enc_out_frames");
+	t.asserteq(f1 - f0, NFRAMES,
+		"encoder produced exactly 10 frames");
+
+	# enc_pcm_bytes counter advanced by exactly what we wrote
+	p0 := int extract(s0, "enc_pcm_bytes");
+	p1 := int extract(s1, "enc_pcm_bytes");
+	t.asserteq(p1 - p0, NFRAMES * FRAME_BYTES,
+		"enc_pcm_bytes counter accurate");
+}
+
+# Read the encoded frames back and feed them straight into the decoder.
+# The decoder should produce roughly the same number of PCM frames out
+# as we put in.
+testRoundTripSilence(t: ref T)
+{
+	ctl_set("rate 48000");
+	ctl_set("chans 1");
+	ctl_set("frame_ms 20");
+
+	# Snapshot
+	s0 := read_status();
+	df0 := int extract(s0, "dec_in_frames");
+	dp0 := int extract(s0, "dec_pcm_bytes");
+
+	# Encode 5 frames of silence
+	encfd := sys->open("/n/opus/enc", Sys->ORDWR);
+	t.assert(encfd != nil, "open enc ORDWR");
+	if(encfd == nil) return;
+	NFRAMES := 5;
+	FRAME_BYTES := 1920;
+	silent := array[NFRAMES * FRAME_BYTES] of byte;
+	sys->write(encfd, silent, len silent);
+
+	# Drain the encoded frames. qread returns one queued buffer per
+	# call (one opus frame in our case), so we loop until status
+	# tells us we've drained every produced frame.
+	encbuf := array[16*1024] of byte;
+	encread := 0;
+	for(loops := 0; loops < NFRAMES * 2; loops++) {
+		r := sys->read(encfd, encbuf[encread:], len encbuf - encread);
+		if(r <= 0) break;
+		encread += r;
+		# Each frame is 2 bytes length + payload. Stop when we've
+		# seen NFRAMES frames in the buffer.
+		framecnt := 0; off := 0;
+		while(off + 2 <= encread) {
+			flen := (int encbuf[off] << 8) | int encbuf[off+1];
+			if(off + 2 + flen > encread) break;
+			framecnt++;
+			off += 2 + flen;
+		}
+		if(framecnt >= NFRAMES) break;
+	}
+	t.assert(encread > 0, "read encoded frames out");
+	if(encread <= 0) return;
+
+	# Feed straight into the decoder
+	decfd := sys->open("/n/opus/dec", Sys->ORDWR);
+	t.assert(decfd != nil, "open dec ORDWR");
+	if(decfd == nil) return;
+	dn := sys->write(decfd, encbuf, encread);
+	t.asserteq(dn, encread, "decoder accepted every encoded byte");
+
+	s1 := read_status();
+	df1 := int extract(s1, "dec_in_frames");
+	dp1 := int extract(s1, "dec_pcm_bytes");
+	t.asserteq(df1 - df0, NFRAMES,
+		"decoder consumed exactly 5 frames");
+	# Each decoded frame is 20ms @ 48k mono = 1920 PCM bytes
+	t.asserteq(dp1 - dp0, NFRAMES * FRAME_BYTES,
+		"decoded PCM bytes match encoded frame count");
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+	testing->init();
+
+	# Mount the opus device under /n/opus (path doesn't conflict with
+	# the read-only /dev). One-shot for every test.
+	sys->bind("#Z", "/n/opus", Sys->MREPL|Sys->MCREATE);
+	if(!opus_mounted()) {
+		# Some builds don't compile /dev/opus (no -DHAVE_OPUS); skip.
+		sys->fprint(sys->fildes(2),
+			"opus_test: /n/opus not mounted — devopus not built with libopus, skipping\n");
+		raise "fail:skip-suite";
+	}
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	run("StatusInitial", testStatusInitial);
+	run("CtlSetsValues", testCtlSetsValues);
+	run("CtlSetsFrameMs", testCtlSetsFrameMs);
+	run("EncoderFramesAdvance", testEncoderFramesAdvance);
+	run("RoundTripSilence", testRoundTripSilence);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}


### PR DESCRIPTION
## Summary

Adds an Opus codec device — `/dev/opus/{ctl,enc,dec,status}` — so the same `mount = call, kill = hangup` voice-mount pattern from INFR-185 can run at ~24 kbps instead of ~1.4 Mbps, which is the difference between voice working only over ZeroTier WiFi and voice working on a normal cellular link without burning battery.

## Shape

```
bind '#Z' /n/opus
ls /n/opus
  ctl     w   "rate N", "chans N", "frame_ms N", "bitrate N"
  enc    rw   write PCM in, read length-prefixed Opus frames out
  dec    rw   write length-prefixed Opus frames in, read PCM out
  status  r   current config + counters
```

Defaults: 48 kHz, 1 channel (mono — voice), 20 ms frames, 24 kbps. WebRTC baseline.

Wire format on `enc`/`dec`: each opus frame is preceded by a 2-byte big-endian length, so a 9P export that re-chunks Styx messages can still reassemble frames on the receiver.

## Build

- `brew install opus` (1.5.2 used here).
- `emu/MacOSX/mkfile-gui-sdl3` adds `OPUS_CFLAGS` / `OPUS_LIBS` via pkg-config with a `PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig` fallback.
- `HAVE_OPUS` gates the libopus impl. The headless macOS build doesn't link libopus, so devopus falls through to a stub that errors any operation — the device still links cleanly, just unusable in headless mode (matches the audio-sdl3 pattern from INFR-185).

## Tests (5/5 pass)

`tests/opus_test.b`:
- `StatusInitial` — defaults reported through `/n/opus/status` match the WebRTC baseline.
- `CtlSetsValues` — `bitrate 32000` round-trips through status.
- `CtlSetsFrameMs` — `frame_ms 40` round-trips through status.
- `EncoderFramesAdvance` — writing 10 × frame-worth of silent PCM produces exactly 10 opus frames in the queue.
- `RoundTripSilence` — encoded frames fed back into the decoder produce the right number of PCM bytes.

Plus the shell smoke: `audiotone /n/opus/enc` ➜ 882000 PCM bytes in, 459 opus frames out (matches the 1920-bytes-per-frame math).

## Test plan

- [x] macOS SDL3 build links libopus (otool confirms)
- [x] macOS headless build links cleanly with devopus stubbed out
- [x] `/n/opus/{ctl,enc,dec,status}` appears after `bind '#Z' /n/opus`
- [x] All 5 unit tests pass
- [ ] `voice/dial-opus` script — next commit on this branch once the 9P pipeline shape is validated
- [ ] iOS cross-build of libopus (separate ticket; waits on INFR-186 audio backend merge)
- [ ] Bandwidth measurement of an opus-mediated 9P loopback (~24 kbps target)

Refs: INFR-187, INFR-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)