### PR TITLE
crypto: hybrid post-quantum native auth handshake for 9P/Styx

### DIFF
--- a/docs/CRYPTO-MODERNIZATION.md
+++ b/docs/CRYPTO-MODERNIZATION.md
@@ -348,6 +348,70 @@ auth/createsignerkey -a slhdsa256s signer_name
 ./emu/Linux/o.emu -r. /tests/sha3_test.dis
 ```
 
+### 10. Native Transport Hybrid Key Agreement (9P / Styx)
+
+The previous PQ work made the *TLS 1.3 client* (`appl/lib/crypt/tls.b`)
+hybrid, but InferNode nodes do not talk to each other over that path — they
+use the native Inferno authentication protocol (`Keyring->auth`, the
+Station-to-Station handshake in `libinterp/keyring.c`) followed by the `ssl`
+line-encryption device. That handshake derived its session key from
+**classical Diffie-Hellman only**, so node-to-node 9P traffic was *not*
+quantum-safe even with PQ certificates. This change closes that gap.
+
+The STS handshake is now **protocol version 2** and performs a hybrid key
+agreement. Because the protocol is symmetric (both peers run identical
+code), it uses a **mutual ML-KEM-768 exchange**:
+
+1. Each peer generates an ephemeral ML-KEM-768 keypair and sends its public
+   key (`ek`, 1184 bytes) alongside the existing `alpha**r0`, certificate
+   and public key.
+2. Each peer encapsulates to the other's `ek` (sending a 1088-byte
+   ciphertext) and decapsulates the ciphertext it receives.
+3. Both `ek`s are bound into the signed STS transcript, so an active
+   attacker cannot substitute ML-KEM keys without invalidating the
+   signature. (The transcript signature hash was also upgraded SHA-1 →
+   SHA-256.)
+4. The session secret is
+
+   ```
+   SHA3-512("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)
+   ```
+
+   where the two KEM secrets and `ek`s are ordered canonically by comparing
+   the public keys, so both peers derive the identical 64-byte secret. That
+   secret feeds the `ssl` device unchanged (64 bytes supplies a full key +
+   IV for any cipher).
+
+The result is safe unless **both** the Diffie-Hellman and the ML-KEM problem
+are broken — directly addressing the harvest-now-decrypt-later threat on the
+native transport.
+
+| Aspect | v1 (classical) | v2 (hybrid) |
+|--------|----------------|-------------|
+| Key agreement | DH only | DH + mutual ML-KEM-768 |
+| Session secret | raw `alpha**(r0*r1)` | `SHA3-512(dh ‖ kem ‖ eks)`, 64 bytes |
+| Transcript signature hash | SHA-1 | SHA-256 |
+| PQ ek/ct on the wire | — | 1184 B ek + 1088 B ct each way |
+| Interop | — | **clean break**: v1 peers are rejected |
+
+**Breaking change:** This is a clean break (consistent with the rest of this
+document). A v2 node refuses to authenticate with a v1 (classical-only)
+node; all nodes must be upgraded together.
+
+**Files modified:**
+- `libinterp/keyring.c` — `Keyring_auth` hybrid handshake (ML-KEM exchange,
+  transcript binding, SHA3-512 combiner, secret scrubbing)
+
+**Files created:**
+- `tests/pqauth_test.b` — runs the handshake on both ends of a pipe and
+  asserts both peers mutually authenticate and derive the **same** 64-byte
+  hybrid secret; then drives the real `Auth->client`/`Auth->server` +
+  `ssl` path and round-trips a 9P-style payload over the encrypted channel.
+
+```sh
+./emu/Linux/o.emu -r. /tests/pqauth_test.dis -v
+```
+
 ## Security Properties (Updated)
 
 After all changes, the complete SigAlgVec registry:

--- a/docs/CRYPTO-MODERNIZATION.md
+++ b/docs/CRYPTO-MODERNIZATION.md
@@ -403,10 +403,23 @@ node; all nodes must be upgraded together.
   transcript binding, SHA3-512 combiner, secret scrubbing)
 
 **Files created:**
-- `tests/pqauth_test.b` — runs the handshake on both ends of a pipe and
-  asserts both peers mutually authenticate and derive the **same** 64-byte
-  hybrid secret; then drives the real `Auth->client`/`Auth->server` +
-  `ssl` path and round-trips a 9P-style payload over the encrypted channel.
+- `tests/pqauth_test.b` — covers the handshake end to end:
+  - *HybridAuthHandshake* — both peers mutually authenticate and derive the
+    **same** 64-byte hybrid secret (ed25519 signer).
+  - *HybridHandshakeMLDSA* — same, with an ML-DSA-65 signer: a **fully
+    post-quantum** handshake (PQ signatures + PQ KEM).
+  - *HybridEncryptedChannel* / *HybridTcpChannel* — drives the real
+    `Auth->client`/`Auth->server` + `ssl` path and round-trips a 9P-style
+    payload over the encrypted channel (over a pipe, and over a real TCP
+    socket; the TCP case skips where no IP stack is available).
+  - *DowngradeRejected* — a v1 (classical-only) peer is refused.
+  - *TamperedEkRejected* — flipping a byte in an ML-KEM public key fails the
+    handshake (`bad certificate`), proving the transcript binding defends
+    against an active KEM-substitution MITM.
+  - *MalformedEkRejected* — a wrong-length ML-KEM key is rejected.
+
+  The negative cases use a configurable man-in-the-middle relay between two
+  real `auth()` endpoints.
 
 ```sh
 ./emu/Linux/o.emu -r. /tests/pqauth_test.dis -v

--- a/docs/QUANTUM-SAFE-CRYPTO-PLAN.md
+++ b/docs/QUANTUM-SAFE-CRYPTO-PLAN.md
@@ -20,8 +20,17 @@
 | 7 | SHA-3 Keyring builtins | **Complete** |
 | 7 | Comprehensive test hardening | **Complete** |
 | 7 | Documentation | **Complete** |
+| 8 | Hybrid DH+ML-KEM-768 native STS handshake (9P/Styx) | **Complete** |
 
 All 8 SigAlgVec slots filled: ed25519, elgamal, rsa, dsa, mldsa65, mldsa87, slhdsa192s, slhdsa256s.
+
+**Phase 8 (node-to-node transport):** The TLS 1.3 hybrid (Phase 3) only
+covers outbound TLS to external servers. InferNode↔InferNode traffic uses
+the native Inferno auth protocol (`Keyring->auth`) + the `ssl` device, which
+was classical-DH-only. Phase 8 makes that handshake hybrid (mutual ML-KEM-768
+combined with DH via SHA3-512), so native 9P/Styx sessions are now
+quantum-safe end-to-end. See
+[CRYPTO-MODERNIZATION.md §10](CRYPTO-MODERNIZATION.md#10-native-transport-hybrid-key-agreement-9p--styx).
 
 ## 1. Motivation
 

--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -1725,6 +1725,12 @@ Keyring_auth(void *fp)
 	uchar *cvb;
 	int n, fd, version;
 	long now;
+	/* hybrid post-quantum (ML-KEM-768) key agreement material */
+	uchar myek[MLKEM768_PKLEN], mydk[MLKEM768_SKLEN];
+	uchar hisek[MLKEM768_PKLEN], myct[MLKEM768_CTLEN], hisct[MLKEM768_CTLEN];
+	uchar ss_local[MLKEM_SSLEN], ss_remote[MLKEM_SSLEN];
+	uchar *kss_lo, *kss_hi, *ek_lo, *ek_hi;
+	int cmp;
 
 	hispk = H;
 	hiscert = H;
@@ -1752,8 +1758,8 @@ Keyring_auth(void *fp)
 		return;
 	}
 
-	/* send auth protocol version number */
-	if(sendmsg(fd, "1", 1) <= 0){
+	/* send auth protocol version number (2 = hybrid PQ; required) */
+	if(sendmsg(fd, "2", 1) <= 0){
 		err = MSG;
 		goto out;
 	}
@@ -1766,8 +1772,8 @@ Keyring_auth(void *fp)
 	}
 	buf[n] = 0;
 	version = atoi(buf);
-	if(version != 1 || n > 4){
-		err = "incompatible authentication protocol";
+	if(version != 2 || n > 4){
+		err = "incompatible authentication protocol (need hybrid PQ v2)";
 		goto out;
 	}
 
@@ -1826,6 +1832,11 @@ if(0)print("X");
 	acquire();
 if(0)print("Y");
 
+	/* generate ephemeral ML-KEM-768 keypair for hybrid PQ key agreement */
+	release();
+	mlkem768_keygen(myek, mydk);
+	acquire();
+
 	/* send alpha**r0 mod p, mycert, and mypk */
 	n = bigtobase64(alphar0, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0){
@@ -1841,6 +1852,12 @@ if(0)print("Y");
 
 	n = pktostr(mypk, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0){
+		err = MSG;
+		goto out;
+	}
+
+	/* send my ML-KEM-768 public key */
+	if(sendmsg(fd, (char*)myek, MLKEM768_PKLEN) <= 0){
 		err = MSG;
 		goto out;
 	}
@@ -1906,10 +1923,51 @@ if(0)print("Y");
 		goto out;
 	}
 
-	/* sign alpha**r0 and alpha**r1 and send */
+	/* get his ML-KEM-768 public key (sent right after his pk) */
+	n = getmsg(fd, buf, Maxbuf-1);
+	if(n < 0){
+		err = buf;
+		goto out;
+	}
+	if(n != MLKEM768_PKLEN){
+		err = "bad ml-kem public key length";
+		goto out;
+	}
+	memmove(hisek, buf, MLKEM768_PKLEN);
+
+	/* encapsulate to his ek, send the ciphertext */
+	release();
+	mlkem768_encaps(myct, ss_local, hisek);
+	acquire();
+	if(sendmsg(fd, (char*)myct, MLKEM768_CTLEN) <= 0){
+		err = MSG;
+		goto out;
+	}
+
+	/* get his ciphertext, decapsulate with my dk */
+	n = getmsg(fd, buf, Maxbuf-1);
+	if(n < 0){
+		err = buf;
+		goto out;
+	}
+	if(n != MLKEM768_CTLEN){
+		err = "bad ml-kem ciphertext length";
+		goto out;
+	}
+	memmove(hisct, buf, MLKEM768_CTLEN);
+	mlkem768_decaps(ss_remote, hisct, mydk);
+
+	/*
+	 * sign alpha**r0, alpha**r1 and both ML-KEM public keys, then send.
+	 * Binding the eks into the signed transcript authenticates the PQ
+	 * key agreement: an active attacker cannot substitute ML-KEM keys
+	 * without invalidating the signature.
+	 */
 	n = bigtobase64(alphar0, buf, Maxbuf);
 	n += bigtobase64(alphar1, buf+n, Maxbuf-n);
-	alphacert = sign(mysk, "sha1", 0, (uchar*)buf, n);
+	memmove(buf+n, myek, MLKEM768_PKLEN); n += MLKEM768_PKLEN;
+	memmove(buf+n, hisek, MLKEM768_PKLEN); n += MLKEM768_PKLEN;
+	alphacert = sign(mysk, "sha256", 0, (uchar*)buf, n);
 	n = certtostr(alphacert, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0){
 		err = MSG;
@@ -1934,12 +1992,24 @@ if(0)print("Y");
 	certimmutable(alphacert);		/* hide from the garbage collector */
 	n = bigtobase64(alphar1, buf, Maxbuf);
 	n += bigtobase64(alphar0, buf+n, Maxbuf-n);
+	memmove(buf+n, hisek, MLKEM768_PKLEN); n += MLKEM768_PKLEN;
+	memmove(buf+n, myek, MLKEM768_PKLEN); n += MLKEM768_PKLEN;
 	if(verify(hispk, alphacert, buf, n) == 0){
 		err = "bad certificate";
 		goto out;
 	}
 
-	/* we are now authenticated and have a common secret, alpha**(r0*r1) */
+	/*
+	 * We are now mutually authenticated.  Derive the session secret by
+	 * combining the classical Diffie-Hellman secret alpha**(r0*r1) with
+	 * both ML-KEM-768 shared secrets using SHA3-512.  ss_local is keyed
+	 * to his ek (we encapsulated to it); ss_remote is keyed to my ek (he
+	 * encapsulated to it).  Both peers order the two KEM secrets and eks
+	 * identically by comparing the two public keys, so they derive the
+	 * same 64-byte secret.  The result stays secret unless BOTH the DH
+	 * and the ML-KEM problem are broken (hybrid / harvest-now-safe).
+	 * 64 bytes gives the ssl device a full key + IV for any cipher.
+	 */
 	f->ret->t0 = stringdup(hispk->x.owner);
 	mpexp(alphar1, r0, p, alphar0r1);
 	n = mptobe(alphar0r1, nil, Maxbuf, &cvb);
@@ -1947,7 +2017,35 @@ if(0)print("Y");
 		err = "bad conversion";
 		goto out;
 	}
-	f->ret->t1 = mem2array(cvb, n);
+
+	cmp = memcmp(myek, hisek, MLKEM768_PKLEN);
+	if(cmp == 0){
+		free(cvb);
+		err = "ml-kem public key collision";
+		goto out;
+	}
+	if(cmp < 0){
+		kss_lo = ss_remote; ek_lo = myek;	/* my ek is the smaller */
+		kss_hi = ss_local;  ek_hi = hisek;
+	}else{
+		kss_lo = ss_local;  ek_lo = hisek;	/* his ek is the smaller */
+		kss_hi = ss_remote; ek_hi = myek;
+	}
+	{
+		uchar dig[SHA3_512dlen];
+		int m;
+
+		m = 0;
+		memmove(buf+m, "infernode-pq-sts-v2", 19); m += 19;
+		memmove(buf+m, cvb, n); m += n;
+		memmove(buf+m, kss_lo, MLKEM_SSLEN); m += MLKEM_SSLEN;
+		memmove(buf+m, kss_hi, MLKEM_SSLEN); m += MLKEM_SSLEN;
+		memmove(buf+m, ek_lo, MLKEM768_PKLEN); m += MLKEM768_PKLEN;
+		memmove(buf+m, ek_hi, MLKEM768_PKLEN); m += MLKEM768_PKLEN;
+		sha3_512((uchar*)buf, m, dig);
+		f->ret->t1 = mem2array(dig, SHA3_512dlen);
+		memset(dig, 0, sizeof(dig));
+	}
 	free(cvb);
 
 out:
@@ -2008,6 +2106,10 @@ out:
 		certmutable(alphacert);
 		destroy(alphacert);
 	}
+	/* scrub ML-KEM secret key and shared secrets from the stack */
+	memset(mydk, 0, sizeof(mydk));
+	memset(ss_local, 0, sizeof(ss_local));
+	memset(ss_remote, 0, sizeof(ss_remote));
 	free(buf);
 	if(r0 != nil){
 		mpfree(r0);

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -50,6 +50,7 @@ TARG=\
 	outlinefont_test.dis\
 	pdf_conformance_test.dis\
 	pdf_test.dis\
+	pqauth_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/pqauth_test.b
+++ b/tests/pqauth_test.b
@@ -8,12 +8,19 @@ implement PQAuthTest;
 # key encapsulation; the session secret returned to the caller (and fed to
 # the ssl device for 9P line encryption) is
 #
-#     SHA3-256("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)
+#     SHA3-512("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)
 #
-# Both peers run identical code, so the test runs auth() on both ends of a
-# pipe and asserts they mutually authenticate and derive the SAME 32-byte
-# secret.  This is the end-to-end proof that two InferNodes negotiate a
-# quantum-safe session key over their native transport.
+# Coverage:
+#   - HybridAuthHandshake        happy path, ed25519 signer
+#   - HybridHandshakeMLDSA        fully post-quantum (ML-DSA-65 signer + ML-KEM)
+#   - HybridEncryptedChannel      real Auth->client/server + ssl data round-trip (pipe)
+#   - HybridTcpChannel            same, over a real TCP connection (skips w/o network)
+#   - DowngradeRejected           a v1 (classical-only) peer is refused
+#   - TamperedEkRejected          a flipped byte in an ML-KEM public key fails the handshake
+#   - MalformedEkRejected         a wrong-length ML-KEM public key is rejected
+#
+# The negative cases use a configurable man-in-the-middle relay between two
+# real auth() endpoints, parsing the wire framing (5-byte "%4.4d\n" header).
 #
 
 include "sys.m";
@@ -37,6 +44,13 @@ PQAuthTest: module
 };
 
 SRCFILE: con "/tests/pqauth_test.b";
+
+# man-in-the-middle relay corruption modes
+Clean, FlipByte, Truncate: con iota;
+
+# ML-KEM public key is frame index 4 in the client->server direction
+# (0=version, 1=alpha**r0, 2=cert, 3=pubkey, 4=ml-kem ek)
+EKFRAME: con 4;
 
 passed := 0;
 failed := 0;
@@ -71,40 +85,7 @@ run(name: string, testfn: ref fn(t: ref T))
 		failed++;
 }
 
