### PR TITLE
fix(/phone): cache JNI class + bounce dial to main thread (INFR-201 follow-up)

### DIFF
--- a/android-app/app/src/main/cpp/jni-emu.c
+++ b/android-app/app/src/main/cpp/jni-emu.c
@@ -44,6 +44,12 @@ extern int emu_run(int argc, char **argv);
  * both the headless o.emu and libemu.so. We just read/write it from
  * JNI_OnLoad (INFR-201). */
 extern JavaVM *g_vm;
+
+/* Populated by phonebridge_jni_init below. Cached here so JNI_OnLoad —
+ * which runs under the app classloader — can resolve our Kotlin bridge
+ * class. FindClass from any other thread sees only the system loader
+ * and can't reach io.infernode.* classes. */
+extern void phonebridge_jni_init(JNIEnv *env);
 static jobject g_listener;          /* global ref */
 static jmethodID g_onLine_mid;
 static pthread_mutex_t g_listener_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -309,11 +315,18 @@ Java_io_infernode_Emu_setOutputListener(JNIEnv *env, jclass cls, jobject listene
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
+	JNIEnv *env;
 	(void)reserved;
 	g_vm = vm;
 	capture_stdio();
 	__android_log_write(ANDROID_LOG_INFO, TAG,
 		"libemu.so JNI_OnLoad — stdin/stdout routed");
+	/* Cache InfernodePhoneBridge here while the app classloader is
+	 * the current loader. From an AttachCurrentThread'd pthread the
+	 * loader is the system one and our app classes are invisible. */
+	if((*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6) == JNI_OK){
+		phonebridge_jni_init(env);
+	}
 	return JNI_VERSION_1_6;
 }
 

--- a/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
 
