### PR TITLE
android-app: single launcher icon, drop the headless duplicate (INFR-110)

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -37,23 +37,22 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
 
+        <!--
+          Headless Phase 2a Activity — kept exported so harness scripts
+          and `adb shell am start -n io.infernode/.InfernodeActivity`
+          still work, but no longer LAUNCHER-listed: Lucifer is the
+          one icon on the home screen now. INFR-110 promotion noted in
+          a previous commit comment; landing it here.
+        -->
         <activity
             android:name=".InfernodeActivity"
             android:exported="true"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:label="@string/app_name" />
 
         <!--
-          Phase 2b.1 (INFR-110) — SDL3-hosted Activity for the Lucifer/wm
-          port. Lives alongside the headless InfernodeActivity, so the
-          user can pick "InferNode" (the Phase 2a interactive shell) or
-          "InferNode (Lucifer)" (this) from the launcher. Once Lucifer is
-          mature enough to be the default surface, the headless icon
-          can drop its LAUNCHER intent.
+          Phase 2b.1 (INFR-110) — SDL3-hosted Activity for the
+          Lucifer/wm port. Now the sole launcher icon (relabeled to
+          just "InferNode" since there's no longer two to disambiguate).
 
           Attributes copied from SDL3's android-project AndroidManifest:
             launchMode=singleInstance — SDL3 expects one instance.
@@ -63,7 +62,7 @@
         -->
         <activity
             android:name=".InfernodeSDLActivity"
-            android:label="InferNode (Lucifer)"
+            android:label="@string/app_name"
             android:exported="true"
             android:launchMode="singleInstance"
             android:configChanges="layoutDirection|locale|fontScale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation">


### PR DESCRIPTION
## Summary

The home screen had two InferNode icons (the Phase 2a headless `InfernodeActivity` and the Phase 2b.1 Lucifer/wm `InfernodeSDLActivity`) because both carried `<intent-filter><LAUNCHER>`. The original 2b.1 commit noted the intent was to drop the headless icon once Lucifer was the default surface; voice over 9P now works end-to-end on the Lucifer build (the INFR-185 → INFR-188 → INFR-194 arc), so this is that promotion.

## Changes

- `InfernodeActivity` — drop the `<intent-filter>`. Still `android:exported="true"` so `adb shell am start -n io.infernode/.InfernodeActivity` works for harness scripts and test rigs that want the headless surface explicitly.
- `InfernodeSDLActivity` — relabel from `InferNode (Lucifer)` back to `@string/app_name`. With only one icon, the suffix is just noise.

## Test plan

- [x] Samsung A55 (Android 16): `adb shell cmd package query-activities -a android.intent.action.MAIN -c android.intent.category.LAUNCHER` returns `InfernodeSDLActivity` only.
- [x] `adb shell am start -n io.infernode/.InfernodeActivity` still launches the headless variant directly.
- [x] APK installs and the Lucifer Activity launches normally from the home-screen icon.

Refs: INFR-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)