### PR TITLE
fix(release): ship usr/ and mnt/ in Windows bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1176,7 +1176,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$Stage\Nt\amd64\bin" | Out-Null
           Copy-Item "Nt\amd64\bin\limbo.exe" "$Stage\Nt\amd64\bin\"
           Copy-Item "Nt\amd64\bin\mk.exe"    "$Stage\Nt\amd64\bin\"
-          foreach ($d in @("dis", "lib", "fonts", "module", "services", "locale")) {
+          foreach ($d in @("dis", "lib", "fonts", "module", "services", "locale", "usr", "mnt")) {
             if (Test-Path $d) { Copy-Item -Recurse $d "$Stage\$d" }
           }
           New-Item -ItemType Directory -Force -Path "$Stage\tmp" | Out-Null


### PR DESCRIPTION
## Summary

- Windows release zips were missing `usr/` and `mnt/`, which the shared `lib/sh/profile` needs as bind targets for the `~/.infernode/` writable overlay introduced in 3879eba3.
- Linux (since af30b701) and macOS already ship both trees; this commit brings Windows to parity by adding `usr` and `mnt` to the `Stage-Common` directory list in `.github/workflows/release.yml`.
- The bind targets are tracked as empty dirs via `.gitkeep`, so `Copy-Item -Recurse` picks them up — no Profile changes, no source changes.

Without the fix, first boot on Windows logged:

```
bind: /usr/inferno/tmp: '/usr/inferno/tmp' does not exist
factotum: can't bind #sfactotum on /mnt/factotum: '/mnt' file does not exist
```

## Test plan

Verified end-to-end on a Windows 11 host against a patched extraction of `infernode-0.2.0-rc2-windows-amd64.zip`:

- [x] `usr/inferno/{secstore,tmp}` and `mnt/factotum` present in bundle
- [x] Both bind errors disappear from `sh -l` boot output
- [x] `~/.infernode/` overlay created on first launch with the expected layout (`lib/{ndb,lucifer/theme,veltro,veltro-agents,veltro-keys,keyring}`, `tmp`, `usr/inferno/{secstore,tmp}`)
- [x] Default configs seeded into the overlay (`lib/ndb/llm`, `lib/lucifer/theme/current`, `lib/veltro/meta.txt`, `lib/veltro-agents/task.txt`)
- [x] `InferNode.exe` spawns the SDL3 GUI with title "InferNode" (canonical args: `-c1 -g 1024x768 -pheap=1024m -pmain=1024m -pimage=1024m -r <bundle> sh -l /lib/lucifer/boot.sh`)
- [x] Headless `o.emu.exe` runs Limbo cleanly (`sh -c 'echo hello'` prints to stdout)
- [ ] Maintainer to confirm end-to-end install on a fresh Windows host using a `workflow_dispatch` build of this PR's release.yml (instructions below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)