### PR TITLE
fix(setup-windows.bat): strip MOTW from bundle before invoking setup

### DIFF
--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -1,14 +1,23 @@
 @echo off
 REM InferNode setup - .bat wrapper around setup-windows.ps1.
 REM
-REM Why this exists: right-click "Run with PowerShell" on a .ps1 sometimes
-REM opens a window that closes too fast to read - either because
-REM ExecutionPolicy blocks the script before any output, or because the
-REM host doesn't keep the window open on exit. This .bat:
-REM   1. Always invokes powershell.exe with -ExecutionPolicy Bypass and
+REM Why this exists:
+REM   1. Mark-of-the-Web: browser-downloaded zips tag every extracted
+REM      file with Zone.Identifier=3. SmartScreen silently blocks the
+REM      unsigned InferNode.exe, and PowerShell refuses to run the .ps1
+REM      until it's unblocked. .bat files are exempt from this gate, so
+REM      this wrapper runs even when nothing else can — and its first
+REM      job is to clear MOTW from the whole bundle so the rest of the
+REM      install (and InferNode.exe itself) works on double-click.
+REM   2. Right-click "Run with PowerShell" on a .ps1 sometimes opens a
+REM      window that closes too fast to read.
+REM
+REM This .bat:
+REM   1. Recursively clears Mark-of-the-Web from every file in the
+REM      bundle directory (silently — no-op if nothing's tagged).
+REM   2. Invokes powershell.exe with -ExecutionPolicy Bypass and
 REM      -NoProfile so the script runs regardless of system policy.
-REM   2. Always pauses at the end so the user can read the result.
-REM   3. Mirrors the PowerShell host's output to a log file in %TEMP%.
+REM   3. Always pauses at the end so the user can read the result.
 REM
 REM Double-click this file, or run "setup-windows.bat" from cmd.
 
@@ -29,6 +38,14 @@ if not exist "%PS_SCRIPT%" (
 REM Prefer modern PowerShell 7 if available; fall back to Windows PowerShell.
 set "PWSH=pwsh.exe"
 where /q pwsh.exe || set "PWSH=powershell.exe"
+
+REM Strip Mark-of-the-Web from every file in the bundle. Unblock-File is
+REM idempotent and silent on already-unblocked files, so this is safe to
+REM run unconditionally. Without this, SmartScreen silently refuses to
+REM launch InferNode.exe after the user runs setup and double-clicks it.
+echo Clearing Mark-of-the-Web tags from bundle (one-time, silent)...
+%PWSH% -NoProfile -ExecutionPolicy Bypass -Command ^
+    "Get-ChildItem -LiteralPath '%SCRIPT_DIR%' -Recurse -File -Force -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue"
 
 echo Launching %PWSH% %PS_SCRIPT% ...
 echo (log: %LOG%)


### PR DESCRIPTION
## Summary

Browser-downloaded zips carry a `Zone.Identifier=3` (Internet zone) ADS; Windows File Explorer propagates that tag to every extracted file. Consequences:

- Double-clicking `InferNode.exe` silently fails — SmartScreen refuses to launch an unsigned MOTW-tagged PE with **no dialog, no Event Log entry**. The "double-clicked, nothing happened" pattern observed during v0.2.0-rc3 testing.
- `Run with PowerShell` on `setup-windows.ps1` hits the ExecutionPolicy gate before any output, even though the `.bat` wrapper passes `-ExecutionPolicy Bypass` — the policy check on PS 7 evaluates MOTW separately from the policy flag.
- The documented manual fix (right-click zip → Properties → Unblock → OK BEFORE extracting) works but is a heavy ask and easy to miss.

`.bat` files are exempt from the MOTW launch gate, so the `.bat` wrapper is the only artifact in the bundle that's guaranteed to run after a browser download. This change makes it the on-ramp: its first action is now to recursively `Unblock-File` the entire bundle directory, then it continues into the existing `setup-windows.ps1` invocation.

After this change, the documented Windows install reduces to:

> Extract the zip. Double-click `setup-windows.bat`. Then double-click `InferNode.exe`.

No right-click-properties dance required.

## Test plan

Verified end-to-end on Windows 11 against a freshly-downloaded `infernode-0.2.0-windows-amd64-gui.zip`:

- [x] Manually applied `ZoneId=3` to the zip and re-extracted (matches File Explorer's MOTW propagation behaviour; `Expand-Archive` doesn't propagate, hence the manual step in testing).
- [x] Confirmed **2247 of 2247 files MOTW-tagged** before running the .bat.
- [x] Ran `setup-windows.bat` with stdin piped from a canned answer file (Ollama path, llama3.2:3b model).
- [x] After bat exit (code 0): **0 of 2247 files still tagged**.
- [x] `setup-windows.ps1` completed cleanly; the "InferNode is currently running" warning correctly detected a test emu.

## Roadmap

- Becomes a no-op once code-signing lands (SignPath application submitted 2026-06-02). Stays load-bearing for unsigned v0.2.0 bundles users may have downloaded prior to signing, and for power users running from locally-built zips that picked up MOTW from a cloud-sync tool.
- Should be paired with a README/release-notes update telling users to start from `setup-windows.bat` instead of double-clicking `InferNode.exe` directly. Filed as a follow-up rather than included here to keep the PR scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)