### PR TITLE
fix(setup-windows): write to ~/.infernode overlay when it exists

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -15,6 +15,69 @@
 $ErrorActionPreference = "Stop"
 $Root = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
+# Once the runtime has booted once, lib/sh/profile creates ~/.infernode/
+# and bind-mounts subtrees of it over /lib/ndb, /lib/veltro/keys, etc.
+# (commit 3879eba3 — read-only bundle root, writable user overlay).
+# Writes to the bundle's lib/* are invisible to the runtime once the
+# overlay exists. Write-Config below mirrors writes to both locations
+# so setup works whether it's run before OR after first launch, and
+# stays consistent if the user later deletes the overlay for a re-seed.
+$Infhome = Join-Path $env:USERPROFILE '.infernode'
+
+# Overlay path mapping per lib/sh/profile binds. Bundle path → overlay
+# subtree-relative path. Where the bind names diverge (the profile
+# avoids putting lib/veltro/keys under lib/veltro so the two binds
+# don't conflict), the mapping records both sides.
+$OverlayMap = @{
+    'lib\ndb'              = 'lib\ndb'
+    'lib\veltro\keys'      = 'lib\veltro-keys'
+    'lib\veltro'           = 'lib\veltro'
+    'lib\veltro\agents'    = 'lib\veltro-agents'
+    'lib\lucifer\theme'    = 'lib\lucifer\theme'
+    'lib\keyring'          = 'lib\keyring'
+}
+
+function Resolve-OverlayPath {
+    param([string]$BundleRel)
+    # Find the longest matching prefix in $OverlayMap.
+    $best = $null; $bestLen = -1
+    foreach ($k in $OverlayMap.Keys) {
+        $kSlash = "$k\"
+        if ($BundleRel -eq $k -or $BundleRel.StartsWith($kSlash, [StringComparison]::OrdinalIgnoreCase)) {
+            if ($k.Length -gt $bestLen) { $best = $k; $bestLen = $k.Length }
+        }
+    }
+    if (-not $best) { return $null }
+    $suffix = $BundleRel.Substring($best.Length)
+    return ($OverlayMap[$best] + $suffix)
+}
+
+function Write-Config {
+    param(
+        [Parameter(Mandatory)] [string]$BundleRel,
+        [Parameter(Mandatory)] [string]$Content
+    )
+    # Always seed the bundle so a fresh first-boot (no overlay yet) picks
+    # this up via the lib/sh/profile cp step.
+    $bundlePath = Join-Path $Root $BundleRel
+    $bundleDir = Split-Path -Parent $bundlePath
+    if (-not (Test-Path $bundleDir)) { New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null }
+    Set-Content -Path $bundlePath -Value $Content -NoNewline
+
+    # If the overlay already exists, write the live copy too. Without
+    # this, the runtime keeps reading the stale overlay value and the
+    # bundle write is invisible until the user deletes ~/.infernode.
+    if (Test-Path $Infhome) {
+        $overlayRel = Resolve-OverlayPath $BundleRel
+        if ($overlayRel) {
+            $overlayPath = Join-Path $Infhome $overlayRel
+            $overlayDir = Split-Path -Parent $overlayPath
+            if (-not (Test-Path $overlayDir)) { New-Item -ItemType Directory -Path $overlayDir -Force | Out-Null }
+            Set-Content -Path $overlayPath -Value $Content -NoNewline
+        }
+    }
+}
+
 # Mirror everything to a log file so right-click "Run with PowerShell" runs
 # have a post-mortem when the window closes too fast to read.
 $LogFile = Join-Path $env:TEMP "infernode-setup-windows.log"
