### PR TITLE
feat(/phone): Android SMS send via SmsManager (INFR-182 slice)

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -35,6 +35,13 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
 
     <!--
+      SEND_SMS — INFR-182 SMS send slice. Lets `/phone/sms` "send"
+      verb dispatch via SmsManager.sendTextMessage / sendMultipartTextMessage
+      through InfernodePhoneBridge.sendSms. Same runtime-grant flow.
+    -->
+    <uses-permission android:name="android.permission.SEND_SMS" />
+
+    <!--
       Launcher icons sourced from MacOSX/InferNode.icns (1024x1024
       master) and downsampled into res/mipmap-{m,h,xh,xxh,xxxh}dpi/
       at the standard Android density steps. ic_launcher.png is the

--- a/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
@@ -5,8 +5,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.telephony.SmsManager
 import android.util.Log
 import androidx.core.content.ContextCompat
 
@@ -98,6 +100,69 @@ object InfernodePhoneBridge {
                 Log.w(TAG, "dial($number): SecurityException — ${se.message}")
             } catch (t: Throwable) {
                 Log.w(TAG, "dial($number): ${t.javaClass.simpleName} — ${t.message}")
+            }
+        }
+        return 0
+    }
+
+    /**
+     * INFR-182 SMS-send slice: ship one SMS via SmsManager.
+     *
+     * Called from emu/Android/phonebridge.c's `phonebridge_send_sms`
+     * when the agent writes `send <number> <body>` to `/phone/sms`.
+     *
+     * Returns 0 on success (SmsManager call dispatched), -1 on a
+     * synchronous failure (no context, permission denied, no
+     * SmsManager service). Delivery itself is asynchronous — the
+     * carrier outcome lands in logcat tagged InfernodePhoneBridge if
+     * you want to follow it; we don't propagate delivery success back
+     * to the C side because devphone's write semantics are
+     * fire-and-forget (matches the iOS path's compose-sheet model —
+     * see emu/iOS/phonebridge.m).
+     *
+     * Long messages (>160 GSM-7 / 70 UCS-2) are split via
+     * `divideMessage` + `sendMultipartTextMessage` so the receiver
+     * gets the whole thing.
+     */
+    @JvmStatic
+    fun sendSms(number: String, body: String): Int {
+        val ctx = appContext
+        if (ctx == null) {
+            Log.w(TAG, "sendSms($number): no context attached — call attach() first")
+            return -1
+        }
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.SEND_SMS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "sendSms($number): SEND_SMS not granted")
+            return -1
+        }
+        val sms: SmsManager? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ctx.getSystemService(SmsManager::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            SmsManager.getDefault()
+        }
+        if (sms == null) {
+            Log.w(TAG, "sendSms($number): SmsManager unavailable")
+            return -1
+        }
+        Handler(Looper.getMainLooper()).post {
+            try {
+                val parts = sms.divideMessage(body)
+                if (parts.size <= 1) {
+                    sms.sendTextMessage(number, null, body, null, null)
+                    Log.i(TAG, "sendSms($number): single-part dispatched (${body.length} chars)")
+                } else {
+                    sms.sendMultipartTextMessage(number, null, parts, null, null)
+                    Log.i(TAG, "sendSms($number): ${parts.size}-part dispatched (${body.length} chars)")
+                }
+            } catch (se: SecurityException) {
+                Log.w(TAG, "sendSms($number): SecurityException — ${se.message}")
+            } catch (iae: IllegalArgumentException) {
+                Log.w(TAG, "sendSms($number): IllegalArgumentException — ${iae.message}")
+            } catch (t: Throwable) {
+                Log.w(TAG, "sendSms($number): ${t.javaClass.simpleName} — ${t.message}")
             }
         }
         return 0

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -121,6 +121,7 @@ class InfernodeSDLActivity : SDLActivity() {
         // /dev/audio would silently return zeros otherwise.
         ensureRecordAudioPermission()
         ensureCallPhonePermission()
+        ensureSendSmsPermission()
         InfernodePhoneBridge.attach(this)
         super.onCreate(savedInstanceState)
 
@@ -206,6 +207,20 @@ class InfernodeSDLActivity : SDLActivity() {
                 this,
                 arrayOf(Manifest.permission.CALL_PHONE),
                 /* requestCode = */ 2
+            )
+        }
+    }
+
+    private fun ensureSendSmsPermission() {
+        // INFR-182 SMS send slice: InfernodePhoneBridge.sendSms calls
+        // SmsManager.sendTextMessage which requires SEND_SMS at runtime.
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.SEND_SMS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.SEND_SMS),
+                /* requestCode = */ 3
             )
         }
     }

