### PR TITLE
ci: workflow audit fixes (pin floating actions, macOS .app source, labels)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,11 @@ jobs:
     - name: Bootstrap build (mk, libraries, limbo, emulator)
       run: |
         chmod +x build-linux-amd64.sh
-        ./build-linux-amd64.sh
+        # Explicit headless: this job installs no SDL3, so the script's
+        # default sdl3 mode would fail the pkg-config check and fall back
+        # to headless anyway. Pass it outright so the "headless build"
+        # guarantee doesn't depend on that fallback (matches linux-arm64).
+        ./build-linux-amd64.sh headless
 
     - name: Verify emulator binary
       run: |
@@ -953,7 +957,7 @@ jobs:
         }
 
     - name: Setup MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: amd64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -945,7 +945,7 @@ jobs:
         RESOURCES="$CONTENTS/Resources"
 
         # Start from the checked-out .app bundle (has Info.plist, icon, launcher)
-        cp -a MacOSX/InferNode.app "$APP"
+        cp -a MacOSX/Infernode.app "$APP"
 
         # Emulator binary and SDL3 go in Contents/MacOS/ (stripped for release)
         cp emu/MacOSX/InferNode "$MACOS/emu"
@@ -1277,12 +1277,6 @@ jobs:
           cosign sign-blob --yes --bundle "${f}.sigstore" "$f"
         done
 
-    - name: Attest build provenance
-      run: |
-        cd artifacts
-        for f in infernode-*.tar.gz infernode-*.dmg infernode-*.zip; do
-          [ -f "$f" ] && echo "Attesting $f" || continue
-        done
     - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
         subject-path: artifacts/infernode-*.tar.gz

--- a/.github/workflows/verify-dis-paths.yml
+++ b/.github/workflows/verify-dis-paths.yml
@@ -22,6 +22,6 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Verify dis paths
         run: ./tools/verify-dis-paths.sh


### PR DESCRIPTION
Fixes from a full audit of the CI/release workflows. Each is independent and low-risk.

- **Pin two floating actions** by SHA: `actions/checkout@v6` (verify-dis-paths) and `ilammy/msvc-dev-cmd@v1` (ci) — the only unpinned actions, contradicting the repo's Scorecard posture.
- **`release.yml` — macOS `.app` source path:** copied `MacOSX/InferNode.app` but the tracked bundle is `MacOSX/Infernode.app` (lowercase n). Worked only because the CI runner's APFS is case-insensitive — a latent break on any case-sensitive checkout.
- **`release.yml` — Windows label:** release notes said "headless"; the Windows zip ships the SDL3 GUI. Corrected.
- **`release.yml` — Windows zip parity:** add `usr/` + `mnt/` to match the Linux/macOS copy loops (`mnt` has no overlay fallback on Windows).
- **`release.yml` — dead step:** drop an attest-provenance `echo` loop that does nothing (the real attestation is the steps that follow).
- **`ci.yml` — explicit headless:** `linux-amd64` now passes `headless` outright instead of relying on the sdl3-fallback.

Audit also surfaced larger items left for follow-up (macOS build-script drift, cppcheck SARIF wiring, formal-verification TLA+/ACSL jobs, a macOS GUI/JIT job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)