### PR TITLE
feat(/phone): Android SMS receive — BroadcastReceiver + JNI postSms (INFR-182)

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -42,6 +42,17 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
 
     <!--
+      RECEIVE_SMS + READ_SMS — INFR-182 SMS receive slice. Lets
+      InfernodeSmsReceiver pick up android.provider.Telephony.SMS_RECEIVED
+      and push the record into devphone's /phone/sms reader queue via
+      phonebridge_post_sms. SMS_RECEIVED is one of the exempt implicit
+      broadcasts on API 26+, so a manifest-declared receiver still
+      fires when the activity isn't in the foreground.
+    -->
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+
+    <!--
       Launcher icons sourced from MacOSX/InferNode.icns (1024x1024
       master) and downsampled into res/mipmap-{m,h,xh,xxh,xxxh}dpi/
       at the standard Android density steps. ic_launcher.png is the
@@ -98,6 +109,23 @@
             android:name=".InfernodeService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <!--
+          INFR-182 SMS-receive slice. SMS_RECEIVED is one of the
+          implicit-broadcast exemptions on API 26+, so a manifest
+          receiver still fires when the activity isn't foregrounded.
+          exported=true is required for system broadcasts; the
+          permission attribute restricts who can send it to BROADCAST_SMS
+          (system-only) so a third-party app can't spoof inbound SMS.
+        -->
+        <receiver
+            android:name=".InfernodeSmsReceiver"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter android:priority="100">
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodePhoneBridge.kt
@@ -167,4 +167,31 @@ object InfernodePhoneBridge {
         }
         return 0
     }
+
+    /**
+     * INFR-182 SMS-receive slice. Pushes a pre-formatted devphone wire
+     * record ("from <sender> <ts>\n<body>\n") into native, which calls
+     * `phonebridge_post_sms` and fans it out to every open reader of
+     * `/phone/sms`. Implementation lives in `emu/Android/phonebridge.c`
+     * (`Java_io_infernode_InfernodePhoneBridge_postSms`).
+     *
+     * Throws `UnsatisfiedLinkError` if libemu.so isn't loaded in the
+     * receiver's process — see InfernodeSmsReceiver for how that's
+     * handled.
+     */
+    @JvmStatic
+    external fun postSms(record: String)
+
+    init {
+        // libemu.so is loaded by SDLActivity.loadLibraries() during the
+        // Activity bring-up, before InfernodePhoneBridge.attach() runs.
+        // But the SMS receiver process may pre-empt that on a cold-start
+        // broadcast: ensure the native side is loaded so postSms resolves.
+        try {
+            System.loadLibrary("SDL3")
+            System.loadLibrary("emu")
+        } catch (ule: UnsatisfiedLinkError) {
+            // Already loaded by SDLActivity in the normal path — ignore.
+        }
+    }
 }

--- a/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSDLActivity.kt
@@ -122,6 +122,7 @@ class InfernodeSDLActivity : SDLActivity() {
         ensureRecordAudioPermission()
         ensureCallPhonePermission()
         ensureSendSmsPermission()
+        ensureReceiveSmsPermission()
         InfernodePhoneBridge.attach(this)
         super.onCreate(savedInstanceState)
 
@@ -221,6 +222,29 @@ class InfernodeSDLActivity : SDLActivity() {
                 this,
                 arrayOf(Manifest.permission.SEND_SMS),
                 /* requestCode = */ 3
+            )
+        }
+    }
+
+    private fun ensureReceiveSmsPermission() {
+        // INFR-182 SMS receive slice: InfernodeSmsReceiver picks up
+        // android.provider.Telephony.SMS_RECEIVED. RECEIVE_SMS is the
+        // runtime perm that lets the broadcast actually reach our
+        // receiver; READ_SMS is in the same group and Android grants
+        // it together. Request both in one batch — the prompt will
+        // collapse since they share the SMS perm group.
+        val needs = mutableListOf<String>()
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECEIVE_SMS)
+            != PackageManager.PERMISSION_GRANTED
+        ) needs += Manifest.permission.RECEIVE_SMS
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_SMS)
+            != PackageManager.PERMISSION_GRANTED
+        ) needs += Manifest.permission.READ_SMS
+        if (needs.isNotEmpty()) {
+            ActivityCompat.requestPermissions(
+                this,
+                needs.toTypedArray(),
+                /* requestCode = */ 4
             )
         }
     }

