### PR TITLE
docs+tests: VOICE.md + voice_scripts_test for the INFR-185 arc

### DIFF
--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -1,0 +1,201 @@
+# Voice over 9P
+
+InferNode does voice calls without inventing a call protocol. Each device
+exports `/dev/audio` over 9P; the peer mounts it; two `cat`s carry the
+audio. `mount` is the call. `kill` is the hangup. No SIP, no INVITE, no
+signalling.
+
+The design was sketched in INFR-185. The arc that lands it on real
+hardware runs from there through INFR-198. As of this writing the bridge
+is demonstrated end-to-end on macOS, iOS (iPhone 17 Pro Max) and Android
+(Samsung A55).
+
+## The shape
+
+Each side runs this once:
+
+```
+bind -a '#A' /dev                       # devaudio onto /dev
+sh /lib/voice/listen                    # announces tcp!*!7070,
+                                        # exports /dev under that mount
+```
+
+Either side dials:
+
+```
+sh /lib/voice/dial tcp!peer-ip!7070
+```
+
+`voice/dial` does the four cats that are the call:
+
+```
+cat /dev/audio  > /n/voice/audio &      # my mic   -> peer speaker
+cat /n/voice/audio > /dev/audio &       # peer mic -> my speaker
+```
+
+(The other two of the "four" are the inverse hookups on the peer's side
+once it dialled back, in the bidirectional case. For one-sided test rigs
+you can read either direction independently.)
+
+Hang up by killing the cat pids the script printed; the network mount
+times out and the listener accepts the next dial.
+
+## Platforms
+
+The audio backend (`emu/MacOSX/audio-sdl3.c`) is shared across macOS,
+iOS, and Android:
+
+- **macOS:** `audio-sdl3.c` direct, driving CoreAudio via SDL3.
+  - Mic capture from the CLI emu is gated by macOS TCC (INFR-199). The
+    listener can speak playback fine without it but its mic stays
+    silent until launched from a permission-granted bundle.
+- **iOS:** `emu/iOS/audio-sdl3.c` is a one-line forwarder around the
+  macOS source plus `emu/iOS/audiosession.m`, which configures
+  `AVAudioSession` in `.playAndRecord` mode with `.voiceChat`. The
+  voice-chat mode is what gives the iPhone hardware AEC (no feedback
+  when two phones share a room) and what raises the foreground TCC mic
+  permission prompt at the right moment (INFR-186 / INFR-190).
+- **Android:** `emu/Android/audio-sdl3.c` is the same one-line forwarder
+  (INFR-188). SDL3 drives AAudio under the hood; the APK's manifest
+  carries `RECORD_AUDIO` so first-use prompts inside Lucifer.
+
+The `audio_file_*` contract from `emu/port/audio.h` is identical on every
+platform. The only platform difference is what `audio_platform_init()`
+does — a no-op on macOS / Linux desktop, the AVAudioSession setup on
+iOS.
+
+## Two things the test rig taught us the hard way
+
+### 1. Bounded queues (INFR-194)
+
+`SDL_AudioStream`'s queue is unbounded. On a sustained voice flow the
+playback side accumulates whatever the network feeds it faster than the
+device drains at real time, and the audio drifts minutes behind the
+speaker. `audio_file_write` / `audio_file_read` now cap the queue
+depth at a configurable budget; when the queue exceeds it, the head is
+dropped so the speaker stays in sync with the talker.
+
+The cap is **off by default** so non-voice workloads (audiotone, music)
+keep their smooth unbounded queue. `voice/listen` and `voice/dial`
+opt in by writing two verbs to `audioctl` as their first action:
+
+```
+echo 'play_buffer_ms 100' > /dev/audioctl
+echo 'rec_buffer_ms  100' > /dev/audioctl
+```
+
+100 ms is the voice-grade default. WebRTC sits at 20-50 ms; the trade is
+smoothness under packet loss vs. latency. Tuning is in INFR-197.
+
+### 2. SDL audio reaches working state only when initialised right (INFR-195)
+
+The headless CLI emu doesn't call `SDL_Init(SDL_INIT_VIDEO)` at startup
+(only the GUI build does). Calling `SDL_InitSubSystem(SDL_INIT_AUDIO)`
+standalone produces an audio subsystem that *looks* initialised but
+that `SDL_OpenAudioDeviceStream` later rejects as "Audio subsystem is
+not initialized." The pattern that actually works:
+
+- `SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "coreaudio")` so SDL3 doesn't
+  silently fall back to the dummy backend.
+- `SDL_Init(SDL_INIT_AUDIO)` (canonical entry point, idempotent past
+  the first call).
+- A **pre-warm** in `voice/listen` that opens `/dev/audio` once inside
+  the `listen` block — same address space as the export server — so
+  the peer's later open just bumps a refcount instead of trying to
+  re-initialise SDL audio from a worker thread.
+
+The recording prewarm on a CLI macOS emu still surfaces "No default
+audio device available" (TCC gating, INFR-199). The bridge still works
+one-way in that case — Mac plays what the phone says, Mac mic stays out
+of the bridge.
+
+## Testing recipes
+
+### Mac ↔ Mac loopback (no devices needed)
+
+```
+./emu/MacOSX/o.emu -r$PWD -c0 sh /lib/voice/test-tone
+```
+
+Spins up its own listener, mounts the local 9P export, pumps an
+`audiotone` pulse train through every byte of the export path, plays
+the decoded result. If you hear ten short 1 kHz beeps over ~5 s, the
+codec + 9P + 4-cat bridge all work.
+
+### Mac ↔ iPhone
+
+```
+# On Mac (Terminal):
+./emu/MacOSX/o.emu -r$PWD -c0 sh /lib/voice/listen
+
+# On iPhone, in a Lucifer task-activity shell:
+sh /lib/voice/dial tcp!mac-ip!7070
+```
+
+iOS prompts for microphone permission on the first audio open. Tap
+Allow. From that point the Mac mic can be heard on the iPhone speaker
+and vice-versa. Wear headphones — there's no AEC on the Mac side
+(INFR-186 covers the iPhone side).
+
+### Mac ↔ Android
+
+Same shape with Samsung. INFR-189 unblocked the local-from-macOS APK
+build; INFR-188 wired the shared audio backend; INFR-194 + INFR-195
+made the bridge usable both ways.
+
+```
+adb shell input text "$(printf 'sh /lib/voice/dial tcp\x21mac-ip\x217070')"
+adb shell input keyevent 66
+```
+
+(`\x21` escapes `!` so zsh's history expansion doesn't mangle it.)
+
+### Phone ↔ Phone
+
+The product story. Not yet verified on hardware — tracked in INFR-198.
+Both phones should be able to do this today; what's untested is the
+iOS listener accepting incoming connections under `UIBackgroundModes`
+rules (`audio` + `voip`, already set) and whether typing the dial
+command into the iPhone Lucifer shell stays survivable in practice.
+
+## Optional opus codec path (INFR-187)
+
+`/dev/opus` wraps `libopus` as a Plan-9 device — `enc`, `dec`, `ctl`,
+`status`. Same `mount` model, just feed the encoded frames through
+instead of raw PCM. The use case is cellular — raw PCM is ~1.4 Mbps,
+opus cuts it to ~24 kbps. macOS builds link `libopus` via Homebrew;
+iOS / Android opus cross-builds are an open follow-up.
+
+```
+# Set up
+mkdir -p /n/opus
+bind '#Z' /n/opus
+echo 'rate 48000' > /n/opus/ctl
+echo 'chans 1'    > /n/opus/ctl
+echo 'frame_ms 20' > /n/opus/ctl
+echo 'bitrate 24000' > /n/opus/ctl
+
+# Pipe
+audiotone -r 48000 -c 1 /n/opus/enc      # writes encoded frames
+```
+
+The opus-aware voice scripts (`voice/listen-opus`, `voice/dial-opus`,
+`voice/test-tone-opus`) follow the same shape as the PCM ones with an
+extra two cats per direction for the encode / decode hops.
+
+## Where the work lives
+
+| Ticket | Status | What |
+|---|---|---|
+| INFR-185 | done | v0 PCM voice, macOS backend, voice/{listen,dial,test-tone} |
+| INFR-186 | done | iOS audio backend, AVAudioSession `.voiceChat` |
+| INFR-187 | done | `/dev/opus` codec device + opus pipeline scripts |
+| INFR-188 | done | Android shares the SDL3 audio backend |
+| INFR-189 | done | Local-from-macOS Android APK build |
+| INFR-190 | done | iOS mic permission prompt threading |
+| INFR-194 | done | SDL3 queue cap (kills minutes-of-drift) |
+| INFR-195 | done | SDL audio init + listen-block prewarm (Phone→Mac plays) |
+| INFR-197 | open | Buffer / sample-rate tuning to remove grit |
+| INFR-198 | open | Phone ↔ phone direct (no Mac in the loop) |
+| INFR-199 | open | Mac CLI listener mic capture (TCC bundle) |
+| INFR-191 | open | Shell backspace glitch on Samsung (blocked typing) |

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -108,6 +108,7 @@ TARG=\
 	sms_msgsrc_test.dis\
 	bioauth_test.dis\
 	softkbd_test.dis\
