### PR TITLE
audio-sdl3: cap SDL playback / capture queue depth — Android side drifts on sustained 9P stream (INFR-194)

### DIFF
--- a/emu/MacOSX/audio-sdl3.c
+++ b/emu/MacOSX/audio-sdl3.c
@@ -104,6 +104,39 @@ static int in_refcnt;			/* opens still holding /dev/audio for read */
 static int out_refcnt;			/* opens still holding /dev/audio for write */
 static Audio_t av;			/* current format (in.rate / chan / bits, out.*) */
 
+/*
+ * Per-stream queue caps in milliseconds (INFR-194). Without these
+ * SDL_AudioStream queues are unbounded; on a sustained 9P voice flow
+ * the macOS playback side accumulates whatever the network feeds it
+ * and the audio drifts minutes behind the speaker.
+ *
+ * Defaults are 0 (no cap) so non-voice workloads — audiotone, music
+ * playback, anything that bulk-writes ahead of the device — keep
+ * smooth, unbounded queueing. Voice opts in by writing to the ctl:
+ *
+ *   echo 'play_buffer_ms 100' > /dev/audioctl
+ *   echo 'rec_buffer_ms  100' > /dev/audioctl
+ *
+ * voice/listen and voice/dial both set these as part of their setup,
+ * so end users don't have to think about it.
+ *
+ * Drop policy is HEAD-drop (clear the stale catch-up backlog, keep
+ * the freshest data). For voice that's always right.
+ */
+static int play_buffer_ms = 0;
+static int rec_buffer_ms  = 0;
+
+/* bytes-per-second for a given Audio_d — used to translate the
+ * per-direction buffer cap from ms to bytes against the live format. */
+static int
+audio_bytes_per_sec(Audio_d *fmt)
+{
+	int bytes_per_sample = fmt->bits / 8;
+	if(bytes_per_sample <= 0)
+		bytes_per_sample = 2;
+	return (int)fmt->rate * (int)fmt->chan * bytes_per_sample;
+}
+
 static SDL_AudioFormat
 sdlfmt(ulong bits)
 {
@@ -248,6 +281,31 @@ audio_file_read(Chan *c, void *va, long n, vlong off)
 	if(in_stream == NULL)
 		return 0;
 
+	/*
+	 * Capture queue cap (INFR-194). If SDL has held onto more than
+	 * `rec_buffer_ms` of audio (because nobody read from us fast
+	 * enough), discard the stale portion. For voice that's right —
+	 * the listener wants fresh mic, not minutes-old chatter. Set
+	 * rec_buffer_ms=0 via ctl to disable.
+	 */
+	if(rec_buffer_ms > 0) {
+		int cap = (int)((vlong)audio_bytes_per_sec(&av.in) *
+				rec_buffer_ms / 1000);
+		int queued = SDL_GetAudioStreamAvailable(in_stream);
+		if(queued > cap) {
+			char drop[4096];
+			int over = queued - cap;
+			while(over > 0) {
+				int take = over > (int)sizeof drop
+					? (int)sizeof drop : over;
+				int r2 = SDL_GetAudioStreamData(in_stream,
+					drop, take);
+				if(r2 <= 0) break;
+				over -= r2;
+			}
+		}
+	}
+
 	/* Block until at least one byte is available. Inferno read(2) is
 	 * blocking on devaudio; SDL3 returns 0 on empty so we poll with
 	 * a short delay. */
@@ -270,6 +328,25 @@ audio_file_write(Chan *c, void *va, long n, vlong off)
 	USED(c); USED(off);
 	if(out_stream == NULL)
 		return 0;
+
+	/*
+	 * Playback queue cap (INFR-194). Without this, SDL's stream
+	 * queue grows unboundedly when the producer (a 9P export over
+	 * the network, in voice's case) feeds data faster than the
+	 * device drains at real time. A sustained Mac<->Samsung voice
+	 * call drifted minutes behind the speaker because of this.
+	 * Drop the stale head before writing the new tail. Set
+	 * play_buffer_ms=0 via ctl to disable (audiotone, music, etc).
+	 */
+	if(play_buffer_ms > 0) {
+		int cap = (int)((vlong)audio_bytes_per_sec(&av.out) *
+				play_buffer_ms / 1000);
+		int queued = SDL_GetAudioStreamQueued(out_stream);
+		if(queued > cap) {
+			SDL_ClearAudioStream(out_stream);
+		}
+	}
+
 	if(!SDL_PutAudioStreamData(out_stream, va, (int)n))
 		error((char*)SDL_GetError());
 	return n;
@@ -282,6 +359,26 @@ audio_ctl_write(Chan *c, void *va, long n, vlong off)
 	int r;
 
 	USED(c); USED(off);
+
+	/*
+	 * Buffer-cap verbs (INFR-194). Parsed and stripped here before
+	 * audioparse sees the rest of the line so audioparse doesn't
+	 * have to learn about non-format verbs. Each verb is a key + int.
+	 * "play_buffer_ms N" — cap playback queue depth, 0 = unbounded
+	 * "rec_buffer_ms  N" — cap capture queue depth, 0 = unbounded
+	 */
+	{
+		char *s = (char*)va;
+		if(n > 16 && memcmp(s, "play_buffer_ms ", 15) == 0) {
+			play_buffer_ms = atoi(s + 15);
+			return n;
+		}
+		if(n > 15 && memcmp(s, "rec_buffer_ms ", 14) == 0) {
+			rec_buffer_ms = atoi(s + 14);
+			return n;
+		}
+	}
+
 	/* Parse the verb into a scratch struct first so a malformed line
 	 * leaves the live av untouched. audioparse mutates only the
 	 * fields the verb mentions, so we start from a copy of av. */

--- a/lib/voice/dial
+++ b/lib/voice/dial
@@ -24,6 +24,12 @@ if {~ $#peer 0} {
 # Local /dev/audio must exist before we route bytes to it.
 bind -a '#A' /dev
 
+# Cap the audio backend's queue depth so the network can't drift the
+# speaker minutes behind real time (INFR-194). 100 ms is the
+# voice-grade default.
+echo 'play_buffer_ms 100' > /dev/audioctl >[2] /dev/null
+echo 'rec_buffer_ms 100'  > /dev/audioctl >[2] /dev/null
+
 # Mount the peer's exported /dev tree at /n/voice. -A skips TLS — same
 # rationale as voice/listen.
 mkdir -p /n/voice

--- a/lib/voice/listen
+++ b/lib/voice/listen
@@ -27,6 +27,13 @@ addr='tcp!*!'$port
 # devaudio onto /dev (idempotent — bind -a is a no-op if already there)
 bind -a '#A' /dev
 
+# Cap the audio backend's queue depth so a sustained network feed
+# can't drift the speaker minutes behind real time (INFR-194).
+# 100 ms is the voice-grade default; bump if you want smoother under
+# packet loss, lower if you want tighter sync.
+echo 'play_buffer_ms 100' > /dev/audioctl >[2] /dev/null
+echo 'rec_buffer_ms 100'  > /dev/audioctl >[2] /dev/null
+
 # announce + accept loop. Each accepted connection gets its own
 # `export /dev` server (the `&` keeps the listen loop free for the
 # next dial). -A turns off TLS for v0 — the spike runs over ZeroTier


### PR DESCRIPTION
## Summary

End-to-end Mac ↔ Samsung voice over 9P (INFR-185 / INFR-188) works in principle on real hardware, but the **Android** side accumulates **minutes of lag** on a sustained one-direction stream (Mac mic → Samsung speaker). User reported hearing their own typing and "testing" vocalisations many minutes after the actual event — coming out of the **Samsung speaker**.

iOS testing earlier in the session did not show comparable lag (the iPhone side stayed roughly in sync, likely because `AVAudioSession` in `.voiceChat` mode imposes tighter playback pacing from INFR-186).

Root cause: `SDL_AudioStream`'s queue is unbounded, and whatever the 9P export server feeds the Android playback side faster than AAudio drains at real time piled up indefinitely. The audio backend code is shared with macOS via `emu/Android/audio-sdl3.c`, the INFR-188 forwarder, so the fix applies once and lands on both platforms.

## Fix

Before each `SDL_PutAudioStreamData` (write) and each `SDL_GetAudioStreamData` (read), check the queue depth and drop the stale head if it exceeds the per-direction budget:

- `audio_file_write` → `SDL_ClearAudioStream(out_stream)` when queue > cap, then put the new tail.
- `audio_file_read` → drain the head into a throwaway buffer until queue ≤ cap, then read fresh frames.

Tunable per direction via ctl verbs:

```
echo 'play_buffer_ms 100' > /dev/audioctl
echo 'rec_buffer_ms  100' > /dev/audioctl
```

Defaults are **0** (cap disabled) so `audiotone`, music playback, anything that bulk-writes ahead of the device keeps its smooth unbounded queue. Voice opts in: both `voice/listen` and `voice/dial` now write the verbs as part of their setup, so the cap applies on Mac, iPhone and Samsung the moment voice/dial is invoked.

## Test plan

- [x] macOS SDL3 build links cleanly
- [x] macOS headless build still links (audio-sdl3 stubbed there)
- [x] `audiotone` (default cap off): 5 s pulse train plays through, no truncation — same runtime as before this CL.
- [x] `audiotone` with `play_buffer_ms 100` set manually via ctl: parsed without error, runs to completion.
- [ ] Rebuild Android APK with this fix; sustained Mac → Samsung call traceable within ≤ 500 ms.
- [ ] Mac → iPhone call: no regression (was already sub-second).

Refs: INFR-194, INFR-185, INFR-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)