### PR TITLE
docs(/phone): iOS SMS-receive is structurally impossible — document it

### DIFF
--- a/docs/HELLAPHONE.md
+++ b/docs/HELLAPHONE.md
@@ -622,6 +622,38 @@ That routes through `msg9p`'s `send` verb to the sms MsgSrc's
 `send(Message)` and produces the same `/phone/sms` write as the
 direct test above.
 
+### iOS SMS receive — there is none, and there cannot be
+
+Android grants the SMS round-trip both ways: a manifest-declared
+`BroadcastReceiver` for `android.provider.Telephony.SMS_RECEIVED` plus
+`RECEIVE_SMS` / `READ_SMS` runtime permissions (INFR-182, PR #188 —
+`emu/Android/phonebridge.c`'s `Java_io_infernode_InfernodePhoneBridge_postSms`
+feeds the wire record into `phonebridge_post_sms`).
+
+iOS does not. Apple's public SDK exposes **no API** for a third-party
+app to read inbound SMS. The closest surface is
+`ILMessageFilterExtension`, which is invoked **without** the message
+body for spam-classification of unknown senders — the body never
+reaches your app, and known senders skip the extension entirely. There
+is no notification, no inbox query, no observer. This is a deliberate
+platform restriction on Apple's part; no entitlement or capability
+unlocks it for third parties.
+
+Practically:
+
+* `/phone/sms` reads on iOS block forever. That is the correct
+  behaviour — there is nothing to deliver.
+* The msg9p `sms` MsgSrc on iOS only ever emits outbound writes (`send`
+  verb) and never produces a `from …` record. The source's `recv`
+  channel idles.
+* For development you can synthesise an inbound record by writing the
+  wire format directly to a test fixture — see `tests/sms_msgsrc_test.b`
+  for the format (`from <sender> <ts>\n<body>\n`).
+
+Do not file tickets to "wire iOS SMS receive." The gap is structural,
+not a TODO. If iMessage / iCloud sync ever becomes scriptable to third
+parties (it isn't), revisit then.
+
 ### What the simulator CAN test
 
 * `phonebridge_init` runs without crashing

--- a/emu/iOS/phonebridge.m
+++ b/emu/iOS/phonebridge.m
@@ -340,10 +340,26 @@ phonebridge_ctl_status(char *buf, int buflen)
 }
 
 /*
- * Inbound SMS: iOS exposes no public inbox API to third-party apps, so
- * there is no path to call phonebridge_post_sms() — readers of
- * /phone/sms simply block forever. On Android the bridge will produce
- * via phonebridge_post_sms() when SMS_RECEIVED arrives (INFR-182).
+ * Inbound SMS — there is none, and there cannot be.
+ *
+ * Apple's public SDK exposes no API for a third-party app to read an
+ * incoming SMS. The closest surface, ILMessageFilterExtension, is
+ * invoked without the message body for spam-classification of unknown
+ * senders only — the body never reaches the app and known senders
+ * skip the extension entirely. No entitlement unlocks it for third
+ * parties. This is a deliberate platform restriction, not a TODO.
+ *
+ * Consequence: there is no path to call phonebridge_post_sms() from
+ * the iOS bridge, ever. Readers of /phone/sms block forever — which
+ * is the correct behaviour (no record to deliver). The msg9p `sms`
+ * MsgSrc on iOS only ever emits outbound writes.
+ *
+ * Android wires this in emu/Android/phonebridge.c via a manifest
+ * BroadcastReceiver on android.provider.Telephony.SMS_RECEIVED, with
+ * RECEIVE_SMS + READ_SMS runtime perms (INFR-182, PR #188).
+ *
+ * See docs/HELLAPHONE.md §"iOS SMS receive — there is none, and there
+ * cannot be" for the full rationale.
  */
 
 int


### PR DESCRIPTION
## Summary

Android SMS round-trip landed (INFR-182, PRs #187 + #188). **iOS will never have a matching receive path.** Apple's public SDK exposes no API for a third-party app to read inbound SMS. `ILMessageFilterExtension` is body-less and fires only for unknown senders for spam-classification. No entitlement, no capability, no workaround.

This commit makes that explicit so we don't burn a future session trying to wire it.

## What's in

- **\`docs/HELLAPHONE.md\`** gains a "### iOS SMS receive — there is none, and there cannot be" subsection in the iOS-on-Ba'al chapter, explaining the platform restriction and what the consumer-side msg9p source does on iOS.
- **\`emu/iOS/phonebridge.m\`** — expand the existing 5-line comment at the inbound-SMS gap into a 20-line block that names the API, names the Android counterpart, and points at the doc. The previous shorter comment was easy to mistake for a TODO.

## What's not in

Outbound SMS on iOS (`MFMessageComposeViewController` compose sheet) was re-verified on Ba'al today after the INFR-201 / INFR-182 changes landed — iOS send path unchanged, smoke-test successful. No code changes there.

## Test plan

- [x] Build green (`IOSSDK=iphoneos ./build-ios-app.sh --gui` already ran before commit)
- [x] iOS SMS send smoke-tested on Ba'al (compose sheet, Send tap, completes)
- [ ] CI green

Refs: INFR-182, INFR-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)