+	voice_scripts_test.dis\
 
 MODULES=
 

--- a/tests/voice_scripts_test.b
+++ b/tests/voice_scripts_test.b
@@ -1,0 +1,155 @@
+implement VoiceScriptsTest;
+
+#
+# voice_scripts_test — pin the shape of the voice/* rc scripts so a
+# refactor doesn't silently drop the audioctl buffer-cap writes
+# (INFR-194) or change the mount/cat structure (INFR-195's prewarm
+# lives inside the listen block; if someone moves it out the bridge
+# regresses to "phone-mic-can't-reach-Mac-speaker").
+#
+# These are not full integration tests — those need real audio
+# hardware + TCC permission on macOS and a connected phone, which is
+# tracked separately. What this test catches: someone edits one of
+# the rc scripts and accidentally removes a load-bearing line.
+#
+# What's verified:
+#   - lib/voice/listen exists, loads std, binds devaudio, writes
+#     both buffer-cap verbs to /dev/audioctl, calls listen.
+#   - lib/voice/dial exists, binds devaudio, writes buffer-cap
+#     verbs, calls mount.
+#   - lib/voice/test-tone exists (single-shell loopback recipe).
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+VoiceScriptsTest: module {
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/voice_scripts_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip"  => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# Read the whole script file into a single string. Bails the test with
+# fail:fatal if the file is missing — that's a stronger signal than
+# "well, this assertion would have passed if the file had existed."
+script_contents(t: ref T, path: string): string
+{
+	fd := sys->open(path, Sys->OREAD);
+	if(fd == nil) {
+		t.fatal(sys->sprint("%s not present", path));
+		raise "fail:fatal";
+	}
+	out := "";
+	buf := array[8192] of byte;
+	for(;;) {
+		n := sys->read(fd, buf, len buf);
+		if(n <= 0) break;
+		out += string buf[:n];
+	}
+	return out;
+}
+
+contains(haystack, needle: string): int
+{
+	if(len needle == 0) return 1;
+	for(i := 0; i + len needle <= len haystack; i++)
+		if(haystack[i:i+len needle] == needle)
+			return 1;
+	return 0;
+}
+
+testListenShape(t: ref T)
+{
+	s := script_contents(t, "/lib/voice/listen");
+	t.assert(contains(s, "load std"),
+		"voice/listen loads the std sh module");
+	t.assert(contains(s, "bind -a '#A' /dev"),
+		"voice/listen binds devaudio onto /dev");
+	t.assert(contains(s, "play_buffer_ms 100"),
+		"voice/listen writes INFR-194 playback buffer cap");
+	t.assert(contains(s, "rec_buffer_ms 100"),
+		"voice/listen writes INFR-194 capture buffer cap");
+	t.assert(contains(s, "listen "),
+		"voice/listen calls listen builtin");
+	t.assert(contains(s, "export /dev"),
+		"voice/listen exports /dev");
+}
+
+testDialShape(t: ref T)
+{
+	s := script_contents(t, "/lib/voice/dial");
+	t.assert(contains(s, "load std"),
+		"voice/dial loads the std sh module");
+	t.assert(contains(s, "bind -a '#A' /dev"),
+		"voice/dial binds devaudio onto /dev");
+	t.assert(contains(s, "play_buffer_ms 100"),
+		"voice/dial writes INFR-194 playback buffer cap");
+	t.assert(contains(s, "rec_buffer_ms 100"),
+		"voice/dial writes INFR-194 capture buffer cap");
+	t.assert(contains(s, "mount "),
+		"voice/dial calls mount");
+	t.assert(contains(s, "/n/voice/audio"),
+		"voice/dial references the mounted /n/voice/audio file");
+	t.assert(contains(s, "/dev/audio"),
+		"voice/dial references the local /dev/audio file");
+}
+
+testTestToneShape(t: ref T)
+{
+	s := script_contents(t, "/lib/voice/test-tone");
+	t.assert(contains(s, "audiotone"),
+		"voice/test-tone invokes audiotone");
+	t.assert(contains(s, "tcp!127.0.0.1!"),
+		"voice/test-tone targets the loopback");
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2),
+			"cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+	testing->init();
+
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("ListenShape", testListenShape);
+	run("DialShape", testDialShape);
+	run("TestToneShape", testTestToneShape);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}


