### PR TITLE
feat(/phone): Android dial via ACTION_CALL + INFR-201 rate guardrail

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -23,6 +23,18 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!--
+      CALL_PHONE — INFR-201. Lets `/phone/phone` dial verb fire
+      Intent.ACTION_CALL via InfernodePhoneBridge, originating a PSTN
+      call without bouncing through the system dialer. Granted at
+      runtime (API 23+) the same way RECORD_AUDIO is.
+
+      Companion is QUERY_ALL_PACKAGES — we don't take it; if the
+      handset has no app that can resolve `tel:` the dial silently
+      no-ops, which is the expected outcome on a tablet etc.
+    -->
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+
+    <!--
       Launcher icons sourced from MacOSX/InferNode.icns (1024x1024
       master) and downsampled into res/mipmap-{m,h,xh,xxh,xxxh}dpi/
       at the standard Android density steps. ic_launcher.png is the

--- a/android-app/app/src/main/cpp/jni-emu.c
+++ b/android-app/app/src/main/cpp/jni-emu.c
@@ -40,7 +40,10 @@ extern int emu_run(int argc, char **argv);
  * Access to g_listener / g_onLine_mid is guarded by g_listener_lock
  * because the stdio reader pthread and Java callers both touch them.
  */
-static JavaVM *g_vm;
+/* Owned by emu/Android/phonebridge.c — that translation unit links into
+ * both the headless o.emu and libemu.so. We just read/write it from
+ * JNI_OnLoad (INFR-201). */
+extern JavaVM *g_vm;
 static jobject g_listener;          /* global ref */
 static jmethodID g_onLine_mid;
 static pthread_mutex_t g_listener_lock = PTHREAD_MUTEX_INITIALIZER;

--- a/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
@@ -1,0 +1,95 @@
+package io.infernode
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+/**
+ * Phone bridge for INFR-201: native side calls into here from
+ * emu/Android/phonebridge.c to originate a PSTN call.
+ *
+ * Why a separate class: the C bridge runs on a non-JVM pthread; it
+ * AttachCurrentThread's, looks this class up by FQN, calls the static
+ * `dial` method. Static-only API keeps the JNI shim trivial — no
+ * jobject lifecycle to manage across the C/Kotlin boundary.
+ *
+ * Context handling: an Intent needs a Context to fire from. The C
+ * thread doesn't have one. The Activity/Service registers one via
+ * [attach] at startup; we hold it as a weak-ish application-scope
+ * field (the Application object lives as long as the process, so a
+ * plain reference is fine — there's no Activity-leak risk because we
+ * never store an Activity, only the applicationContext).
+ *
+ * Permission contract: CALL_PHONE is declared in AndroidManifest and
+ * granted at runtime by [ensureCallPhonePermission] in the Activity.
+ * If the user denies it, [dial] returns -1 and the agent surfaces the
+ * `permission denied` error path through devphone.
+ */
+object InfernodePhoneBridge {
+
+    private const val TAG = "InfernodePhoneBridge"
+
+    @Volatile
+    private var appContext: Context? = null
+
+    /**
+     * Hand the bridge an applicationContext. Call once from the
+     * Activity (or Service) onCreate; subsequent calls overwrite.
+     * The C side is no-op until this has been called at least once.
+     */
+    @JvmStatic
+    fun attach(ctx: Context) {
+        appContext = ctx.applicationContext
+        Log.i(TAG, "attached applicationContext for /phone bridge")
+    }
+
+    /**
+     * Originate a PSTN call. Returns 0 on success (Intent dispatched),
+     * -1 on any failure (no context, permission denied, no resolver).
+     *
+     * Called from emu/Android/phonebridge.c's `phonebridge_phone_ctl`
+     * when the agent writes `dial <number>` to `/phone/phone`. The
+     * number is whatever the agent passed — we don't reformat it here;
+     * devphone strips the verb and trailing newline, and the host OS
+     * parses the `tel:` URI on its end.
+     *
+     * Threading: invoked on a JVM-attached pthread from JNI. Intent
+     * dispatch is thread-safe via startActivity; we don't bounce to
+     * the main thread.
+     */
+    @JvmStatic
+    fun dial(number: String): Int {
+        val ctx = appContext
+        if (ctx == null) {
+            Log.w(TAG, "dial($number): no context attached — call attach() first")
+            return -1
+        }
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.CALL_PHONE)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "dial($number): CALL_PHONE not granted")
+            return -1
+        }
+        return try {
+            val intent = Intent(Intent.ACTION_CALL, Uri.parse("tel:$number")).apply {
+                // FLAG_ACTIVITY_NEW_TASK is mandatory when starting an
+                // Activity from a non-Activity Context (we hold an
+                // applicationContext, not an Activity ref — see attach()).
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            ctx.startActivity(intent)
+            Log.i(TAG, "dial($number): ACTION_CALL dispatched")
+            0
+        } catch (se: SecurityException) {
+            Log.w(TAG, "dial($number): SecurityException — ${se.message}")
+            -1
+        } catch (t: Throwable) {
+            Log.w(TAG, "dial($number): ${t.javaClass.simpleName} — ${t.message}")
+            -1
+        }
+    }
+}

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -120,6 +120,8 @@ class InfernodeSDLActivity : SDLActivity() {
         // dialog off before SDL takes the surface; AAudio capture in
         // /dev/audio would silently return zeros otherwise.
         ensureRecordAudioPermission()
+        ensureCallPhonePermission()
+        InfernodePhoneBridge.attach(this)
         super.onCreate(savedInstanceState)
 
         // Phase 2b.2 / INFR-115 — keep Lucifer's SDL surface inside the
@@ -188,6 +190,22 @@ class InfernodeSDLActivity : SDLActivity() {
                 this,
                 arrayOf(Manifest.permission.RECORD_AUDIO),
                 /* requestCode = */ 1
+            )
+        }
+    }
+
+    private fun ensureCallPhonePermission() {
+        // INFR-201: required so InfernodePhoneBridge.dial can fire
+        // ACTION_CALL without bouncing through the system dialer.
+        // Distinct requestCode from RECORD_AUDIO so the result callback
+        // (if we add one later) can disambiguate.
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CALL_PHONE)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.CALL_PHONE),
+                /* requestCode = */ 2
             )
         }
     }

