### PR TITLE
fix(crypto): scrub residual session-secret material in Keyring_auth

### DIFF
--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -1825,12 +1825,10 @@ Keyring_auth(void *fp)
 	alphar0r1 = mpnew(0);
 
 	/* generate alpha**r0 */
-if(0)print("X");
 	release();
 	mprand(mpsignif(p), genrandom, r0);
 	mpexp(alpha, r0, p, alphar0);
 	acquire();
-if(0)print("Y");
 
 	/* generate ephemeral ML-KEM-768 keypair for hybrid PQ key agreement */
 	release();
@@ -2020,6 +2018,7 @@ if(0)print("Y");
 
 	cmp = memcmp(myek, hisek, MLKEM768_PKLEN);
 	if(cmp == 0){
+		memset(cvb, 0, n);
 		free(cvb);
 		err = "ml-kem public key collision";
 		goto out;
@@ -2046,6 +2045,7 @@ if(0)print("Y");
 		f->ret->t1 = mem2array(dig, SHA3_512dlen);
 		memset(dig, 0, sizeof(dig));
 	}
+	memset(cvb, 0, n);
 	free(cvb);
 
 out:
@@ -2110,8 +2110,14 @@ out:
 	memset(mydk, 0, sizeof(mydk));
 	memset(ss_local, 0, sizeof(ss_local));
 	memset(ss_remote, 0, sizeof(ss_remote));
+	/* scrub the combiner buffer: it held the DH secret and both ML-KEM shared secrets */
+	memset(buf, 0, Maxbuf);
 	free(buf);
 	if(r0 != nil){
+		/* scrub the ephemeral DH private exponents and the DH shared secret */
+		memset(r0->p, 0, r0->size*sizeof(*r0->p));
+		memset(r1->p, 0, r1->size*sizeof(*r1->p));
+		memset(alphar0r1->p, 0, alphar0r1->size*sizeof(*alphar0r1->p));
 		mpfree(r0);
 		mpfree(r1);
 		mpfree(alphar0);


### PR DESCRIPTION
## Problem
The hybrid PQ handshake (`libinterp/keyring.c` `Keyring_auth`) explicitly scrubs `mydk`, `ss_local`, `ss_remote`, and the SHA3 `dig` — but leaves copies/sources of the same session-secret material un-scrubbed:

- **`buf`** — the combiner assembles `dh || kss_lo || kss_hi || ek_lo || ek_hi` into `buf`, then `free(buf)` without `memset` → DH secret + **both ML-KEM shared secrets** left in freed heap.
- **`cvb`** — `mptobe` DH-secret bytes, freed without scrubbing (both free sites).
- **`r0` / `r1`** — ephemeral DH private exponents — and **`alphar0r1`** (the DH **shared secret**) — `mpfree`'d without zeroing the limbs.

**Severity: medium** — defense-in-depth; local heap disclosure / uninitialized-reuse. Found by the INFR-234 security review.

## Fix
- `memset(buf, 0, Maxbuf)` before `free(buf)`.
- `memset(cvb, 0, n)` at both `free(cvb)` sites.
- Zero the limbs of `r0`, `r1`, and `alphar0r1` before `mpfree`.
- Remove two dead `if(0)print("X")` / `if(0)print("Y")` debug lines (also noted in the review).

All scrubs run **after** the session secret (`f->ret->t1`) is derived, so behaviour is unchanged.

## Verification
Rebuilt emu (macOS ARM64); `pqauth_test` **7/7 PASS** — both ends still derive identical 64-byte secrets (happy path, ML-DSA signer, ssl round-trip over pipe + TCP, downgrade/tamper/malformed rejection all green).

Refs: INFR-237, INFR-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)