--- a/emu/Android/phonebridge.c
+++ b/emu/Android/phonebridge.c
@@ -55,8 +55,9 @@ JavaVM *g_vm = NULL;
  * Stays NULL on builds without the JNI surface (headless o.emu) and
  * android_dial fails cleanly in that case.
  */
-jclass    g_bridge_class;    /* global ref, owned */
-jmethodID g_bridge_dial_mid; /* dial(Ljava/lang/String;)I */
+jclass    g_bridge_class;        /* global ref, owned */
+jmethodID g_bridge_dial_mid;     /* dial(Ljava/lang/String;)I */
+jmethodID g_bridge_sendsms_mid;  /* sendSms(Ljava/lang/String;Ljava/lang/String;)I */
 
 void
 phonebridge_jni_init(JNIEnv *env)
@@ -83,7 +84,17 @@ phonebridge_jni_init(JNIEnv *env)
 	g_bridge_class = (*env)->NewGlobalRef(env, local);
 	(*env)->DeleteLocalRef(env, local);
 	g_bridge_dial_mid = mid;
-	fprintf(stderr, "phone: JNI_OnLoad: InfernodePhoneBridge.dial cached\n");
+	g_bridge_sendsms_mid = (*env)->GetStaticMethodID(env, g_bridge_class,
+		"sendSms", "(Ljava/lang/String;Ljava/lang/String;)I");
+	if(g_bridge_sendsms_mid == NULL){
+		(*env)->ExceptionClear(env);
+		fprintf(stderr,
+			"phone: JNI_OnLoad: GetStaticMethodID(sendSms) failed\n");
+		/* Non-fatal — dial still works without it. */
+	}
+	fprintf(stderr,
+		"phone: JNI_OnLoad: InfernodePhoneBridge dial=%p sendSms=%p cached\n",
+		(void*)g_bridge_dial_mid, (void*)g_bridge_sendsms_mid);
 }
 
 /*
@@ -179,13 +190,87 @@ phonebridge_ctl_status(char *buf, int buflen)
 	return snprintf(buf, buflen, "stub (Telephony not wired)\n");
 }
 
+/*
+ * INFR-182 SMS-send slice: hop through the cached
+ * InfernodePhoneBridge.sendSms static. Same attach/cache pattern as
+ * android_dial — see that function's comment for why we cache in
+ * JNI_OnLoad and main-thread-post the SmsManager call.
+ */
+static int
+android_send_sms(const char *number, const char *body, char *err, int errlen)
+{
+	JNIEnv *env;
+	jclass cls;
+	jmethodID mid;
+	jstring jnum, jbody;
+	jint rc;
+	int attached = 0;
+
+	if(g_vm == NULL){
+		snprintf(err, errlen, "phone: JNI not initialised (g_vm null)");
+		return -1;
+	}
+	switch((*g_vm)->GetEnv(g_vm, (void**)&env, JNI_VERSION_1_6)){
+	case JNI_OK:
+		break;
+	case JNI_EDETACHED:
+		if((*g_vm)->AttachCurrentThread(g_vm, &env, NULL) != JNI_OK){
+			snprintf(err, errlen, "phone: AttachCurrentThread failed");
+			return -1;
+		}
+		attached = 1;
+		break;
+	default:
+		snprintf(err, errlen, "phone: GetEnv failed");
+		return -1;
+	}
+
+	cls = g_bridge_class;
+	mid = g_bridge_sendsms_mid;
+	if(cls == NULL || mid == NULL){
+		snprintf(err, errlen,
+			"phone: sendSms class/methodID not cached "
+			"(JNI_OnLoad lookup failed; check libemu.so loader)");
+		if(attached) (*g_vm)->DetachCurrentThread(g_vm);
+		return -1;
+	}
+	jnum  = (*env)->NewStringUTF(env, number ? number : "");
+	jbody = (*env)->NewStringUTF(env, body   ? body   : "");
+	rc = (*env)->CallStaticIntMethod(env, cls, mid, jnum, jbody);
+	if((*env)->ExceptionCheck(env)){
+		(*env)->ExceptionDescribe(env);
+		(*env)->ExceptionClear(env);
+		rc = -1;
+	}
+
+	(*env)->DeleteLocalRef(env, jnum);
+	(*env)->DeleteLocalRef(env, jbody);
+	if(attached)
+		(*g_vm)->DetachCurrentThread(g_vm);
+
+	if(rc != 0){
+		snprintf(err, errlen,
+			"phone: Android sendSms returned %d "
+			"(no context attached, SEND_SMS not granted, or SmsManager null)",
+			(int)rc);
+		return -1;
+	}
+	return 0;
+}
+
 int
 phonebridge_send_sms(const char *number, const char *body, char *err, int errlen)
 {
-	fprintf(stderr, "phone: Android send_sms to=%s body=%s (stub)\n",
-		number ? number : "(nil)", body ? body : "(nil)");
-	(void)err; (void)errlen;
-	return 0;
+	if(number == NULL || number[0] == 0){
+		snprintf(err, errlen, "send_sms: missing number");
+		return -1;
+	}
+	if(body == NULL || body[0] == 0){
+		snprintf(err, errlen, "send_sms: missing body");
+		return -1;
+	}
+	fprintf(stderr, "phone: Android send_sms to=%s body=%s\n", number, body);
+	return android_send_sms(number, body, err, errlen);
 }
 
 /* Inbound paths land via phonebridge_post_sms / phonebridge_post_call_event


### PR DESCRIPTION
## Summary

Mirror of INFR-201's dial wiring for the SMS-send half of INFR-182. `/phone/sms` *"send <number> <body>"* lands at `SmsManager` on Android the same shape it lands at `MFMessageComposeViewController` on iOS.

Long messages split via `SmsManager.divideMessage` and dispatched as multipart. `SmsManager` acquisition uses API-31+ `context.getSystemService(SmsManager::class.java)` with fall-back to the deprecated `getDefault()` on older releases.

## What's wired

- `AndroidManifest.xml` — `SEND_SMS`.
- `InfernodeSDLActivity.onCreate` — `ensureSendSmsPermission` alongside the existing two perms. Distinct request code.
- `InfernodePhoneBridge.sendSms(number, body)` — `JvmStatic`, pre-flight (context + perm), then `Handler(mainLooper).post` the `SmsManager` call. Same main-thread bounce as dial — the Inferno kproc thread's ~28 KB stack can't survive the AMS binder roundtrip.
- `emu/Android/phonebridge.c phonebridge_send_sms` — JNI dispatch via cached methodID. Cache added in `phonebridge_jni_init` next to the existing dial cache. `sendSms` methodID miss is non-fatal at load so dial still works if Kotlin sendSms ever disappears.

## On-device (SM-A556E, no SIM)

```
I/InferNode: phone: JNI_OnLoad: InfernodePhoneBridge dial=0x1 sendSms=0x3 cached
I/InferNode: phone: Android send_sms to=+6585028639 body=hello from infernode
I/InfernodePhoneBridge: sendSms(+6585028639): single-part dispatched (20 chars)
I/BugleDataModel: ACTION_EXECUTE_QUEUED_ProcessTelephonyChangeAction
I/CarrierServices: Initializing Carrier Services Library
```

Google Messages (`Bugle`) received the SmsManager-triggered `TelephonyChangeAction` broadcast — the OS accepted the send into the carrier layer. SIM is the only missing piece; same gate INFR-202 captures for dial.

## Test plan

- [x] APK build green
- [x] On-device JNI dispatch on A55 (logs above)
- [ ] CI green
- [ ] SIM-equipped verification — folds into INFR-202

Refs: INFR-182, INFR-201, INFR-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)