--- a/android-app/app/src/main/java/io/infernode/InfernodeSmsReceiver.kt
+++ b/android-app/app/src/main/java/io/infernode/InfernodeSmsReceiver.kt
@@ -1,0 +1,76 @@
+package io.infernode
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Telephony
+import android.util.Log
+
+/**
+ * INFR-182 SMS-receive slice.
+ *
+ * Manifest-declared receiver for `android.provider.Telephony.SMS_RECEIVED`.
+ * Extracts the PDU array, concatenates multi-part messages by sender,
+ * formats the canonical devphone wire record
+ *
+ *     from <sender> <timestamp>\n<body>\n
+ *
+ * (matches the parser in `appl/veltro/sources/sms.b:227`), and pushes
+ * each record to native via [InfernodePhoneBridge.postSms]. devphone's
+ * `phonebridge_post_sms` then fans the bytes out to every open reader
+ * of `/phone/sms`.
+ *
+ * SMS_RECEIVED is one of the implicit-broadcast exemptions on API 26+,
+ * so this still fires when the Activity isn't running. The bridge will
+ * be loaded on-demand if it isn't already in the process — but in
+ * practice the Activity is the only entry point and InfernodePhoneBridge
+ * is already loaded once SDL boots. If the bridge isn't loaded, the
+ * native call will throw `UnsatisfiedLinkError` and we drop the record;
+ * better to drop than to crash the receiver. The user will see the
+ * SMS in the system Messages app regardless.
+ */
+class InfernodeSmsReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
+
+        // getMessagesFromIntent stitches multi-part PDUs together
+        // already on the sending side; we still group by sender below
+        // for safety against carriers that don't honour that contract.
+        val msgs = Telephony.Sms.Intents.getMessagesFromIntent(intent) ?: return
+        if (msgs.isEmpty()) return
+
+        // Concatenate body fragments under their originating address.
+        // The PDU array is already in delivery order; a single SMS is
+        // up to seven concatenated fragments, all from the same sender.
+        val bySender = LinkedHashMap<String, StringBuilder>()
+        var earliestTs = Long.MAX_VALUE
+        for (m in msgs) {
+            val from = m.displayOriginatingAddress ?: m.originatingAddress ?: continue
+            val text = m.displayMessageBody ?: m.messageBody ?: ""
+            bySender.getOrPut(from) { StringBuilder() }.append(text)
+            if (m.timestampMillis < earliestTs) earliestTs = m.timestampMillis
+        }
+
+        val ts = if (earliestTs == Long.MAX_VALUE) System.currentTimeMillis() else earliestTs
+
+        for ((sender, body) in bySender) {
+            val record = "from $sender $ts\n${body}\n"
+            try {
+                InfernodePhoneBridge.postSms(record)
+                Log.i(TAG, "received SMS from=$sender bytes=${record.length}")
+            } catch (ule: UnsatisfiedLinkError) {
+                // libemu.so not loaded in this process — Activity isn't
+                // up. Surface the drop so we know it happened, but don't
+                // crash the receiver.
+                Log.w(TAG, "drop: postSms native not linked (Activity not up?)")
+            } catch (t: Throwable) {
+                Log.w(TAG, "drop: ${t.javaClass.simpleName} — ${t.message}")
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "InfernodeSmsReceiver"
+    }
+}

--- a/emu/Android/phonebridge.c
+++ b/emu/Android/phonebridge.c
@@ -273,6 +273,37 @@ phonebridge_send_sms(const char *number, const char *body, char *err, int errlen
 	return android_send_sms(number, body, err, errlen);
 }
 