--- a/emu/Android/phonebridge.c
+++ b/emu/Android/phonebridge.c
@@ -31,7 +31,97 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <jni.h>
 #include "phonebridge.h"
+
+/* Owns the JavaVM* used by both the JNI bridge and our dial path.
+ * jni-emu.c (built into libemu.so) extern-declares this and assigns
+ * to it in JNI_OnLoad; the headless o.emu links this translation unit
+ * with g_vm staying NULL, and android_dial() handles that as a clean
+ * "JNI not initialised" failure. */
+JavaVM *g_vm = NULL;
+
+/*
+ * INFR-201: fire Intent.ACTION_CALL via InfernodePhoneBridge.dial.
+ *
+ * Runs on whichever thread called phonebridge_phone_ctl (Inferno
+ * kproc), which the JVM doesn't know about. AttachCurrentThread is
+ * mandatory; we detach before returning so a long-lived Inferno
+ * thread doesn't accumulate JVM attachments.
+ *
+ * Returns 0 on success, -1 on any failure (no JVM, lookup miss,
+ * Kotlin reported failure, exception). Caller surfaces the error
+ * string the C side already populated.
+ */
+static int
+android_dial(const char *number, char *err, int errlen)
+{
+	JNIEnv *env;
+	jclass cls;
+	jmethodID mid;
+	jstring jnum;
+	jint rc;
+	int attached = 0;
+
+	if(g_vm == NULL){
+		snprintf(err, errlen, "phone: JNI not initialised (g_vm null)");
+		return -1;
+	}
+	switch((*g_vm)->GetEnv(g_vm, (void**)&env, JNI_VERSION_1_6)){
+	case JNI_OK:
+		break;
+	case JNI_EDETACHED:
+		if((*g_vm)->AttachCurrentThread(g_vm, &env, NULL) != JNI_OK){
+			snprintf(err, errlen, "phone: AttachCurrentThread failed");
+			return -1;
+		}
+		attached = 1;
+		break;
+	default:
+		snprintf(err, errlen, "phone: GetEnv failed");
+		return -1;
+	}
+
+	cls = (*env)->FindClass(env, "io/infernode/InfernodePhoneBridge");
+	if(cls == NULL){
+		(*env)->ExceptionClear(env);
+		snprintf(err, errlen,
+			"phone: FindClass(InfernodePhoneBridge) failed");
+		if(attached) (*g_vm)->DetachCurrentThread(g_vm);
+		return -1;
+	}
+	mid = (*env)->GetStaticMethodID(env, cls, "dial",
+		"(Ljava/lang/String;)I");
+	if(mid == NULL){
+		(*env)->ExceptionClear(env);
+		(*env)->DeleteLocalRef(env, cls);
+		snprintf(err, errlen,
+			"phone: GetStaticMethodID(dial) failed");
+		if(attached) (*g_vm)->DetachCurrentThread(g_vm);
+		return -1;
+	}
+	jnum = (*env)->NewStringUTF(env, number ? number : "");
+	rc = (*env)->CallStaticIntMethod(env, cls, mid, jnum);
+	if((*env)->ExceptionCheck(env)){
+		(*env)->ExceptionDescribe(env);
+		(*env)->ExceptionClear(env);
+		rc = -1;
+	}
+
+	(*env)->DeleteLocalRef(env, jnum);
+	(*env)->DeleteLocalRef(env, cls);
+	if(attached)
+		(*g_vm)->DetachCurrentThread(g_vm);
+
+	if(rc != 0){
+		snprintf(err, errlen,
+			"phone: Android dial returned %d "
+			"(no context attached, CALL_PHONE not granted, or no tel: resolver)",
+			(int)rc);
+		return -1;
+	}
+	return 0;
+}
 
 void
 phonebridge_init(void)