-# Build an Authinfo for `name`, certified by the given signer, sharing the
-# DH group (alpha, p).  Mirrors appl/cmd/auth/mkauthinfo.b.
-mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
-		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
-{
-	sk := kr->genSKfromPK(signerpk, name);
-	pk := kr->sktopk(sk);
-	pkbuf := array of byte kr->pktostr(pk);
-	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
-	cert := kr->sign(signersk, 0, state, "sha256");
-
-	ai := ref Keyring->Authinfo;
-	ai.mysk = sk;
-	ai.mypk = pk;
-	ai.cert = cert;
-	ai.spk = signerpk;
-	ai.alpha = alpha;
-	ai.p = p;
-	return ai;
-}
-
-# one side of the handshake, run in a spawned proc
-authproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Result)
-{
-	(owner, secret) := kr->auth(fd, ai, 0);
-	r := ref Result;
-	if(secret == nil)
-		r.err = owner;
-	else {
-		r.owner = owner;
-		r.secret = secret;
-	}
-	c <-= r;
-}
+# ---- helpers -------------------------------------------------------------
 
 byteseq(a, b: array of byte): int
 {
@@ -114,53 +95,6 @@ byteseq(a, b: array of byte): int
 		if(a[i] != b[i])
 			return 0;
 	return 1;
-}
-
-testHandshake(t: ref T)
-{
-	# shared signer that certifies both identities
-	signersk := kr->genSK("ed25519", "test-signer", 0);
-	if(signersk == nil)
-		t.fatal("genSK signer failed");
-	signerpk := kr->sktopk(signersk);
-
-	# shared DH group; 2048 is precomputed (RFC 3526), so this is fast
-	(alpha, p) := kr->dhparams(2048);
-	if(alpha == nil || p == nil)
-		t.fatal("dhparams failed");
-
-	alice := mkauthinfo(signersk, signerpk, alpha, p, "alice");
-	bob := mkauthinfo(signersk, signerpk, alpha, p, "bob");
-
-	fds := array[2] of ref Sys->FD;
-	if(sys->pipe(fds) < 0)
-		t.fatal(sys->sprint("pipe failed: %r"));
-
-	c := chan of ref Result;
-	spawn authproc(fds[1], bob, c);
-
-	# this proc plays alice; the spawned proc plays bob
-	(cowner, csecret) := kr->auth(fds[0], alice, 0);
-	sr := <-c;
-
-	# both sides must succeed
-	if(csecret == nil)
-		t.fatal("client (alice) auth failed: " + cowner);
-	if(sr.err != nil)
-		t.fatal("server (bob) auth failed: " + sr.err);
-
-	# each side learns the other's authenticated identity
-	t.assertseq(cowner, "bob", "alice authenticates bob");
-	t.assertseq(sr.owner, "alice", "bob authenticates alice");
-
-	# the derived secret is the 64-byte SHA3-512 hybrid output
-	t.asserteq(len csecret, 64, "alice secret is 64 bytes (SHA3-512)");
-	t.asserteq(len sr.secret, 64, "bob secret is 64 bytes (SHA3-512)");
-
-	# and, crucially, both sides derive the IDENTICAL session key
-	t.assert(byteseq(csecret, sr.secret), "both peers derive the same hybrid session secret");
-
-	t.log(sys->sprint("hybrid session secret: %s", hex(csecret)));
 }
 
 hex(a: array of byte): string
