### PR TITLE
fix(release): install opus on macOS runner + make HAVE_OPUS conditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -848,8 +848,8 @@ jobs:
         sed -i '' "s|InferNode 0.1|InferNode ${VERSION} build ${BUILD_DATE}-${SHORT_SHA}|" include/version.h
         echo "Version: $(cat include/version.h)"
 
-    - name: Install SDL3
-      run: brew install sdl3 sdl3_ttf
+    - name: Install SDL3 and opus
+      run: brew install sdl3 sdl3_ttf opus
 
     - name: Build mk
       run: |

--- a/emu/MacOSX/mkfile-gui-sdl3
+++ b/emu/MacOSX/mkfile-gui-sdl3
@@ -9,10 +9,13 @@ GUISRC=\
 SDL3_CFLAGS=`pkg-config --cflags sdl3 2>/dev/null || echo "-I/opt/homebrew/include"`
 SDL3_LIBS=`pkg-config --libs sdl3 2>/dev/null || echo "-L/opt/homebrew/lib -lSDL3"`
 
-# Opus codec for /dev/opus (INFR-187). pkg-config search path needs the
-# Homebrew prefix so brew-installed opus is found on a stock zsh.
-OPUS_CFLAGS=`PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --cflags opus 2>/dev/null || echo "-I/opt/homebrew/include"`
-OPUS_LIBS=`PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --libs opus 2>/dev/null || echo "-L/opt/homebrew/lib -lopus"`
+# Opus codec for /dev/opus (INFR-187). Only enable -DHAVE_OPUS when the opus
+# headers are actually present (brew install opus), so a host without opus
+# degrades to a build without /dev/opus instead of failing to find
+# <opus/opus.h>. pkg-config search path needs the Homebrew prefix so
+# brew-installed opus is found on a stock zsh.
+OPUS_CFLAGS=`export PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig; if pkg-config --exists opus 2>/dev/null; then echo -DHAVE_OPUS; pkg-config --cflags opus; fi`
+OPUS_LIBS=`export PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig; if pkg-config --exists opus 2>/dev/null; then pkg-config --libs opus; fi`
 
-GUIFLAGS=-DGUI_SDL3 -DHAVE_OPUS $SDL3_CFLAGS $OPUS_CFLAGS
+GUIFLAGS=-DGUI_SDL3 $SDL3_CFLAGS $OPUS_CFLAGS
 GUILIBS=$SDL3_LIBS $OPUS_LIBS


### PR DESCRIPTION
## Problem

Cutting `v0.2.0-rc2` failed: the **macOS ARM64** release job errored with
`fatal error: 'opus/opus.h' file not found`, so **Create Release** was skipped
and no draft/artifacts were produced. The other 5 platforms (Linux ×4, Windows) built fine.

Root cause: `emu/MacOSX/mkfile-gui-sdl3` hard-codes `-DHAVE_OPUS`, but the macOS
release job only `brew install sdl3 sdl3_ttf` — **opus was never installed**.
The opus / `/dev/opus` work (INFR-187) landed since `v0.2.0-rc1`. CI never caught
it because **CI builds only the Linux SDL3 GUI, never the macOS GUI** — the gap
was structurally invisible to every PR check and only surfaces in `release.yml`.

## Fix

- **`release.yml`**: add `opus` to the macOS `brew install` so the shipped DMG
  keeps `/dev/opus` support.
- **`mkfile-gui-sdl3`**: only set `-DHAVE_OPUS` (and opus cflags/libs) when
  `pkg-config` actually finds opus. `devopus.c` already has a `#else /* !HAVE_OPUS */`
  stub branch and defines `opusdevtab` unconditionally, so an opus-absent host now
  degrades to a build without `/dev/opus` instead of failing on the missing header.

## Validation

- Conditional shell logic verified both ways locally: opus present → emits
  `-DHAVE_OPUS` + opus cflags/libs; opus absent → emits nothing.
- Positive path emits flags identical to the previous hard-coded line.

After merge, `v0.2.0-rc2` will be re-pointed at the fixed master tip to re-cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)