### PR TITLE
docs(windows): point install instructions at setup-windows.bat for MOTW

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1328,9 +1328,9 @@ jobs:
 
           **Linux (headless):** Extract, then `./infernode-headless`
 
-          **Windows (GUI):** Extract the `-gui` zip, optionally run `setup-windows.ps1` (or `setup-windows.bat`) to configure an LLM backend, then double-click `InferNode.exe`. The launcher embeds an icon and version metadata; the SDL3 GUI emulator and `SDL3.dll` ship in the same zip.
+          **Windows (GUI):** Extract the `-gui` zip, **double-click `setup-windows.bat`** (it clears the Mark-of-the-Web tag from the bundle and configures an LLM backend), then double-click `InferNode.exe`. The launcher embeds an icon and version metadata; the SDL3 GUI emulator and `SDL3.dll` ship in the same zip. Without running `setup-windows.bat` first, Windows SmartScreen silently blocks the unsigned `InferNode.exe` after browser download — see the Code signing section below.
 
-          **Windows (headless):** Extract the zip, then from a console run `o.emu.exe -c1 -r. sh -l`.
+          **Windows (headless):** Extract the zip, double-click `setup-windows.bat` to clear Mark-of-the-Web, then from a console run `o.emu.exe -c1 -r. sh -l`.
 
           ### Verification
 
@@ -1350,7 +1350,8 @@ jobs:
           [SignPath Foundation](https://signpath.org/), with certificates
           issued by SSL.com. Signed Windows binaries carry verified
           Publisher metadata and accumulate Microsoft SmartScreen
-          reputation; unsigned downloads are silently blocked by Windows
-          after browser delivery (the "Mark of the Web") and require the
-          manual right-click → Properties → Unblock step described in
-          the Windows download bullet above.
+          reputation. Until the signing path is live, unsigned downloads
+          are silently blocked by Windows after browser delivery (the
+          "Mark of the Web"); `setup-windows.bat` works around this by
+          clearing the tag from the bundle on first run — see the
+          Windows install bullet above.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ InferNode is a modern Inferno® distribution with JIT compilation on AMD64 (14×
 Every tagged release ships signed binaries for macOS, Linux, and Windows on the [latest release page](https://github.com/infernode-os/infernode/releases/latest). No toolchain, no build step — download and run.
 
 - **macOS (Apple Silicon)** — `infernode-*-macos-arm64.dmg`: open, drag to Applications, launch.
-- **Windows (x86_64)** — `infernode-*-windows-amd64.zip`: **before extracting**, right-click the downloaded zip → Properties → tick **Unblock** → OK. Then extract, optionally run `setup-windows.ps1` (or `setup-windows.bat`) to configure an LLM backend, double-click `InferNode.exe`. (Without the Unblock step Windows propagates the browser's Mark-of-the-Web to every extracted file; SmartScreen then silently refuses to launch the unsigned exe with no error dialog. Code-signing is on the roadmap.)
+- **Windows (x86_64)** — `infernode-*-windows-amd64-gui.zip`: extract, **double-click `setup-windows.bat`** (it clears the Mark-of-the-Web tag from the bundle and configures an LLM backend), then double-click `InferNode.exe`. (Until code-signing lands, the unsigned `InferNode.exe` would otherwise be silently blocked by SmartScreen after browser download — Windows propagates Mark-of-the-Web from the zip to every extracted file. `.bat` files are exempt from that gate, so `setup-windows.bat` runs anyway and its first job is to unblock the rest of the bundle.)
 - **Linux x86_64 (GUI)** — `infernode-*-linux-amd64-gui.tar.gz`: SDL3 is bundled.
 - **Linux ARM64 (GUI)** — `infernode-*-linux-arm64-gui.tar.gz`: for Jetson, Raspberry Pi, etc.
 - **Linux (headless)** — `infernode-*-linux-amd64.tar.gz` or `infernode-*-linux-arm64.tar.gz`.
@@ -40,7 +40,7 @@ cd infernode-*-linux-*-gui
 
 Every release asset is published with a cosign bundle (`.pem` + `.sig`) and a signed `SHA256SUMS.txt`; container images carry SLSA build provenance. See [Releases](https://github.com/infernode-os/infernode/releases) for the full history.
 
-Code signing for Windows builds is provided by the [SignPath Foundation](https://signpath.org/) — a non-profit that signs open-source releases with certificates issued by SSL.com. Signed Windows binaries get verified Publisher metadata and Microsoft SmartScreen reputation; without signing, browser-downloaded zips carry a Mark-of-the-Web tag that Windows propagates to every extracted file and SmartScreen then silently blocks (see the Windows install bullet above for the manual Unblock workaround in the meantime).
+Code signing for Windows builds is provided by the [SignPath Foundation](https://signpath.org/) — a non-profit that signs open-source releases with certificates issued by SSL.com. Signed Windows binaries get verified Publisher metadata and Microsoft SmartScreen reputation; without signing, browser-downloaded zips carry a Mark-of-the-Web tag that Windows propagates to every extracted file and SmartScreen then silently blocks (handled in the meantime by `setup-windows.bat`, which clears the tag from the bundle on first run — see the Windows install bullet above).
 
 ### Build from source
 


### PR DESCRIPTION
## Summary

v0.2.1 shipped PR #200, which made \`setup-windows.bat\` strip Mark-of-the-Web from the bundle on first run. But the install documentation still pointed at the old manual right-click-Properties-Unblock-before-extracting workaround — telling users to do work they no longer need to do, and (more importantly) failing to tell them that running \`setup-windows.bat\` is now load-bearing.

## Changes

- **README.md** — Windows install bullet and SignPath attribution paragraph rewritten around \`setup-windows.bat\` as the on-ramp.
- **release.yml** — release-notes body (Windows GUI + headless Quick Start, Code signing section) updated to match. This propagates to every future release's GitHub release page.

The new Windows flow now reads consistently across both surfaces:

> Extract the zip, double-click \`setup-windows.bat\` (it clears Mark-of-the-Web and configures an LLM backend), then double-click \`InferNode.exe\`.

## Related

- v0.2.1 release (the version this PR's text is documenting): https://github.com/infernode-os/infernode/releases/tag/v0.2.1
- PR #200 — the underlying .bat fix
- \`pdfinn/infernode.io\` PR #8 — parallel \`winBody\` update on the public download page

## Test plan

- [x] Diff reviewed — only docs touched, no behavior change
- [x] release.yml YAML still well-formed (changes are inside the existing multi-line \`body:\` literal)
- [ ] Merge → cut v0.2.2 patch release so the next published release-notes body reflects the new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)