@@ -71,7 +161,18 @@ phonebridge_send_sms(const char *number, const char *body, char *err, int errlen
 int
 phonebridge_phone_ctl(const char *verb, const char *rest, char *err, int errlen)
 {
-	fprintf(stderr, "phone: Android phone_ctl %s%s%s (stub)\n",
+	/* INFR-201: dial is the only verb wired today. answer / hangup
+	 * need TelecomManager.acceptRingingCall + endCall (API 26+,
+	 * ANSWER_PHONE_CALLS perm) and live with the rest of INFR-182. */
+	if(verb != NULL && strcmp(verb, "dial") == 0){
+		if(rest == NULL || rest[0] == 0){
+			snprintf(err, errlen, "phone: dial: missing number");
+			return -1;
+		}
+		fprintf(stderr, "phone: Android dial %s\n", rest);
+		return android_dial(rest, err, errlen);
+	}
+	fprintf(stderr, "phone: Android phone_ctl %s%s%s (stub — INFR-182)\n",
 		verb ? verb : "", rest ? " " : "", rest ? rest : "");
 	(void)err; (void)errlen;
 	return 0;

--- a/emu/port/devphone.c
+++ b/emu/port/devphone.c
@@ -42,6 +42,25 @@
 #define	ERRBUFSZ	256
 #define	QLIMIT		16384	/* per-channel queue cap; 32 SMS records ≈ */
 
+/*
+ * INFR-201 dial-rate guardrail. A misbehaving agent (looped tool call,
+ * bad prompt, anything) could otherwise dial-storm the radio. Cap is
+ * intentionally generous for human-paced use but tight enough to bound
+ * abuse: 10 dials per 60-second sliding window.
+ *
+ * The "window" is a single epoch — we don't keep a ring buffer of
+ * timestamps because the limit is small and a single-second-resolution
+ * counter is sufficient. When elapsed >= DIAL_WINDOW_SEC since the
+ * window's start, reset counter and start a new window. State is
+ * process-global; the namespace itself is process-global so this is
+ * the right scope.
+ */
+#define	DIAL_MAX_PER_WINDOW	10
+#define	DIAL_WINDOW_MS		(60 * 1000)
+
+static long	dial_window_start_ms;	/* osmillisec() at window start */
+static int	dial_window_count;
+
 enum
 {
 	Qdir,
@@ -484,6 +503,37 @@ phonewrite(Chan *c, void *va, long n, vlong offset)
 
 	case Qphone:
 		/* dial <num> / answer [id] / hangup [id] */
+		if(verb != nil && strcmp(verb, "dial") == 0){
+			/*
+			 * INFR-201 dial-rate guardrail. Sliding 60-second window,
+			 * 10-dial cap. Single epoch, no ring buffer — see
+			 * DIAL_MAX_PER_WINDOW comment above.
+			 *
+			 * Audit line goes to stderr on every dial attempt
+			 * regardless of accept/reject so a "where did this call
+			 * come from" question is answerable from the host log.
+			 */
+			long now = osmillisec();
+			if(now - dial_window_start_ms >= DIAL_WINDOW_MS){
+				dial_window_start_ms = now;
+				dial_window_count = 0;
+			}
+			if(dial_window_count >= DIAL_MAX_PER_WINDOW){
+				fprint(2,
+					"phone: dial %s REJECTED (rate limit %d/%dms)\n",
+					rest ? rest : "(nil)",
+					DIAL_MAX_PER_WINDOW, DIAL_WINDOW_MS);
+				snprint(errbuf, sizeof errbuf,
+					"phone: dial rate limit reached (%d per %d s)",
+					DIAL_MAX_PER_WINDOW, DIAL_WINDOW_MS / 1000);
+				r = -1;
+				break;
+			}
+			dial_window_count++;
+			fprint(2, "phone: dial %s (audit %d/%d in window)\n",
+				rest ? rest : "(nil)",
+				dial_window_count, DIAL_MAX_PER_WINDOW);
+		}
 		r = phonebridge_phone_ctl(verb, rest, errbuf, sizeof errbuf);
 		break;
 


### PR DESCRIPTION
## Summary

The `/phone/phone` dial verb has been working on iOS since CXCallObserver landed. Android was a logging stub. This PR fills in the dial half so an agent can finally originate a PSTN call on the Samsung A55 the same way it does on Ba'al.

The full Telephony bridge (SMS send + inbound observer + answer/hangup) stays under INFR-182. INFR-201 is just the outbound dial path and the cross-platform guardrail.

### Why ACTION_CALL, not RIL

Hellaphone (2012) talked straight to RIL via `/dev/socket/rild` with a hand-rolled `RIL_REQUEST_DIAL` parcel. SELinux locked that socket behind `u:r:rild:s0` in Android 6 — userspace apps cannot reach it without root + a custom SEPolicy patch. The only path for a third-party app today is `TelecomManager` or `Intent.ACTION_CALL`. ACTION_CALL is the simpler one: no `ConnectionService`, no `ROLE_DIALER` / `PhoneAccount` registration, no API-26 floor.

### What's wired

**Android**
- `AndroidManifest.xml` — `CALL_PHONE`.
- `InfernodeSDLActivity` — requests `CALL_PHONE` alongside `RECORD_AUDIO` in `onCreate`, attaches an `applicationContext` to the bridge.
- `InfernodePhoneBridge.kt` (new) — `object` with a `@JvmStatic dial(number)` that fires `Intent.ACTION_CALL` against the captured `applicationContext`. Returns 0 / -1.
- `emu/Android/phonebridge.c` — dispatches on verb; `dial` goes through JNI (`AttachCurrentThread` → `FindClass` → `CallStaticIntMethod`). `answer` / `hangup` stay logged-stub for INFR-182.

`g_vm` storage moved into `phonebridge.c` (extern in `jni-emu.c`) so the headless `o.emu` — which doesn't link `jni-emu.c` — still links cleanly with `phonebridge.o` providing the symbol.

**Cross-platform (`emu/port/devphone.c` Qphone case)**

Sliding 60-second window capped at 10 dials. Process-global counter, matches namespace scope. Audit line goes to host stderr on every dial attempt (accepted and rejected) so "where did this call come from" stays answerable from the log. iOS picks up the guardrail for free.

## Test plan

Build (all four green locally):
- [x] `./build-macos-sdl3.sh`
- [x] `ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk/28.0.12674087 ./build-android-ndk-arm64.sh`
- [x] `ANDROID_NDK_HOME=… ANDROID_HOME=$HOME/Library/Android/sdk ./build-android-apk.sh --gui sdl3`
- [x] `IOSSDK=iphoneos ./build-ios-arm64.sh`

Device smoke (manual, requires Samsung A55):
- [ ] `adb install -r app-debug.apk`
- [ ] Launch InferNode → grant `CALL_PHONE` at first prompt
- [ ] In Lucifer task shell: `echo 'dial +6512345678' > /phone/phone`
- [ ] Android dialer launches with number; cellular call originates
- [ ] `adb logcat -s InfernodePhoneBridge:* InferNode:*` shows `dial(...) ACTION_CALL dispatched` + the audit line from devphone

Guardrail (any device):
- [ ] 11 consecutive dials in <60s — the 11th returns `phone: dial rate limit reached (10 per 60 s)` on the write

No automated test added: macOS test rig doesn't compile `devphone.c` (not in the `emu` conf), and the Android dial path needs a real device with a SIM and the dialer permission grant — outside CI scope.

Refs: INFR-201, INFR-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)