@@ -57,9 +59,17 @@ object InfernodePhoneBridge {
      * devphone strips the verb and trailing newline, and the host OS
      * parses the `tel:` URI on its end.
      *
-     * Threading: invoked on a JVM-attached pthread from JNI. Intent
-     * dispatch is thread-safe via startActivity; we don't bounce to
-     * the main thread.
+     * Threading: invoked on an AttachCurrentThread'd Inferno kproc
+     * pthread whose stack is ~28 KB — far too small for the
+     * startActivity → ActivityManager binder roundtrip (StackOverflowError
+     * shows up in logcat tagged with our TAG if you try). We post the
+     * actual dispatch to the main thread, where the stack is the system
+     * default. Trade: we lose the in-band error result, so we report
+     * success/fail asynchronously via logcat and return 0 to the caller
+     * unconditionally once the post is scheduled. The pre-flight checks
+     * (context null, permission denied) still run synchronously and
+     * return -1 — those are the cases where the C side genuinely needs
+     * to know the dial won't happen.
      */
     @JvmStatic
     fun dial(number: String): Int {
@@ -74,22 +84,22 @@ object InfernodePhoneBridge {
             Log.w(TAG, "dial($number): CALL_PHONE not granted")
             return -1
         }
-        return try {
-            val intent = Intent(Intent.ACTION_CALL, Uri.parse("tel:$number")).apply {
-                // FLAG_ACTIVITY_NEW_TASK is mandatory when starting an
-                // Activity from a non-Activity Context (we hold an
-                // applicationContext, not an Activity ref — see attach()).
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        Handler(Looper.getMainLooper()).post {
+            try {
+                val intent = Intent(Intent.ACTION_CALL, Uri.parse("tel:$number")).apply {
+                    // FLAG_ACTIVITY_NEW_TASK is mandatory when starting an
+                    // Activity from a non-Activity Context (we hold an
+                    // applicationContext, not an Activity ref — see attach()).
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                ctx.startActivity(intent)
+                Log.i(TAG, "dial($number): ACTION_CALL dispatched on main thread")
+            } catch (se: SecurityException) {
+                Log.w(TAG, "dial($number): SecurityException — ${se.message}")
+            } catch (t: Throwable) {
+                Log.w(TAG, "dial($number): ${t.javaClass.simpleName} — ${t.message}")
             }
-            ctx.startActivity(intent)
-            Log.i(TAG, "dial($number): ACTION_CALL dispatched")
-            0
-        } catch (se: SecurityException) {
-            Log.w(TAG, "dial($number): SecurityException — ${se.message}")
-            -1
-        } catch (t: Throwable) {
-            Log.w(TAG, "dial($number): ${t.javaClass.simpleName} — ${t.message}")
-            -1
         }
+        return 0
     }
 }

--- a/emu/Android/phonebridge.c
+++ b/emu/Android/phonebridge.c
@@ -42,6 +42,51 @@
 JavaVM *g_vm = NULL;
 
 /*
+ * Cached references to io.infernode.InfernodePhoneBridge so android_dial
+ * can call into Kotlin from any (Inferno kproc) thread.
+ *
+ * FindClass from an AttachCurrentThread'd pthread uses the SYSTEM
+ * classloader, not the app classloader — so it cannot resolve
+ * `io/infernode/InfernodePhoneBridge`. Cache the jclass as a global ref
+ * here, populated from JNI_OnLoad in jni-emu.c (which runs under the
+ * app classloader because that's what loaded libemu.so).
+ *
+ * Populated by phonebridge_jni_init below, invoked from JNI_OnLoad.
+ * Stays NULL on builds without the JNI surface (headless o.emu) and
+ * android_dial fails cleanly in that case.
+ */
+jclass    g_bridge_class;    /* global ref, owned */
+jmethodID g_bridge_dial_mid; /* dial(Ljava/lang/String;)I */
+
+void
+phonebridge_jni_init(JNIEnv *env)
+{
+	jclass local;
+	jmethodID mid;
+
+	local = (*env)->FindClass(env, "io/infernode/InfernodePhoneBridge");
+	if(local == NULL){
+		(*env)->ExceptionClear(env);
+		fprintf(stderr,
+			"phone: JNI_OnLoad: FindClass(InfernodePhoneBridge) failed\n");
+		return;
+	}
+	mid = (*env)->GetStaticMethodID(env, local, "dial",
+		"(Ljava/lang/String;)I");
+	if(mid == NULL){
+		(*env)->ExceptionClear(env);
+		(*env)->DeleteLocalRef(env, local);
+		fprintf(stderr,
+			"phone: JNI_OnLoad: GetStaticMethodID(dial) failed\n");
+		return;
+	}
+	g_bridge_class = (*env)->NewGlobalRef(env, local);
+	(*env)->DeleteLocalRef(env, local);
+	g_bridge_dial_mid = mid;
+	fprintf(stderr, "phone: JNI_OnLoad: InfernodePhoneBridge.dial cached\n");
+}
+
+/*
  * INFR-201: fire Intent.ACTION_CALL via InfernodePhoneBridge.dial.
  *
  * Runs on whichever thread called phonebridge_phone_ctl (Inferno
@@ -82,21 +127,12 @@ android_dial(const char *number, char *err, int errlen)
 		return -1;
 	}
 
-	cls = (*env)->FindClass(env, "io/infernode/InfernodePhoneBridge");
-	if(cls == NULL){
-		(*env)->ExceptionClear(env);
+	cls = g_bridge_class;
+	mid = g_bridge_dial_mid;
+	if(cls == NULL || mid == NULL){
 		snprintf(err, errlen,
-			"phone: FindClass(InfernodePhoneBridge) failed");
-		if(attached) (*g_vm)->DetachCurrentThread(g_vm);
-		return -1;
-	}
-	mid = (*env)->GetStaticMethodID(env, cls, "dial",
-		"(Ljava/lang/String;)I");
-	if(mid == NULL){
-		(*env)->ExceptionClear(env);
-		(*env)->DeleteLocalRef(env, cls);
-		snprintf(err, errlen,
-			"phone: GetStaticMethodID(dial) failed");
+			"phone: bridge class/methodID not cached "
+			"(JNI_OnLoad lookup failed; check libemu.so loader)");
 		if(attached) (*g_vm)->DetachCurrentThread(g_vm);
 		return -1;
 	}
@@ -109,7 +145,6 @@ android_dial(const char *number, char *err, int errlen)
 	}
 
 	(*env)->DeleteLocalRef(env, jnum);
-	(*env)->DeleteLocalRef(env, cls);
 	if(attached)
 		(*g_vm)->DetachCurrentThread(g_vm);
 


### PR DESCRIPTION
## Summary

Follow-up to #181. Two on-device bugs gated the dial path from actually reaching the OS Telecom service; both fixed here. Verified end-to-end on the SM-A556E.

### 1. `FindClass` from an `AttachCurrentThread`'d pthread

JNI semantics: `FindClass` uses the **system classloader** when called from a pthread that was attached after the fact — only `JNI_OnLoad` runs under the app classloader. The shell on the device printed:

```
write error: phone: FindClass(InfernodePhoneBridge) failed
```

Fix: cache the `jclass` + `methodID` once in `JNI_OnLoad` and re-use the global ref from every subsequent dial. `phonebridge.c` owns the storage (also the `JavaVM *`); `jni-emu.c` just calls `phonebridge_jni_init` once at load.

### 2. ~28 KB pthread stack overflows in `startActivity → AMS binder`

The Inferno kproc thread has a tiny stack. `startActivity` blew it:

```
W/InfernodePhoneBridge: dial(+...): StackOverflowError — stack size 28KB
```

Fix: post the Intent dispatch to the main thread via `Handler(Looper.getMainLooper()).post`. Pre-flight checks (context null / permission denied) still run synchronously, so the C side still gets a definitive -1 for genuine "won't happen" cases; the async result lands in logcat.

## Device log — end-to-end, post-fix

```
I/InfernodePhoneBridge: attached applicationContext for /phone bridge
I/InferNode: phone: JNI_OnLoad: InfernodePhoneBridge.dial cached
I/InferNode: phone: dial +6585028639 (audit 1/10 in window)
I/InferNode: phone: Android dial +6585028639
I/InfernodePhoneBridge: dial(+6585028639): ACTION_CALL dispatched on main thread
I/ActivityManager: Start proc com.android.server.telecom:ui for next-top-activity
W/Telecom: Call: ... request on a call without a connection service.
```

The "no connection service" tail is the expected outcome on this device — it has no SIM, so Telecom has nothing to attach the call to and disconnects ~2 s in. The InferNode-owned path is complete and exercised.

The remaining work — end-to-end against a real carrier on a SIM-equipped device — is tracked in the new follow-up ticket.

Refs: INFR-201, INFR-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)