### PR TITLE
fix(crypto): read/write full PQ-signer keyfiles (Maxbuf, not Maxmsg)

### DIFF
--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -2171,17 +2171,17 @@ Keyring_writeauthinfo(void *fp)
 		goto out;
 
 	/* signer's public key */
-	n = pktostr(spk, buf, Maxmsg);
+	n = pktostr(spk, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* certificate for my public key */
-	n = certtostr(c, buf, Maxmsg);
+	n = certtostr(c, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* my secret/public key */
-	n = sktostr(mysk, buf, Maxmsg);
+	n = sktostr(mysk, buf, Maxbuf);
 	if(sendmsg(fd, buf, n) <= 0)
 		goto out;
 
@@ -2243,7 +2243,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* signer's public key */
-	n = getmsg(fd, buf, Maxmsg);
+	n = getmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 
@@ -2252,7 +2252,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* certificate for my public key */
-	n = getmsg(fd, buf, Maxmsg);
+	n = getmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	ai->cert = (Keyring_Certificate*)strtocert(buf);
@@ -2260,7 +2260,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* my secret/public key */
-	n = getmsg(fd, buf, Maxmsg);
+	n = getmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	mysk = strtosk(buf);
@@ -2273,14 +2273,14 @@ Keyring_readauthinfo(void *fp)
 	ai->mypk = (Keyring_PK*)mypk;
 
 	/* diffie hellman base */
-	n = getmsg(fd, buf, Maxmsg);
+	n = getmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	b = strtomp(buf, nil, 64, nil);
 	ai->alpha = newIPint(b);
 
 	/* diffie hellman modulus */
-	n = getmsg(fd, buf, Maxmsg);
+	n = getmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	b = strtomp(buf, nil, 64, nil);


### PR DESCRIPTION
## Problem
`readauthinfo`/`writeauthinfo` in `libinterp/keyring.c` capped each Authinfo field at `Maxmsg=4096`, even though their buffers are `malloc(Maxbuf)` (`Maxbuf=49152`) and the `getmsg`/`sendmsg` framing supports up to 99999 bytes/field. The hybrid PQ (v2) change raised `Maxbuf` and the `malloc`s but left **8 field-size args** at `Maxmsg`.

Result: `auth/createsignerkey -a {mldsa65,mldsa87,slhdsa192s,slhdsa256s}` wrote **truncated** PQ-signer keyfiles, and `readauthinfo` then rejected them with `input or format error` — so a node could not be provisioned with a post-quantum *signer* certificate via the standard keyfile flow. (The handshake logic itself was fine; `pqauth_test`'s in-process ML-DSA case never serialized to disk.)

Found during INFR-225 cross-host acceptance testing (INFR-229).

## Fix
Change the 8 args to `Maxbuf`:
- `writeauthinfo`: `pktostr` / `certtostr` / `sktostr`
- `readauthinfo`: the 5 `getmsg` calls (spk, cert, sk, dh-base, dh-modulus)

Other `Maxmsg` uses (functions with `malloc(Maxmsg)` buffers) are intentionally untouched.

## Verification
Rebuilt emu on macOS ARM64 + Linux AMD64. Regenerated keyfiles are now complete (slhdsa256s 40512 B vs the old truncated 4852 B). Live hybrid handshake passes for every provisionable signer:

| signer | result |
|---|---|
| ed25519, rsa | ✅ |
| mldsa65, mldsa87 | ✅ |
| slhdsa192s, slhdsa256s | ✅ |
| slhdsa256s **cross-arch** | ✅ macOS-ARM64 ↔ Linux-AMD64, ~29 KB transcript signature, keyfile fetched md5-exact over the channel |

`dsa` remains unsupported by `createsignerkey` (not in its alg list) — separate pre-existing gap.

Refs: INFR-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)