@@ -44,10 +107,7 @@ function Write-Fail  { param($msg) Write-Host "  X " -ForegroundColor Red -NoNew
 
 function Write-Key {
     param([string]$Service, [string]$Key)
-    $dir = Join-Path $Root "lib\veltro\keys"
-    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-    $path = Join-Path $dir $Service
-    Set-Content -Path $path -Value $Key -NoNewline
+    Write-Config -BundleRel "lib\veltro\keys\$Service" -Content $Key
     Write-Ok "Key saved to lib\veltro\keys\$Service"
 }
 
@@ -58,6 +118,17 @@ Write-Host ""
 Write-Host "InferNode Setup" -ForegroundColor White -BackgroundColor DarkBlue
 Write-Host "Configure the LLM backend for Veltro" -ForegroundColor DarkGray
 Write-Host ""
+
+# Heads-up if a runtime is already loaded. llmsrv reads its backend
+# settings at start, so a running emu won't pick up the new config
+# until it's restarted.
+$running = Get-Process -Name 'o.emu','InferNode' -ErrorAction SilentlyContinue
+if ($running) {
+    Write-Warn "InferNode is currently running (PID $($running.Id -join ', '))."
+    Write-Host "    Settings will be written to disk, but the live emulator" -ForegroundColor DarkGray
+    Write-Host "    won't see the new backend until you close and relaunch it." -ForegroundColor DarkGray
+    Write-Host ""
+}
 
 # ── Choose backend ─────────────────────────────────────────────────
 Write-Host "Veltro needs an LLM to work. Choose your backend:"
@@ -140,16 +211,13 @@ function Setup-Anthropic {
     # Write the runtime LLM config so profile/boot.sh starts llmsrv with
     # the right backend. We leave model= blank so Settings doesn't
     # pre-populate a model string; the user picks one from the UI.
-    $cfgDir = Join-Path $Root "lib\ndb"
-    if (-not (Test-Path $cfgDir)) { New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null }
-    $cfgPath = Join-Path $cfgDir "llm"
-    @"
+    Write-Config -BundleRel "lib\ndb\llm" -Content @"
 mode=local
 backend=api
 url=https://api.anthropic.com
 model=
 dial=
-"@ | Set-Content -Path $cfgPath -NoNewline
+"@
     Write-Ok "Config saved to lib\ndb\llm"
 
     Write-Host ""
@@ -261,16 +329,13 @@ function Setup-Ollama {
     # Write the LLM config. The runtime reads /lib/ndb/llm (see
     # lib/sh/profile and lib/lucifer/boot.sh); the old
     # lib/veltro/llm.cfg path was a dead file - nothing read it.
-    $cfgDir = Join-Path $Root "lib\ndb"
-    if (-not (Test-Path $cfgDir)) { New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null }
-    $cfgPath = Join-Path $cfgDir "llm"
-    @"
+    Write-Config -BundleRel "lib\ndb\llm" -Content @"
 mode=local
 backend=openai
 url=http://localhost:11434/v1
 model=$model
 dial=
-"@ | Set-Content -Path $cfgPath -NoNewline
+"@
     Write-Ok "Config saved to lib\ndb\llm"
 
     Write-Host ""


### PR DESCRIPTION
## Summary

`setup-windows.ps1` writes the LLM config and API keys into the bundle's `lib\ndb\llm` and `lib\veltro\keys\<service>`. That works for first-time setup before InferNode is ever launched — `lib/sh/profile` copies those files into the user overlay on first boot.

But once the runtime has booted once, `lib/sh/profile` bind-mounts the user overlay over those locations:

```
bind -bc $infhome/lib/ndb         /lib/ndb
bind -bc $infhome/lib/veltro-keys /lib/veltro/keys
```

A re-run of setup (e.g. to switch backend, rotate a key, or swap models) wrote into the bundle, the runtime kept reading the stale overlay, and the user's change was silently invisible until they deleted `~/.infernode` and re-seeded.

The script predates the read-only-bundle / writable-overlay design (commit `3879eba3`, Apr 2026) — it just hadn't caught up to the new layout.

## Changes

- Add `$Infhome = ~/.infernode` and an `$OverlayMap` that encodes the bind renames the profile applies (`lib\veltro\keys` → `lib\veltro-keys`, `lib\veltro\agents` → `lib\veltro-agents`).
- New `Write-Config` helper writes the bundle copy (so a future overlay-rebuild seeds the same defaults via the profile's first-run `cp`) AND, when `~/.infernode` already exists, writes the live overlay copy too.
- `Resolve-OverlayPath` handles the path rewrite via longest-prefix match — paths under `lib\veltro\keys\*` redirect to `lib\veltro-keys\*` without breaking unrelated paths under `lib\veltro\*` (which keeps its name).
- `Write-Key` and the two inline LLM-config writes (Anthropic + Ollama paths) refactored onto `Write-Config`.
- New banner check: warns the user if `o.emu` / `InferNode` is currently running, since `llmsrv` reads its backend at startup and won't pick up the new config until the runtime restarts.

## Test plan

Verified end-to-end on a Windows 11 host with a live `~/.infernode` overlay:

- [x] `Resolve-OverlayPath` unit cases — all 8 paths (`lib\ndb\llm`, `lib\veltro\keys\anthropic`, `lib\veltro\keys\brave`, `lib\veltro\meta.txt`, `lib\veltro\agents\task.txt`, `lib\lucifer\theme\current`, `lib\keyring\serve-llm`, and an unmapped path) map correctly with the `lib\veltro\keys` → `lib\veltro-keys` rewrite applied.
- [x] `Write-Config` from a test harness produced both bundle and overlay copies for `lib\ndb\llm` (no rename) and `lib\veltro\keys\anthropic` (rename to `lib\veltro-keys\anthropic`). Overlay file content matches bundle file content byte-for-byte.
- [x] Script parses cleanly under Windows PowerShell 5.1.
- [x] Live overlay restored to original state after the test (no leaked test API keys).
- [ ] Maintainer to run the full interactive `setup-windows.ps1` on a fresh extraction of the next release zip (verify the Ollama path detects + installs + pulls + writes config) and on a re-run against an existing overlay (verify the new write is picked up).

## Related

- The setup script ships in every Windows release zip via `Stage-Common` in `release.yml`.
- Pairs with #196 (release: ship `usr/` and `mnt/`) and #197 (settings: Backend radio snap-back) for a clean Windows release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)