+/*
+ * INFR-182 SMS-receive slice. Kotlin's InfernodeSmsReceiver formats
+ * the canonical devphone wire record ("from <num> <ts>\n<body>\n") and
+ * calls this entry point. We forward the UTF-8 bytes verbatim into
+ * phonebridge_post_sms, which fans them to every /phone/sms reader.
+ *
+ * Naming convention path — works without RegisterNatives.
+ */
+JNIEXPORT void JNICALL
+Java_io_infernode_InfernodePhoneBridge_postSms(JNIEnv *env, jclass cls,
+                                               jstring jrecord)
+{
+	const char *bytes;
+	jsize n;
+
+	(void)cls;
+	if(jrecord == NULL)
+		return;
+	n = (*env)->GetStringUTFLength(env, jrecord);
+	if(n <= 0)
+		return;
+	bytes = (*env)->GetStringUTFChars(env, jrecord, NULL);
+	if(bytes == NULL){
+		(*env)->ExceptionClear(env);
+		return;
+	}
+	phonebridge_post_sms(bytes, (int)n);
+	(*env)->ReleaseStringUTFChars(env, jrecord, bytes);
+	fprintf(stderr, "phone: Android postSms forwarded %d bytes\n", (int)n);
+}
+
 /* Inbound paths land via phonebridge_post_sms / phonebridge_post_call_event
  * once INFR-182 wires the ContentObserver + TelephonyCallback through the
  * JNI surface. Stub does nothing — readers of /phone/sms and /phone/phone


### PR DESCRIPTION
## Summary

Completes the SMS round-trip for Android. Outbound (\`send\`) landed in #187; inbound now fans every \`SMS_RECEIVED\` into devphone's \`/phone/sms\` listener queue so msg9p's existing \`sms\` MsgSrc picks it up verbatim — **no changes on the Limbo side**. Wire format matches the existing parser at \`appl/veltro/sources/sms.b:227\`:

\`\`\`
from <sender> <timestamp>\n<body>\n
\`\`\`

## What's wired

- \`AndroidManifest.xml\` — \`RECEIVE_SMS\` + \`READ_SMS\`, plus manifest receiver for \`InfernodeSmsReceiver\`. \`SMS_RECEIVED\` is on the implicit-broadcast exemption list (API 26+) so manifest registration still fires when the Activity isn't foregrounded. \`exported=true\` + \`permission=BROADCAST_SMS\` pins senders to system (no third-party spoofing).
- \`InfernodeSDLActivity.onCreate\` — \`ensureReceiveSmsPermission\` requests both in one batch (same perm group, single prompt).
- \`InfernodeSmsReceiver.kt\` (new) — extracts PDUs via \`Telephony.Sms.Intents.getMessagesFromIntent\`, concatenates body fragments per sender, formats the wire record and calls \`InfernodePhoneBridge.postSms\`. Drops on \`UnsatisfiedLinkError\` instead of crashing the receiver — the SMS still surfaces in the system Messages app regardless.
- \`InfernodePhoneBridge.kt\` — \`external fun postSms(record: String)\` plus an \`init {}\` block that idempotently loads \`libSDL3\`/\`libemu\` so the receiver process resolves the symbol even on a cold-start broadcast before SDLActivity has loaded the libs.
- \`emu/Android/phonebridge.c\` — \`Java_io_infernode_InfernodePhoneBridge_postSms\` forwards UTF-8 bytes verbatim into \`phonebridge_post_sms\`. Naming-convention path — no \`RegisterNatives\` plumbing.

## On-device verification (SM-A556E)

- \`dumpsys package io.infernode\` shows the receiver registered for \`android.provider.Telephony.SMS_RECEIVED\`.
- \`RECEIVE_SMS\` + \`READ_SMS\` granted at runtime.
- \`nm -D libemu.so | grep postSms\` → \`T Java_io_infernode_InfernodePhoneBridge_postSms\`.
- JNI cache log present at boot.

Actual SMS arrival is gated on a SIM, same as outbound delivery — INFR-202 covers SIM-equipped verification of both directions.

## Test plan

- [x] APK build green
- [x] Receiver + perms + native symbol verified on A55
- [ ] CI green
- [ ] SIM-equipped end-to-end — folds into INFR-202

Refs: INFR-182, INFR-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)