### PR TITLE
fix(ios): flatten smart-punctuation back to ASCII at SDL_EVENT_TEXT_INPUT (INFR-211)

### DIFF
--- a/emu/port/draw-sdl3.c
+++ b/emu/port/draw-sdl3.c
@@ -1241,9 +1241,56 @@ update_and_present(Uint64 now, Uint64 last_refresh)
 }
 
 /*
+ * iOS smart-punctuation map (INFR-211). The iOS soft keyboard runs
+ * `UITextInputTraits.smartQuotesType` / `smartDashesType` enabled by
+ * default; SDL3 doesn't expose those traits, so the bytes we receive
+ * via SDL_EVENT_TEXT_INPUT for a single quote are U+2019, not U+0027.
+ * Inferno sh's tokeniser treats only ASCII `'` as the literal-string
+ * delimiter, so a typed `'foo bar'` never delimits and parses wrong.
+ *
+ * We translate at our own boundary: just before the rune lands in
+ * gkbdq, swap the typographic punctuation iOS gives us back to the
+ * ASCII the user is trying to type. iOS-only — on desktop the user
+ * actually wanted U+2019 if they pressed Option-Shift-`]`.
+ *
+ * Returns the (possibly-substituted) primary rune. If the substitution
+ * expands to multiple ASCII bytes (only U+2026 → "..."), `extra` and
+ * `*extralen` carry the trailing bytes; otherwise *extralen is 0.
+ *
+ * Kept tiny on purpose — Inferno sh-relevant punctuation only. Other
+ * curly characters pass through untouched.
+ */
+#if defined(__APPLE__) && TARGET_OS_IOS
+static Rune
+ios_normalize_rune(Rune r, char *extra, int *extralen)
+{
+	*extralen = 0;
+	switch (r) {
+	case 0x2018:	/* LEFT SINGLE QUOTATION MARK */
+	case 0x2019:	/* RIGHT SINGLE QUOTATION MARK / APOSTROPHE */
+		return '\'';
+	case 0x201C:	/* LEFT DOUBLE QUOTATION MARK */
+	case 0x201D:	/* RIGHT DOUBLE QUOTATION MARK */
+		return '"';
+	case 0x2013:	/* EN DASH */
+	case 0x2014:	/* EM DASH */
+		return '-';
+	case 0x2026:	/* HORIZONTAL ELLIPSIS */
+		extra[0] = '.';
+		extra[1] = '.';
+		*extralen = 2;
+		return '.';
+	default:
+		return r;
+	}
+}
+#endif
+
+/*
  * Handle SDL_EVENT_TEXT_INPUT.
  * Decodes UTF-8 text to Unicode codepoints and sends to keyboard queue.
  * Skips control characters (handled by Ctrl+letter in KEY_DOWN).
+ * On iOS, also flattens smart-punctuation back to ASCII (INFR-211).
  */
 static void
 handle_text_input(const char *text)
@@ -1260,7 +1307,19 @@ handle_text_input(const char *text)
 			text++;
 			continue;
 		}
+#if defined(__APPLE__) && TARGET_OS_IOS
+		{
+			char extra[4];
+			int extralen = 0;
+			int i;
+			r = ios_normalize_rune(r, extra, &extralen);
+			gkbdputc(gkbdq, r);
+			for (i = 0; i < extralen; i++)
+				gkbdputc(gkbdq, (Rune)(uchar)extra[i]);
+		}
+#else
 		gkbdputc(gkbdq, r);
+#endif
 		text += n;
 	}
 }


### PR DESCRIPTION
## Summary

iOS's soft keyboard runs \`UITextInputTraits.smartQuotesType\` / \`smartDashesType\` enabled by default. SDL3 doesn't expose those traits, so the bytes we receive via \`SDL_EVENT_TEXT_INPUT\` for a typed single quote are U+2019, not U+0027. Inferno sh's tokeniser only recognises ASCII \`'\` as the literal-string delimiter, which means a Ba'al user typing

\`\`\`
echo 'send +6585028639 hello world' > /phone/sms
\`\`\`

couldn't quote their argument at all — the smart-quote bytes never matched and the line parsed wrong. Workaround so far was to omit the quotes entirely.

## Why this approach

Earlier proposals to disable the trait at the source were rejected as impractical:
- **iOS Settings system-wide** — moves the problem to a system preference no user will toggle just for Lucifer.
- **SDL3 hot-patch** — would fork upstream SDL3 brittly and lose the change on every SDL3 upgrade.

This fix translates at our own boundary. \`ios_normalize_rune()\` in \`emu/port/draw-sdl3.c\` maps typographic punctuation back to ASCII just before each rune lands in \`gkbdq\`:

| Smart → ASCII |
|---|
| U+2018, U+2019 → \`'\` |
| U+201C, U+201D → \`"\` |
| U+2013, U+2014 → \`-\` |
| U+2026 → \`...\` |

iOS-only (\`TARGET_OS_IOS\` gated) — on desktop SDL3 builds the user genuinely typed U+2019 if they pressed Option-Shift-\`]\` and we leave it alone. The U+2026 → \`...\` case is the only one that expands; the extra ASCII bytes are queued via additional \`gkbdputc\` calls.

## Test plan

- [x] macOS desktop SDL3 build green (no-op path on the desktop branch)
- [x] iOS device build green (\`IOSSDK=iphoneos ./build-ios-app.sh --gui\`)
- [x] Verified on Ba'al (iPhone 17 Pro Max, iOS 26.4.2): typing \`echo 'send 1 hello' > /phone/sms\` now parses correctly
- [ ] CI green

Refs: INFR-211, INFR-182, INFR-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)