### PR DESCRIPTION
## Summary

### docs/VOICE.md

Single source of truth for the voice arc that ran from INFR-185 through INFR-200 this session. Covers:

- The design ("mount = call, kill = hangup", no SIP, no signalling)
- The 9P plumbing — `bind '#A' /dev` + `voice/listen` + `voice/dial` + the four-cat bridge
- All three platforms (macOS, iOS via INFR-186, Android via INFR-188)
- The two hard lessons from the test rig:
  - INFR-194 — bounded queues (without them: minutes of drift)
  - INFR-195 — SDL audio init + listen-block prewarm (without them: phone mic → Mac speaker silent)
- Testing recipes that actually worked on real hardware (Mac↔Mac loopback, Mac↔iPhone, Mac↔Samsung, the phone↔phone case that's tracked but not yet verified)
- Optional opus codec path (INFR-187)
- Index of every ticket in the arc

### tests/voice_scripts_test.b

Three tests that pin the shape of `lib/voice/{listen,dial,test-tone}`. Not full end-to-end integration — those need real hardware + TCC + a connected phone, tracked under INFR-197 / INFR-198 / INFR-199. What this catches: someone edits a load-bearing line out of the rc scripts (audioctl buffer-cap writes from INFR-194, the mount call, the `export /dev`) without realising what it broke.

3/3 pass locally.

## Test plan

- [x] `mk install` in `tests/` builds `voice_scripts_test.dis`
- [x] `./emu/MacOSX/o.emu -r. /dis/tests/voice_scripts_test.dis -v` — 3 passed
- [x] No other tests touched
- [ ] CI green

## Follow-ups filed (already linked from VOICE.md)

- **INFR-197** — voice quality tuning (buffer ms + sample rate)
- **INFR-198** — phone ↔ phone direct call
- **INFR-199** — Mac CLI listener mic via .app bundle (TCC)
- **INFR-200** — shell backspace glitch (Samsung)

Refs: INFR-185, INFR-194, INFR-195, INFR-197, INFR-198, INFR-199, INFR-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)