### PR TITLE
audio-sdl3: retry open after SDL re-init if listener's forked child hits 'not initialized'

### DIFF
--- a/emu/MacOSX/audio-sdl3.c
+++ b/emu/MacOSX/audio-sdl3.c
@@ -145,6 +145,26 @@ open_stream(SDL_AudioDeviceID dev, Audio_d *fmt)
 
 	s = SDL_OpenAudioDeviceStream(dev, &spec, NULL, NULL);
 	if(s == NULL) {
+		/* Inferno's `listen { ... & }` builtin forks the parent
+		 * process to run the accept block; SDL3's audio subsystem
+		 * state doesn't survive across that fork on macOS (the
+		 * CoreAudio thread is in the parent address space only),
+		 * so the child sees "Audio subsystem is not initialized"
+		 * the first time it touches the device even though our
+		 * sdl_audio_inited static is still 1. Retry once after a
+		 * forced re-init — that brings the audio subsystem back up
+		 * in the child without disturbing the parent. */
+		const char *err = SDL_GetError();
+		if(err != nil && strstr(err, "not initialized") != nil) {
+			SDL_QuitSubSystem(SDL_INIT_AUDIO);
+			sdl_audio_inited = 0;
+			if(SDL_InitSubSystem(SDL_INIT_AUDIO)) {
+				sdl_audio_inited = 1;
+				s = SDL_OpenAudioDeviceStream(dev, &spec, NULL, NULL);
+			}
+		}
+	}
+	if(s == NULL) {
 		fprint(2, "audio-sdl3: SDL_OpenAudioDeviceStream(%s) failed: %s\n",
 			dev == SDL_AUDIO_DEVICE_DEFAULT_RECORDING ? "rec" : "play",
 			SDL_GetError());


### PR DESCRIPTION
## Summary

End-to-end voice between a Mac running `voice/listen` and an iPhone running `voice/dial` was almost working — the network handshake completed, mic capture on both sides worked, but Mac's speaker stayed silent. Stderr showed `SDL_OpenAudioDeviceStream(play) failed: Audio subsystem is not initialized` from the export server child every time.

Root cause: Inferno's `listen { ... & }` builtin **forks** the parent process to run the accept block. SDL3's audio subsystem state on macOS does not survive that fork — CoreAudio's threads live in the parent address space only. The forked export child sees "not initialized" the first time it touches the device, even though our `sdl_audio_inited` static is still 1 (inherited from the parent's heap).

## Fix

In `open_stream`, if `SDL_OpenAudioDeviceStream` returns NULL and the error string contains "not initialized", do `SDL_QuitSubSystem(SDL_INIT_AUDIO)` + `SDL_InitSubSystem(SDL_INIT_AUDIO)` in the child, reset the static guard, and retry the open once. Single retry — if the second open still fails, we surface the original error path. No infinite loop.

This brings CoreAudio back up in the child without disturbing the parent's audio state.

## Test plan

- [x] Mac SDL3 build links cleanly
- [x] Local `audiotone` still plays from a CLI emu (no regression to the single-process case)
- [x] End-to-end on real hardware: Mac listener (this patch) ↔ iPhone Ba'al over the test LAN
  - `voice/dial: connected to tcp!192.168.1.174!7070` — handshake intact
  - Mac mic → 9P → iPhone speaker (was already working)
  - **iPhone mic → 9P → Mac speaker** ← unblocked by this patch
  - User reports audible feedback as expected (no AEC at this layer — iOS already has hardware AEC via AVAudioSession `.voiceChat` from INFR-186; the Mac side has none, so a shared room mic/speaker pair will feed back)

Refs: INFR-188, INFR-185, INFR-186

🤖 Generated with [Claude Code](https://claude.com/claude-code)