@@ -183,8 +117,132 @@ readn(fd: ref Sys->FD, buf: array of byte, n: int): int
 	return tot;
 }
 
-# server end of a real auth + ssl connection: authenticate, then read
-# `expect` bytes off the encrypted channel and hand them back.
+# strstr: does haystack contain needle?
+contains(hay, needle: string): int
+{
+	n := len needle;
+	if(n == 0)
+		return 1;
+	for(i := 0; i + n <= len hay; i++)
+		if(hay[i:i+n] == needle)
+			return 1;
+	return 0;
+}
+
+# Build an Authinfo for `name`, certified by the given signer, sharing the
+# DH group (alpha, p).  Mirrors appl/cmd/auth/mkauthinfo.b.
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk;
+	ai.mypk = pk;
+	ai.cert = cert;
+	ai.spk = signerpk;
+	ai.alpha = alpha;
+	ai.p = p;
+	return ai;
+}
+
+# Create a signer and a mutually-trusting pair (alice, bob) using the given
+# signer key algorithm.
+setupPair(t: ref T, signeralg: string, bits: int): (ref Keyring->Authinfo, ref Keyring->Authinfo)
+{
+	signersk := kr->genSK(signeralg, "test-signer", bits);
+	if(signersk == nil)
+		t.fatal("genSK signer (" + signeralg + ") failed");
+	signerpk := kr->sktopk(signersk);
+
+	(alpha, p) := kr->dhparams(2048);	# 2048 is precomputed (RFC 3526), fast
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+
+	alice := mkauthinfo(signersk, signerpk, alpha, p, "alice");
+	bob := mkauthinfo(signersk, signerpk, alpha, p, "bob");
+	return (alice, bob);
+}
+
+# one side of the handshake, run in a spawned proc
+authproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Result)
+{
+	(owner, secret) := kr->auth(fd, ai, 0);
+	r := ref Result;
+	if(secret == nil)
+		r.err = owner;
+	else {
+		r.owner = owner;
+		r.secret = secret;
+	}
+	c <-= r;
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# collect a spawned peer's result with a timeout safety net.
+# returns (result, ok); ok=0 means it timed out (the peer hung).
+collect(cb: chan of ref Result, ms: int): (ref Result, int)
+{
+	tmo := chan of int;
+	spawn timerproc(tmo, ms);
+	alt {
+	r := <-cb =>
+		return (r, 1);
+	<-tmo =>
+		return (nil, 0);
+	}
+}
+
+# ---- happy-path tests ----------------------------------------------------
+
+handshakeOK(t: ref T, signeralg: string, bits: int)
+{
+	(alice, bob) := setupPair(t, signeralg, bits);
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	cb := chan of ref Result;
+	spawn authproc(fds[1], bob, cb);
+	(aowner, asecret) := kr->auth(fds[0], alice, 0);	# alice runs in main
+	rb := <-cb;
+
+	if(asecret == nil)
+		t.fatal("alice auth failed: " + aowner);
+	if(rb.secret == nil)
+		t.fatal("bob auth failed: " + rb.err);
+
+	t.assertseq(aowner, "bob", "alice authenticates bob");
+	t.assertseq(rb.owner, "alice", "bob authenticates alice");
+	t.asserteq(len asecret, 64, "alice secret is 64 bytes (SHA3-512)");
+	t.asserteq(len rb.secret, 64, "bob secret is 64 bytes (SHA3-512)");
+	t.assert(byteseq(asecret, rb.secret), "both peers derive the same hybrid session secret");
+	t.log(sys->sprint("%s signer: hybrid secret %s", signeralg, hex(asecret)));
+}
+
+testHandshake(t: ref T)
+{
+	handshakeOK(t, "ed25519", 0);
+}
+
+testHandshakeMLDSA(t: ref T)
+{
+	# ML-DSA-65 signer + ML-KEM-768 KEM = a fully post-quantum handshake
+	handshakeOK(t, "mldsa65", 0);
+}
+
+# ---- encrypted-channel tests (real Auth->client/server + ssl) ------------
+
 serverside(fd: ref Sys->FD, ai: ref Keyring->Authinfo, expect: int,
 		rc: chan of (array of byte, string))
 {
@@ -202,56 +260,244 @@ serverside(fd: ref Sys->FD, ai: ref Keyring->Authinfo, expect: int,
 	rc <-= (buf, nil);
 }
 
-# Full end-to-end: two peers run the real Inferno auth handshake (now hybrid
-# PQ) and then push the ssl device keyed by the derived secret, exactly as
-# styxlisten -A / 9P transport do.  Data written by the client must arrive
-# intact at the server, proving the hybrid-derived key keys a working
-# encrypted channel.
-testEncryptedChannel(t: ref T)
+# drive the real auth handshake (now hybrid PQ) then push ssl keyed by the
+# derived secret, exactly as styxlisten -A / 9P transport do, and confirm a
+# 9P-style payload survives the encrypted channel.
+encryptedRoundtrip(t: ref T, cfd, sfdForServer: ref Sys->FD,
+		alice, bob: ref Keyring->Authinfo)
 {
-	if(auth == nil)
-		t.fatal("auth module not loaded");
-	if((e := auth->init()) != nil)
-		t.fatal("auth init failed: " + e);
-
-	signersk := kr->genSK("ed25519", "test-signer", 0);
-	if(signersk == nil)
-		t.fatal("genSK signer failed");
-	signerpk := kr->sktopk(signersk);
-
-	(alpha, p) := kr->dhparams(2048);
-	if(alpha == nil || p == nil)
-		t.fatal("dhparams failed");
-
-	alice := mkauthinfo(signersk, signerpk, alpha, p, "alice");
-	bob := mkauthinfo(signersk, signerpk, alpha, p, "bob");
-
-	fds := array[2] of ref Sys->FD;
-	if(sys->pipe(fds) < 0)
-		t.fatal(sys->sprint("pipe failed: %r"));
-
 	msg := array of byte "9P-over-hybrid-PQC: the quick brown fox authenticates the lazy node";
 
 	rc := chan of (array of byte, string);
-	spawn serverside(fds[1], bob, len msg, rc);
+	spawn serverside(sfdForServer, bob, len msg, rc);
 
-	# client authenticates (hybrid PQ) and gets the ssl-wrapped fd
-	(cfd, cerr) := auth->client("aes_256_cbc sha256", alice, fds[0]);
-	if(cfd == nil)
+	(wrapped, cerr) := auth->client("aes_256_cbc sha256", alice, cfd);
+	if(wrapped == nil)
 		t.fatal("client auth+ssl failed: " + cerr);
-
-	# write plaintext; the ssl device encrypts it with the hybrid key
-	if(sys->write(cfd, msg, len msg) != len msg)
+	if(sys->write(wrapped, msg, len msg) != len msg)
 		t.fatal(sys->sprint("encrypted write failed: %r"));
 
 	(got, serr) := <-rc;
 	if(serr != nil)
 		t.fatal(serr);
-
 	t.asserteq(len got, len msg, "bytes received over encrypted channel");
 	t.assert(byteseq(got, msg), "plaintext survives AES-256 round-trip keyed by the hybrid PQ secret");
-	t.log("9P-style payload decrypted intact over hybrid-keyed ssl channel");
 }
+
+testEncryptedChannel(t: ref T)
+{
+	if(auth == nil || (e := auth->init()) != nil)
+		t.fatal("auth init failed");
+	(alice, bob) := setupPair(t, "ed25519", 0);
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+	encryptedRoundtrip(t, fds[0], fds[1], alice, bob);
+	t.log("9P-style payload decrypted intact over hybrid-keyed ssl channel (pipe)");
+}
+
+tcpserver(ac: Sys->Connection, ai: ref Keyring->Authinfo, expect: int,
+		rc: chan of (array of byte, string))
+{
+	(lok, nc) := sys->listen(ac);
+	if(lok < 0){
+		rc <-= (nil, sys->sprint("listen failed: %r"));
+		return;
+	}
+	dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil){
+		rc <-= (nil, sys->sprint("open data failed: %r"));
+		return;
+	}
+	serverside(dfd, ai, expect, rc);
+}
+
+testTcpChannel(t: ref T)
+{
+	if(auth == nil || (e := auth->init()) != nil)
+		t.fatal("auth init failed");
+
+	addr := "tcp!127.0.0.1!19897";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+
+	(alice, bob) := setupPair(t, "ed25519", 0);
+
+	msg := array of byte "9P-over-hybrid-PQC across a real TCP socket";
+	rc := chan of (array of byte, string);
+	spawn tcpserver(ac, bob, len msg, rc);
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){
+		t.skip(sys->sprint("dial failed (no loopback?): %r"));
+		return;
+	}
+
+	(wrapped, cerr) := auth->client("aes_256_cbc sha256", alice, dc.dfd);
+	if(wrapped == nil)
+		t.fatal("client auth+ssl over tcp failed: " + cerr);
+	if(sys->write(wrapped, msg, len msg) != len msg)
+		t.fatal(sys->sprint("encrypted write over tcp failed: %r"));
+
+	(got, serr) := <-rc;
+	if(serr != nil)
+		t.fatal(serr);
+	t.asserteq(len got, len msg, "tcp: bytes received over encrypted channel");
+	t.assert(byteseq(got, msg), "9P payload round-trips over hybrid-keyed TCP channel");
+	t.log("9P-style payload decrypted intact over hybrid-keyed ssl channel (tcp)");
+}
+
+# ---- negative / security tests -------------------------------------------
+
+# pump one direction of the wire, optionally corrupting a target frame.
+# Frames are: 5-byte header "%4.4d\n" (or "!%3.3d\n" for errors) + payload.
+pump(src, dst: ref Sys->FD, mode, target: int, done: chan of int)
+{
+	idx := 0;
+	for(;;){
+		hdr := array[5] of byte;
+		if(readn(src, hdr, 5) != 5)
+			break;
+		neg := (hdr[0] == byte '!');
+		ns: string;
+		if(neg)
+			ns = string hdr[1:4];
+		else
+			ns = string hdr[0:4];
+		n := int ns;
+		if(n < 0 || n > 9000)
+			break;
+		payload := array[n] of byte;
+		if(n > 0 && readn(src, payload, n) != n)
+			break;
+
+		if(!neg && idx == target && mode == Truncate){
+			# rewrite the frame with a bogus (too-short) length
+			newn := 100;
+			nh := array of byte sys->sprint("%4.4d\n", newn);
+			sys->write(dst, nh, len nh);
+			sys->write(dst, payload[0:newn], newn);
+			idx++;
+			continue;
+		}
+		if(!neg && idx == target && mode == FlipByte && n > 0)
+			payload[0] = byte (int payload[0] ^ 16r01);
+
+		sys->write(dst, hdr, len hdr);
+		if(n > 0)
+			sys->write(dst, payload, n);
+		idx++;
+	}
+	done <-= 1;
+}
+
+# run alice (in main) <-> relay <-> bob, corrupting the client->server EK
+# frame.  Returns (alice-result, bob-result-or-nil-if-bob-hung).
+relayedHandshake(t: ref T, alice, bob: ref Keyring->Authinfo, mode: int): (ref Result, ref Result)
+{
+	pa := array[2] of ref Sys->FD;	# alice <-> relay
+	pb := array[2] of ref Sys->FD;	# relay <-> bob
+	if(sys->pipe(pa) < 0 || sys->pipe(pb) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	cb := chan of ref Result;
+	d := chan[2] of int;	# buffered: pumps signal completion without a reader
+
+	spawn authproc(pb[0], bob, cb);			# bob on pb[0]
+	spawn pump(pa[1], pb[1], mode, EKFRAME, d);	# alice -> bob (corrupting)
+	spawn pump(pb[1], pa[1], Clean, -1, d);		# bob -> alice (clean)
+
+	(aowner, asecret) := kr->auth(pa[0], alice, 0);	# alice runs in main
+	ra := ref Result;
+	if(asecret == nil)
+		ra.err = aowner;
+	else {
+		ra.owner = aowner;
+		ra.secret = asecret;
+	}
+
+	(rb, ok) := collect(cb, 20000);
+	if(!ok){
+		rb = ref Result;
+		rb.err = "bob hung";
+	}
+	return (ra, rb);
+}
+
+testTamperedEk(t: ref T)
+{
+	(alice, bob) := setupPair(t, "ed25519", 0);
+	(ra, rb) := relayedHandshake(t, alice, bob, FlipByte);
+
+	# the EK is bound into the signed transcript, so flipping a byte must
+	# break signature verification; neither side may derive a secret.
+	t.assert(ra.secret == nil, "alice must NOT derive a secret when ek is tampered");
+	t.assert(rb.secret == nil, "bob must NOT derive a secret when ek is tampered");
+	t.assert(ra.secret == nil && rb.secret == nil, "tampered ML-KEM key fails the handshake closed");
+}
+
+testMalformedEk(t: ref T)
+{
+	(alice, bob) := setupPair(t, "ed25519", 0);
+	(nil, rb) := relayedHandshake(t, alice, bob, Truncate);
+
+	# bob reads alice's (truncated) ek and must reject it on length
+	t.assert(rb.secret == nil, "bob must reject a wrong-length ML-KEM key");
+	t.assert(contains(rb.err, "ml-kem") || contains(rb.err, "length"),
+		sys->sprint("bob reports a ml-kem length error (got %q)", rb.err));
+}
+
+# write a framed message matching keyring.c's sendmsg ("%4.4d\n" + payload)
+sendframe(fd: ref Sys->FD, data: array of byte)
+{
+	hdr := array of byte sys->sprint("%4.4d\n", len data);
+	sys->write(fd, hdr, len hdr);
+	if(len data > 0)
+		sys->write(fd, data, len data);
+}
+
+# a fake peer that speaks classical-only protocol version 1
+fakev1peer(fd: ref Sys->FD, done: chan of int)
+{
+	# the real peer sends its version first; read it
+	hdr := array[5] of byte;
+	readn(fd, hdr, 5);
+	if(int string hdr[0:4] > 0){
+		body := array[int string hdr[0:4]] of byte;
+		readn(fd, body, len body);
+	}
+	# claim version "1"; the real (v2) peer will reject.  Then send "OK" so
+	# its error-path "read responses" loop terminates cleanly (the protocol
+	# ends on an "OK"/error frame, not on fd close -- a ref FD here only
+	# shuts on GC, so we must not rely on an implicit hangup).
+	sendframe(fd, array of byte "1");
+	sendframe(fd, array of byte "OK");
+	done <-= 1;
+}
+
+testDowngradeRejected(t: ref T)
+{
+	(alice, nil) := setupPair(t, "ed25519", 0);
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	done := chan[1] of int;	# buffered: fake peer signals without a reader
+	spawn fakev1peer(fds[1], done);
+
+	# the real (v2) peer runs in main and must reject the v1 claim
+	(owner, secret) := kr->auth(fds[0], alice, 0);
+	t.assert(secret == nil, "v2 node must refuse a v1 (classical-only) peer");
+	t.assert(contains(owner, "incompatible") || contains(owner, "protocol"),
+		sys->sprint("downgrade rejected with protocol error (got %q)", owner));
+}
+
+# ---- entry point ---------------------------------------------------------
 
 init(nil: ref Draw->Context, args: list of string)
 {
@@ -277,7 +523,12 @@ init(nil: ref Draw->Context, args: list of string)
 	}
 
 	run("HybridAuthHandshake", testHandshake);
+	run("HybridHandshakeMLDSA", testHandshakeMLDSA);
 	run("HybridEncryptedChannel", testEncryptedChannel);
+	run("HybridTcpChannel", testTcpChannel);
+	run("DowngradeRejected", testDowngradeRejected);
+	run("TamperedEkRejected", testTamperedEk);
+	run("MalformedEkRejected", testMalformedEk);
 
 	if(testing->summary(passed, failed, skipped) > 0)
 		raise "fail:tests failed";

--- a/tests/pqauth_test.b
+++ b/tests/pqauth_test.b
@@ -1,0 +1,284 @@
+implement PQAuthTest;
+
+#
+# Tests for the hybrid post-quantum native authentication handshake
+# (Keyring->auth, the Station-to-Station protocol in libinterp/keyring.c).
+#
+# Protocol v2 combines classical Diffie-Hellman with a mutual ML-KEM-768
+# key encapsulation; the session secret returned to the caller (and fed to
+# the ssl device for 9P line encryption) is
+#
+#     SHA3-256("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)
+#
+# Both peers run identical code, so the test runs auth() on both ends of a
+# pipe and asserts they mutually authenticate and derive the SAME 32-byte
+# secret.  This is the end-to-end proof that two InferNodes negotiate a
+# quantum-safe session key over their native transport.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+PQAuthTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/pqauth_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+# result of one side of the handshake, passed back over a channel
+Result: adt {
+	owner:	string;
+	secret:	array of byte;
+	err:	string;
+};
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	* =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# Build an Authinfo for `name`, certified by the given signer, sharing the
+# DH group (alpha, p).  Mirrors appl/cmd/auth/mkauthinfo.b.
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk;
+	ai.mypk = pk;
+	ai.cert = cert;
+	ai.spk = signerpk;
+	ai.alpha = alpha;
+	ai.p = p;
+	return ai;
+}
+
+# one side of the handshake, run in a spawned proc
+authproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Result)
+{
+	(owner, secret) := kr->auth(fd, ai, 0);
+	r := ref Result;
+	if(secret == nil)
+		r.err = owner;
+	else {
+		r.owner = owner;
+		r.secret = secret;
+	}
+	c <-= r;
+}
+
+byteseq(a, b: array of byte): int
+{
+	if(len a != len b)
+		return 0;
+	for(i := 0; i < len a; i++)
+		if(a[i] != b[i])
+			return 0;
+	return 1;
+}
+
+testHandshake(t: ref T)
+{
+	# shared signer that certifies both identities
+	signersk := kr->genSK("ed25519", "test-signer", 0);
+	if(signersk == nil)
+		t.fatal("genSK signer failed");
+	signerpk := kr->sktopk(signersk);
+
+	# shared DH group; 2048 is precomputed (RFC 3526), so this is fast
+	(alpha, p) := kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+
+	alice := mkauthinfo(signersk, signerpk, alpha, p, "alice");
+	bob := mkauthinfo(signersk, signerpk, alpha, p, "bob");
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	c := chan of ref Result;
+	spawn authproc(fds[1], bob, c);
+
+	# this proc plays alice; the spawned proc plays bob
+	(cowner, csecret) := kr->auth(fds[0], alice, 0);
+	sr := <-c;
+
+	# both sides must succeed
+	if(csecret == nil)
+		t.fatal("client (alice) auth failed: " + cowner);
+	if(sr.err != nil)
+		t.fatal("server (bob) auth failed: " + sr.err);
+
+	# each side learns the other's authenticated identity
+	t.assertseq(cowner, "bob", "alice authenticates bob");
+	t.assertseq(sr.owner, "alice", "bob authenticates alice");
+
+	# the derived secret is the 64-byte SHA3-512 hybrid output
+	t.asserteq(len csecret, 64, "alice secret is 64 bytes (SHA3-512)");
+	t.asserteq(len sr.secret, 64, "bob secret is 64 bytes (SHA3-512)");
+
+	# and, crucially, both sides derive the IDENTICAL session key
+	t.assert(byteseq(csecret, sr.secret), "both peers derive the same hybrid session secret");
+
+	t.log(sys->sprint("hybrid session secret: %s", hex(csecret)));
+}
+
+hex(a: array of byte): string
+{
+	s := "";
+	for(i := 0; i < len a; i++)
+		s += sys->sprint("%02x", int a[i]);
+	return s;
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+# server end of a real auth + ssl connection: authenticate, then read
+# `expect` bytes off the encrypted channel and hand them back.
+serverside(fd: ref Sys->FD, ai: ref Keyring->Authinfo, expect: int,
+		rc: chan of (array of byte, string))
+{
+	(sfd, serr) := auth->server(nil, ai, fd, 0);
+	if(sfd == nil){
+		rc <-= (nil, "server auth+ssl failed: " + serr);
+		return;
+	}
+	buf := array[expect] of byte;
+	n := readn(sfd, buf, expect);
+	if(n != expect){
+		rc <-= (nil, sys->sprint("short read on encrypted channel: %d != %d", n, expect));
+		return;
+	}
+	rc <-= (buf, nil);
+}
+
+# Full end-to-end: two peers run the real Inferno auth handshake (now hybrid
+# PQ) and then push the ssl device keyed by the derived secret, exactly as
+# styxlisten -A / 9P transport do.  Data written by the client must arrive
+# intact at the server, proving the hybrid-derived key keys a working
+# encrypted channel.
+testEncryptedChannel(t: ref T)
+{
+	if(auth == nil)
+		t.fatal("auth module not loaded");
+	if((e := auth->init()) != nil)
+		t.fatal("auth init failed: " + e);
+
+	signersk := kr->genSK("ed25519", "test-signer", 0);
+	if(signersk == nil)
+		t.fatal("genSK signer failed");
+	signerpk := kr->sktopk(signersk);
+
+	(alpha, p) := kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+
+	alice := mkauthinfo(signersk, signerpk, alpha, p, "alice");
+	bob := mkauthinfo(signersk, signerpk, alpha, p, "bob");
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	msg := array of byte "9P-over-hybrid-PQC: the quick brown fox authenticates the lazy node";
+
+	rc := chan of (array of byte, string);
+	spawn serverside(fds[1], bob, len msg, rc);
+
+	# client authenticates (hybrid PQ) and gets the ssl-wrapped fd
+	(cfd, cerr) := auth->client("aes_256_cbc sha256", alice, fds[0]);
+	if(cfd == nil)
+		t.fatal("client auth+ssl failed: " + cerr);
+
+	# write plaintext; the ssl device encrypts it with the hybrid key
+	if(sys->write(cfd, msg, len msg) != len msg)
+		t.fatal(sys->sprint("encrypted write failed: %r"));
+
+	(got, serr) := <-rc;
+	if(serr != nil)
+		t.fatal(serr);
+
+	t.asserteq(len got, len msg, "bytes received over encrypted channel");
+	t.assert(byteseq(got, msg), "plaintext survives AES-256 round-trip keyed by the hybrid PQ secret");
+	t.log("9P-style payload decrypted intact over hybrid-keyed ssl channel");
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+	if(kr == nil) {
+		sys->fprint(sys->fildes(2), "cannot load keyring module: %r\n");
+		raise "fail:cannot load keyring";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	run("HybridAuthHandshake", testHandshake);
+	run("HybridEncryptedChannel", testEncryptedChannel);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}


### PR DESCRIPTION
## Summary

Makes the **native Inferno authentication handshake quantum-safe**, so two InferNodes talking over their native 9P/Styx transport negotiate a hybrid post-quantum session key by default.

Prior PQ work only hybridized the **TLS 1.3 client** (`appl/lib/crypt/tls.b`), which nodes don't use to talk to each other. Node-to-node traffic goes through `Keyring->auth` (the Station-to-Station handshake in `libinterp/keyring.c`) → the `ssl` line-encryption device, and that handshake derived its key from **classical Diffie-Hellman only**. So node-to-node 9P was *not* quantum-safe even with PQ certificates. This closes that gap.

## What changed

The STS handshake is now **protocol version 2** and performs a hybrid key agreement. Because the protocol is symmetric (both peers run identical code), it uses a **mutual ML-KEM-768 exchange**:

1. Each peer generates an ephemeral ML-KEM-768 keypair and sends its public key (`ek`) alongside `alpha**r0`, cert and pubkey.
2. Each encapsulates to the peer's `ek` (sending a ciphertext) and decapsulates the one it receives.
3. Both `ek`s are **bound into the signed STS transcript** — an active attacker can't substitute ML-KEM keys without breaking the signature. The transcript signature hash is also upgraded **SHA-1 → SHA-256**.
4. Session secret = `SHA3-512("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)`, with the two KEM secrets/`ek`s ordered canonically so both peers derive the identical **64-byte** secret. It feeds the `ssl` device unchanged (64 bytes = full key + IV for any cipher).

Result: the channel stays secret unless **both** Diffie-Hellman and ML-KEM are broken — directly addressing harvest-now-decrypt-later on the native transport. ML-KEM is reused as-is from `libsec` (no new crypto); ML-KEM secret key and shared secrets are scrubbed from the stack on exit.

## ⚠️ Clean break (breaking change)

A v2 node **refuses** a v1 (classical-only) peer with `incompatible authentication protocol (need hybrid PQ v2)` — no silent downgrade. **The entire fleet must be upgraded together.** DH params still come from the signer's authinfo, so existing key/cert setup is unchanged; only the `emu` binary changes.

## Tests

New `tests/pqauth_test.b` (auto-discovered by the runner, so it runs in CI):

- **HybridAuthHandshake** — mutual auth + identical 64-byte hybrid secret (ed25519 signer).
- **HybridHandshakeMLDSA** — same with an ML-DSA-65 signer: a **fully post-quantum** handshake.
- **HybridEncryptedChannel / HybridTcpChannel** — real `Auth->client`/`Auth->server` + `ssl` round-trip of a 9P-style payload, over a pipe and over a real TCP socket (TCP case skips where no IP stack).
- **DowngradeRejected** — v1 peer refused.
- **TamperedEkRejected** — flipping a byte in an ML-KEM key fails the handshake (`bad certificate`), empirically proving the transcript binding stops a KEM-substitution MITM.
- **MalformedEkRejected** — wrong-length ML-KEM key rejected.

All pass on AMD64 Linux. No regressions in `crypto_test` / `ssl_transport_test`. (`keyring_test`/`factotum_test` have pre-existing, unrelated failures — confirmed identical on a baseline build.)

## Docs

- `docs/CRYPTO-MODERNIZATION.md` §10 — full description + test list.
- `docs/QUANTUM-SAFE-CRYPTO-PLAN.md` — status table updated (Phase 8, native transport).

## Acceptance testing (tracked in Jira)

Pre-merge validation that in-process unit tests can't cover is tracked under **INFR-225** (epic), with child tasks INFR-226…INFR-235. The headline gate is **INFR-226** — heterogeneous 3-way interop across **macOS ARM64 / Linux AMD64 / Linux ARM64** — plus a security-review sign-off (INFR-234). Refs: INFR-225.

## Files

- `libinterp/keyring.c` — `Keyring_auth` hybrid handshake.
- `tests/pqauth_test.b`, `tests/mkfile` — new test suite.
- `docs/CRYPTO-MODERNIZATION.md`, `docs/QUANTUM-SAFE-CRYPTO-PLAN.md`.

https://claude.ai/code/session_01MmP3biWaMQopfjfqdUwTr3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmP3biWaMQopfjfqdUwTr3)_