### PR TITLE
Node interop suite + IPv4 fallback for IPv6-less hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,7 @@ android-app/app/src/main/jniLibs/x86_64/libemu.so
 android-app/app/src/main/jniLibs/x86_64/libSDL3.so
 build-android-apk.ndk-arm64-v8a.log
 build-android-apk.ndk-x86_64.log
+
+# node interop harness artifacts (generated; never commit keys)
+usr/inferno/keyring/interop-*
+tmp/interop_pulled_*

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -1,0 +1,103 @@
+# Node-to-node interoperability testing (cert auth + post-quantum transport)
+
+This document covers how InferNode and NERVA3 nodes authenticate and talk to
+each other over the native Inferno transport, the test assets that exercise it,
+and a transport-layer bug found and fixed while building them.
+
+## What "talking to each other" means here
+
+Two nodes establish a session over the native Inferno authentication protocol
+(`Keyring->auth`, the Station-to-Station handshake in `libinterp/keyring.c`)
+plus the `ssl` line-encryption device:
+
+1. **Cert auth.** Each node presents an X.509-style certificate signed by a
+   common signer (`auth/createsignerkey` → `auth/mkauthinfo`). Certs may be
+   classical (ed25519) or post-quantum (ML-DSA-65 / -87, SLH-DSA).
+2. **Hybrid PQ key agreement.** Protocol v2 combines classical Diffie-Hellman
+   with a mutual **ML-KEM-768** encapsulation; the session secret is
+   `SHA3-512("infernode-pq-sts-v2" || dh || kem_lo || kem_hi || ek_lo || ek_hi)`.
+   This closes the harvest-now-decrypt-later gap on node-to-node traffic.
+   See [CRYPTO-MODERNIZATION.md §10](CRYPTO-MODERNIZATION.md).
+3. **Line encryption.** The 64-byte secret feeds the `ssl` device; the default
+   negotiated by `mount -k` / `styxlisten` is `aes_256_cbc` + `sha256`.
+4. **9P/Styx.** Everything above carries Styx (9P) — `sys->export` on the
+   serving node, `sys->mount` on the connecting node.
+
+The same path backs `mount -k <keyfile> tcp!host!5640 /mnt/llm` against the
+headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
+
+## Test assets
+
+| Asset | Kind | What it proves |
+|-------|------|----------------|
+| `tests/pqauth_test.b` | in-emu unit (auto-discovered by the runner) | the hybrid handshake itself: happy path (ed25519 + ML-DSA-65 signers), real-TCP encrypted channel, and the negatives (downgrade, tampered/malformed ML-KEM key) |
+| `tests/interop_test.b` | in-emu unit (auto-discovered) | end-to-end: real TCP + cert auth + PQ handshake + `aes_256_cbc` ssl + a real `export`/`mount` **file transfer**, for both ed25519 and ML-DSA-65 certs |
+| `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
+
+### Running the in-emu tests
+
+```sh
+# build once
+export ROOT=$PWD; export PATH=$PWD/Linux/amd64/bin:$PATH    # Linux amd64
+cd tests && mk install && cd ..
+
+./emu/Linux/o.emu -c1 -r$PWD /dis/tests/pqauth_test.dis  -v
+./emu/Linux/o.emu -c1 -r$PWD /dis/tests/interop_test.dis -v
+```
+
+Both **skip cleanly** (rather than fail) on a host with no IP stack at all.
+
+### Running the cross-binary harness
+
+```sh
+# InferNode serves, NERVA3 connects, fully post-quantum certs:
+tests/interop/run-interop.sh /path/to/infernode /path/to/nerva3 mldsa65
+
+# Same binary on both ends (smoke test), classical certs:
+tests/interop/run-interop.sh
+```
+
+It generates a signer keyfile in the server tree, shares it with the client
+tree (the crypto core is identical across the two forks, so keyfiles are
+portable), starts `interop_node_server` under the server emu and
+`interop_node_client` under the client emu, and `cmp`s the pulled file against
+the source. Expected output ends with:
+
+```
+PASS: 722 bytes transferred and verified byte-for-byte over cert-auth + PQC + ssl
+```
+
+## Transport bug fixed: IPv4 fallback for IPv6-less hosts
+
+**Symptom.** On any host whose kernel has IPv6 compiled out or disabled
+(common in containers, CI runners, and hardened deployments), *all* emu
+networking failed with `Address family not supported by protocol` —
+`/net/tcp/clone`, `announce`, `dial`, every mount. Node-to-node auth could not
+even open a socket, so cert auth + PQC over the wire was untestable and, more
+importantly, unusable on those hosts.
+
+**Cause.** The Linux/Posix IP device (`emu/port/ipif6-posix.c`, selected by
+`emu/Linux/emu`) created every socket with `socket(AF_INET6, …)` and used
+v4-mapped addresses, with **no fallback** when `AF_INET6` is unavailable.
+
+**Fix.** `so_socket()` now detects an unavailable `AF_INET6` once
+(`EAFNOSUPPORT`/`EPROTONOSUPPORT`) and transparently falls back to `AF_INET`
+for the life of the process; the address-marshalling helpers
+(`so_connect`/`so_bind`/`so_accept`/`so_getsockname`/`so_send`/`so_recv`)
+build `sockaddr_in` for v4-mapped/unspecified addresses in that mode. On a
+normal dual-stack host nothing changes — the `AF_INET6` path is byte-for-byte
+the original. After the fix, `pqauth_test`'s `HybridTcpChannel` runs for real
+(previously skipped) and the interop harness passes on this host.
+
+## Known issue (not a transport/crypto-correctness bug)
+
+`keyring_test`'s `AES256` and `DESCBC` cases fail in the long test run because
+of a **Dis-runtime, allocation-layout-dependent heap corruption** that is
+exposed when an AES cipher builtin is followed by a DES cipher builtin (a
+minimal repro: `kr->aescbc(...)` then `kr->descbc(...)` roundtrip). The
+underlying libsec ciphers are correct in pure C (AES-128/192/256 and DES-CBC
+all round-trip), and the `ssl` line-encryption device calls libsec directly in
+C — **not** through these Dis builtins — so node-to-node encrypted comms are
+unaffected (consistent with `pqauth_test`'s encrypted-channel cases passing).
+The corruption is pre-existing and lives in the emu interpreter/heap layer;
+it needs a separate, dedicated investigation. Tracked for follow-up.

--- a/emu/port/ipif6-posix.c
+++ b/emu/port/ipif6-posix.c
@@ -25,6 +25,76 @@
 #include        "ip.h"
 #include        "error.h"
 
+/*
+ * Some kernels are built without IPv6 (CONFIG_IPV6=n), and some containers /
+ * CI sandboxes disable it entirely; on those, socket(AF_INET6, ...) fails with
+ * EAFNOSUPPORT and this device — which is otherwise dual-stack via v4-mapped
+ * addresses — would have no working transport at all (no 9P/Styx, no mounts,
+ * no node-to-node auth).  Detect that once and transparently fall back to a
+ * classic AF_INET socket, translating the v4-mapped plan9 addresses to/from
+ * sockaddr_in.  On a normal IPv6-capable host noipv6 stays 0 and every path
+ * below is byte-for-byte the original AF_INET6 code.
+ */
+static int noipv6 = 0;
+
+/*
+ * Build a host sockaddr from a 16-byte plan9 IP address (v6 form, possibly
+ * v4-mapped) plus a host-order port.  Returns the sockaddr length.  When
+ * running IPv4-only, a genuine (non-mapped, non-unspecified) IPv6 address
+ * cannot be represented and raises an error.
+ */
+static int
+sockaddrfromip(struct sockaddr_storage *sa, uchar *ip, ushort port)
+{
+	struct sockaddr_in *sin;
+	struct sockaddr_in6 *sin6;
+
+	memset(sa, 0, sizeof(*sa));
+	if(noipv6){
+		sin = (struct sockaddr_in*)sa;
+		sin->sin_family = AF_INET;
+		hnputs((uchar*)&sin->sin_port, port);
+		if(isv4(ip))
+			memmove(&sin->sin_addr, ip+IPv4off, IPv4addrlen);
+		else if(ipcmp(ip, v6Unspecified) == 0)
+			sin->sin_addr.s_addr = INADDR_ANY;
+		else
+			error("IPv6 address on an IPv4-only host");
+		return sizeof(*sin);
+	}
+	sin6 = (struct sockaddr_in6*)sa;
+	sin6->sin6_family = AF_INET6;
+	hnputs((uchar*)&sin6->sin6_port, port);
+	memmove(&sin6->sin6_addr, ip, IPaddrlen);
+	return sizeof(*sin6);
+}
+
+/*
+ * Inverse of sockaddrfromip: decode a host sockaddr (either family) into a
+ * 16-byte plan9 IP address (v4-mapped for AF_INET) and a host-order port.
+ */
+static void
+ipfromsockaddr(struct sockaddr_storage *sa, uchar *ip, ushort *port)
+{
+	struct sockaddr_in *sin;
+	struct sockaddr_in6 *sin6;
+
+	switch(sa->ss_family){
+	case AF_INET:
+		sin = (struct sockaddr_in*)sa;
+		v4tov6(ip, (uchar*)&sin->sin_addr);
+		*port = nhgets((uchar*)&sin->sin_port);
+		break;
+	case AF_INET6:
+		sin6 = (struct sockaddr_in6*)sa;
+		memmove(ip, &sin6->sin6_addr, IPaddrlen);
+		*port = nhgets((uchar*)&sin6->sin6_port);
+		break;
+	default:
+		error("unexpected socket address family");
+	}
+}
+
 int
 so_socket(int type)
 {
@@ -42,14 +112,23 @@ so_socket(int type)
 		break;
 	}
 
-	fd = socket(AF_INET6, type, 0);
+	fd = -1;
+	if(!noipv6){
+		fd = socket(AF_INET6, type, 0);
+		if(fd < 0 && (errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT))
+			noipv6 = 1;	/* IPv4-only for the rest of this process */
+	}
+	if(fd < 0 && noipv6)
+		fd = socket(AF_INET, type, 0);
 	if(fd < 0)
 		oserror();
 
-	/* OpenBSD has v6only fixed to 1, so the following will fail */
-	v6only = 0;
-	if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&v6only, sizeof v6only) < 0)
-		oserror();
+	if(!noipv6){
+		/* OpenBSD has v6only fixed to 1, so the following will fail */
+		v6only = 0;
+		if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&v6only, sizeof v6only) < 0)
+			oserror();
+	}
 
 	if(type == SOCK_DGRAM){
 		one = 1;
@@ -72,6 +151,31 @@ so_send(int sock, void *va, int len, void *hdr, int hdrlen)
 	osenter();
 	if(hdr == 0)
 		r = write(sock, va, len);
+	else if(noipv6){
+		/* IPv4-only host: decode the header into a v4-mapped addr+port,
+		 * then let sockaddrfromip() emit a sockaddr_in. */
+		uchar rip[IPaddrlen];
+		ushort rport;
+		int sl;
+
+		memset(rip, 0, sizeof(rip));
+		switch(hdrlen){
+		case OUdphdrlenv4:
+			v4tov6(rip, (uchar*)h);
+			rport = nhgets((uchar*)h+2*IPv4addrlen);
+			break;
+		case OUdphdrlen:
+			memmove(rip, h, IPaddrlen);
+			rport = nhgets((uchar*)h+2*IPaddrlen);
+			break;
+		default:
+			memmove(rip, h, IPaddrlen);
+			rport = nhgets((uchar*)h+3*IPaddrlen);
+			break;
+		}
+		sl = sockaddrfromip(&sa, rip, rport);
+		r = sendto(sock, va, len, 0, (struct sockaddr*)&sa, sl);
+	}
 	else {
 		memset(&sa, 0, sizeof(sa));
 		sin6 = (struct sockaddr_in6*)&sa;
@@ -107,6 +211,46 @@ so_recv(int sock, void *va, int len, void *hdr, int hdrlen)
 	osenter();
 	if(hdr == 0)
 		r = read(sock, va, len);
+	else if(noipv6){
+		/* IPv4-only host: read into a sockaddr_in and rebuild the header
+		 * in the same layout the AF_INET6 path produces (v4-mapped). */
+		struct sockaddr_in rsin, lsin;
+		uchar rip[IPaddrlen], lip[IPaddrlen];
+
+		memset(&rsin, 0, sizeof(rsin));
+		l = sizeof(rsin);
+		r = recvfrom(sock, va, len, 0, (struct sockaddr*)&rsin, &l);
+		if(r >= 0){
+			memset(h, 0, sizeof(h));
+			v4tov6(rip, (uchar*)&rsin.sin_addr);
+			memset(&lsin, 0, sizeof(lsin));
+			l = sizeof(lsin);
+			getsockname(sock, (struct sockaddr*)&lsin, &l);
+			v4tov6(lip, (uchar*)&lsin.sin_addr);
+			switch(hdrlen){
+			case OUdphdrlenv4:
+				memmove(h, (uchar*)&rsin.sin_addr, IPv4addrlen);
+				memmove(h+2*IPv4addrlen, &rsin.sin_port, 2);
+				memmove(h+IPv4addrlen, (uchar*)&lsin.sin_addr, IPv4addrlen);
+				memmove(h+2*IPv4addrlen+2, &lsin.sin_port, 2);
+				break;
+			case OUdphdrlen:
+				memmove(h, rip, IPaddrlen);
+				memmove(h+2*IPaddrlen, &rsin.sin_port, 2);
+				memmove(h+IPaddrlen, lip, IPaddrlen);
+				memmove(h+2*IPaddrlen+2, &lsin.sin_port, 2);
+				break;
+			default:
+				memmove(h, rip, IPaddrlen);
+				memmove(h+3*IPaddrlen, &rsin.sin_port, 2);
+				memmove(h+IPaddrlen, lip, IPaddrlen);
+				memmove(h+2*IPaddrlen, lip, IPaddrlen);	/* ifcaddr */
+				memmove(h+3*IPaddrlen+2, &lsin.sin_port, 2);
+				break;
+			}
+			memmove(hdr, h, hdrlen);
+		}
+	}
 	else {
 		sin6 = (struct sockaddr_in6*)&sa;
 		l = sizeof(sa);
@@ -174,18 +318,13 @@ so_close(int sock)
 void
 so_connect(int fd, uchar *raddr, ushort rport)
 {
-	int r;
+	int r, len;
 	struct sockaddr_storage sa;
-	struct sockaddr_in6 *sin6;
 
-	memset(&sa, 0, sizeof(sa));
-	sin6 = (struct sockaddr_in6*)&sa;
-	sin6->sin6_family = AF_INET6;
-	hnputs(&sin6->sin6_port, rport);
-	memmove((uchar*)&sin6->sin6_addr, raddr, IPaddrlen);
+	len = sockaddrfromip(&sa, raddr, rport);
 
 	osenter();
-	r = connect(fd, (struct sockaddr*)sin6, sizeof(*sin6));
+	r = connect(fd, (struct sockaddr*)&sa, len);
 	osleave();
 	if(r < 0)
 		oserror();
@@ -196,18 +335,12 @@ so_getsockname(int fd, uchar *laddr, ushort *lport)
 {
 	int len;
 	struct sockaddr_storage sa;
-	struct sockaddr_in6 *sin6;
 
-	len = sizeof(*sin6);
+	len = sizeof(sa);
 	if(getsockname(fd, (struct sockaddr*)&sa, &len) < 0)
 		oserror();
 
-	sin6 = (struct sockaddr_in6*)&sa;
-	if(sin6->sin6_family != AF_INET6 || len != sizeof(*sin6))
-		error("not AF_INET6");
-
-	memmove(laddr, &sin6->sin6_addr, IPaddrlen);
-	*lport = nhgets(&sin6->sin6_port);
+	ipfromsockaddr(&sa, laddr, lport);
 }
 
 void
@@ -227,11 +360,8 @@ so_accept(int fd, uchar *raddr, ushort *rport)
 {
 	int nfd, len;
 	struct sockaddr_storage sa;
-	struct sockaddr_in6 *sin6;
 
-	sin6 = (struct sockaddr_in6*)&sa;
-
-	len = sizeof(*sin6);
+	len = sizeof(sa);
 	osenter();
 	do {
 		nfd = accept(fd, (struct sockaddr*)&sa, &len);
@@ -240,22 +370,15 @@ so_accept(int fd, uchar *raddr, ushort *rport)
 	if(nfd < 0)
 		oserror();
 
-	if(sin6->sin6_family != AF_INET6 || len != sizeof(*sin6))
-		error("not AF_INET6");
-
-	memmove(raddr, &sin6->sin6_addr, IPaddrlen);
-	*rport = nhgets(&sin6->sin6_port);
+	ipfromsockaddr(&sa, raddr, rport);
 	return nfd;
 }
 
 void
 so_bind(int fd, int su, uchar *addr, ushort port)
 {
-	int i, one;
+	int i, one, len;
 	struct sockaddr_storage sa;
-	struct sockaddr_in6 *sin6;
-
-	sin6 = (struct sockaddr_in6*)&sa;
 
 	one = 1;
 	if(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&one, sizeof(one)) < 0) {
@@ -265,23 +388,15 @@ so_bind(int fd, int su, uchar *addr, ushort port)
 
 	if(su) {
 		for(i = 600; i < 1024; i++) {
-			memset(&sa, 0, sizeof(sa));
-			sin6->sin6_family = AF_INET6;
-			memmove(&sin6->sin6_addr, addr, IPaddrlen);
-			hnputs(&sin6->sin6_port, i);
-
-			if(bind(fd, (struct sockaddr*)sin6, sizeof(*sin6)) >= 0)	
+			len = sockaddrfromip(&sa, addr, i);
+			if(bind(fd, (struct sockaddr*)&sa, len) >= 0)
 				return;
 		}
 		oserror();
 	}
 
-	memset(&sa, 0, sizeof(sa));
-	sin6->sin6_family = AF_INET6;
-	memmove(&sin6->sin6_addr, addr, IPaddrlen);
-	hnputs(&sin6->sin6_port, port);
-
-	if(bind(fd, (struct sockaddr*)sin6, sizeof(*sin6)) < 0)
+	len = sockaddrfromip(&sa, addr, port);
+	if(bind(fd, (struct sockaddr*)&sa, len) < 0)
 		oserror();
 }
 

--- a/tests/interop/node_client.b
+++ b/tests/interop/node_client.b
@@ -1,0 +1,62 @@
+implement NodeClient;
+
+# Minimal connecting node for cross-binary interop testing.
+#   node_client keyfile addr mountpt file outpath
+# Reads its Authinfo, dials `addr`, authenticates with the hybrid PQ handshake,
+# wraps the line in aes_256_cbc/sha256 ssl, mounts the remote export at
+# `mountpt`, reads `mountpt+file` over the encrypted 9P channel and writes the
+# bytes to `outpath` (so a harness can compare against the source). Prints
+# OK/ERR summary to stderr.  (A dedicated output file avoids relying on how emu
+# wires fd 1/2 when a .dis is run directly.)
+
+include "sys.m"; sys: Sys;
+include "draw.m";
+include "keyring.m"; kr: Keyring;
+include "security.m"; auth: Auth;
+
+NodeClient: module { init: fn(nil: ref Draw->Context, args: list of string); };
+
+fail(s: string) { sys->fprint(sys->fildes(2), "node_client: %s\n", s); raise "fail:error"; }
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	if(auth == nil) fail(sys->sprint("load Auth: %r"));
+	if((e := auth->init()) != nil) fail("auth init: " + e);
+
+	args = tl args;
+	if(len args != 5) fail("usage: node_client keyfile addr mountpt file outpath");
+	keyfile := hd args; addr := hd tl args; mountpt := hd tl tl args;
+	file := hd tl tl tl args; outpath := hd tl tl tl tl args;
+
+	ai := kr->readauthinfo(keyfile);
+	if(ai == nil) fail(sys->sprint("readauthinfo %s: %r", keyfile));
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0) fail(sys->sprint("dial %s: %r", addr));
+
+	(wrapped, cerr) := auth->client("aes_256_cbc sha256", ai, dc.dfd);
+	if(wrapped == nil) fail("client auth+ssl: " + cerr);
+	sys->fprint(sys->fildes(2), "node_client: authenticated to %s\n", addr);
+
+	sys->unmount(nil, mountpt);
+	if(sys->mount(wrapped, nil, mountpt, Sys->MREPL, "") < 0) fail(sys->sprint("mount %s: %r", mountpt));
+
+	fd := sys->open(mountpt + file, Sys->OREAD);
+	if(fd == nil) fail(sys->sprint("open %s%s: %r", mountpt, file));
+	out := sys->create(outpath, Sys->OWRITE, 8r644);
+	if(out == nil) fail(sys->sprint("create %s: %r", outpath));
+	tot := 0;
+	buf := array[8192] of byte;
+	for(;;){
+		n := sys->read(fd, buf, len buf);
+		if(n < 0) fail(sys->sprint("read: %r"));
+		if(n == 0) break;
+		if(sys->write(out, buf, n) != n) fail(sys->sprint("write %s: %r", outpath));
+		tot += n;
+	}
+	sys->fprint(sys->fildes(2), "node_client: OK read %d bytes of %s over cert-auth + PQC + ssl\n", tot, file);
+	sys->unmount(nil, mountpt);
+}

--- a/tests/interop/node_server.b
+++ b/tests/interop/node_server.b
@@ -1,0 +1,54 @@
+implement NodeServer;
+
+# Minimal serving node for cross-binary interop testing.
+#   node_server keyfile addr exporttree
+# Reads its Authinfo (a signer keyfile from auth/createsignerkey), announces
+# `addr`, and on each connection authenticates the peer with the native hybrid
+# post-quantum handshake, wraps the line in aes_256_cbc/sha256 ssl, and exports
+# `exporttree` as a 9P service over the encrypted channel.
+
+include "sys.m"; sys: Sys;
+include "draw.m";
+include "keyring.m"; kr: Keyring;
+include "security.m"; auth: Auth;
+
+NodeServer: module { init: fn(nil: ref Draw->Context, args: list of string); };
+
+fail(s: string) { sys->fprint(sys->fildes(2), "node_server: %s\n", s); raise "fail:error"; }
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	if(auth == nil) fail(sys->sprint("load Auth: %r"));
+	if((e := auth->init()) != nil) fail("auth init: " + e);
+
+	args = tl args;
+	if(len args != 3) fail("usage: node_server keyfile addr exporttree");
+	keyfile := hd args; addr := hd tl args; tree := hd tl tl args;
+
+	ai := kr->readauthinfo(keyfile);
+	if(ai == nil) fail(sys->sprint("readauthinfo %s: %r", keyfile));
+
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0) fail(sys->sprint("announce %s: %r", addr));
+	sys->fprint(sys->fildes(2), "node_server: listening on %s, exporting %s\n", addr, tree);
+
+	for(;;){
+		(lok, nc) := sys->listen(ac);
+		if(lok < 0) fail(sys->sprint("listen: %r"));
+		dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+		if(dfd == nil) { sys->fprint(sys->fildes(2), "node_server: open data: %r\n"); continue; }
+		spawn serve(ai, tree, dfd);
+	}
+}
+
+serve(ai: ref Keyring->Authinfo, tree: string, dfd: ref Sys->FD)
+{
+	algs := "aes_256_cbc" :: "sha256" :: nil;
+	(wrapped, who) := auth->server(algs, ai, dfd, 0);
+	if(wrapped == nil) { sys->fprint(sys->fildes(2), "node_server: auth failed: %s\n", who); return; }
+	sys->fprint(sys->fildes(2), "node_server: peer authenticated (%s); serving %s\n", who, tree);
+	sys->export(wrapped, tree, Sys->EXPWAIT);
+}

--- a/tests/interop/run-interop.sh
+++ b/tests/interop/run-interop.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Cross-binary node interoperability harness.
+#
+# Launches two *separate* emu processes — a serving node and a connecting
+# node, optionally from two different InferNode/NERVA3 trees — and drives a
+# real file transfer between them over the native transport: cert auth + the
+# hybrid post-quantum (ML-KEM-768) STS handshake + aes_256_cbc/sha256 ssl line
+# encryption + 9P export/mount.  Proves two independently-built nodes speak the
+# same authenticated, post-quantum-encrypted wire protocol.
+#
+# Usage:
+#   run-interop.sh [server_root] [client_root] [alg]
+#
+#   server_root  tree whose emu serves   (default: this repo)
+#   client_root  tree whose emu connects  (default: same as server_root)
+#   alg          signer cert algorithm: ed25519 | mldsa65 (default: ed25519)
+#
+# Example (InferNode serves, NERVA3 connects, fully post-quantum certs):
+#   tests/interop/run-interop.sh /path/to/infernode /path/to/nerva3 mldsa65
+#
+set -u
+
+SERVER_ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+CLIENT_ROOT="${2:-$SERVER_ROOT}"
+ALG="${3:-ed25519}"
+PORT="${INTEROP_PORT:-19877}"
+ADDR="tcp!127.0.0.1!${PORT}"
+
+emu_bin() {
+	if   [ -x "$1/emu/Linux/o.emu" ];  then echo "$1/emu/Linux/o.emu"
+	elif [ -x "$1/emu/MacOSX/o.emu" ]; then echo "$1/emu/MacOSX/o.emu"
+	else echo ""; fi
+}
+SERVER_EMU="$(emu_bin "$SERVER_ROOT")"
+CLIENT_EMU="$(emu_bin "$CLIENT_ROOT")"
+[ -n "$SERVER_EMU" ] || { echo "interop: no emu binary under $SERVER_ROOT" >&2; exit 2; }
+[ -n "$CLIENT_EMU" ] || { echo "interop: no emu binary under $CLIENT_ROOT" >&2; exit 2; }
+
+KEY_INF="/usr/inferno/keyring/interop-${ALG}"
+KEY_HOST_SERVER="${SERVER_ROOT}${KEY_INF}"
+EXPORT_TREE="/lib"
+XFER="/ndb/inferno"
+SRC_FILE="${SERVER_ROOT}${EXPORT_TREE}${XFER}"
+
+LIMBO=""
+for c in "$SERVER_ROOT/Linux/amd64/bin/limbo" "$SERVER_ROOT/Linux/arm64/bin/limbo" \
+         "$SERVER_ROOT/MacOSX/arm64/bin/limbo"; do
+	[ -x "$c" ] && { LIMBO="$c"; break; }
+done
+
+echo "=== interop: $ALG cert, $SERVER_EMU (server) <-> $CLIENT_EMU (client) ==="
+
+# Build the node programs into both trees (idempotent; needs native limbo).
+if [ -n "$LIMBO" ]; then
+	for R in "$SERVER_ROOT" "$CLIENT_ROOT"; do
+		"$LIMBO" -I "$R/module" -o "$R/dis/interop_node_server.dis" \
+			"$(dirname "$0")/node_server.b" 2>/dev/null
+		"$LIMBO" -I "$R/module" -o "$R/dis/interop_node_client.dis" \
+			"$(dirname "$0")/node_client.b" 2>/dev/null
+	done
+fi
+[ -f "$SERVER_ROOT/dis/interop_node_server.dis" ] || { echo "interop: server dis missing (build with native limbo)" >&2; exit 2; }
+[ -f "$CLIENT_ROOT/dis/interop_node_client.dis" ] || { echo "interop: client dis missing (build with native limbo)" >&2; exit 2; }
+
+# Generate the signer keyfile once in the server tree, then share it with the
+# client tree (keyring.c is identical across InferNode/NERVA3, so a keyfile is
+# portable).  Both nodes present the same signer identity -> mutual trust.
+mkdir -p "$(dirname "$KEY_HOST_SERVER")"
+if [ ! -s "$KEY_HOST_SERVER" ]; then
+	echo "interop: generating $ALG signer keyfile"
+	timeout 90 "$SERVER_EMU" -c1 -r"$SERVER_ROOT" /dis/auth/createsignerkey.dis \
+		-a "$ALG" -f "$KEY_INF" interopnode >/dev/null 2>&1
+fi
+[ -s "$KEY_HOST_SERVER" ] || { echo "interop: keyfile generation failed" >&2; exit 1; }
+mkdir -p "$(dirname "${CLIENT_ROOT}${KEY_INF}")"
+[ "$(cd "$SERVER_ROOT" && pwd)" = "$(cd "$CLIENT_ROOT" && pwd)" ] || cp -f "$KEY_HOST_SERVER" "${CLIENT_ROOT}${KEY_INF}"
+
+TMP="$(mktemp -d)"
+trap 'kill $SRV_PID 2>/dev/null; rm -rf "$TMP"' EXIT
+
+# Start the serving node.
+timeout 60 "$SERVER_EMU" -c1 -r"$SERVER_ROOT" /dis/interop_node_server.dis \
+	"$KEY_INF" "$ADDR" "$EXPORT_TREE" >"$TMP/srv.out" 2>"$TMP/srv.err" &
+SRV_PID=$!
+
+# emu wires a directly-run .dis's status output to the harness stdout, so the
+# node's "listening"/auth lines may land in either stream — scan both.
+srvlog() { cat "$TMP/srv.out" "$TMP/srv.err" 2>/dev/null; }
+# Wait for it to announce (or skip gracefully if this host has no IP stack).
+for i in $(seq 1 50); do
+	srvlog | grep -q "listening on" && break
+	if ! kill -0 $SRV_PID 2>/dev/null; then break; fi
+	sleep 0.2
+done
+if srvlog | grep -qiE "address family|network unavailable|cannot announce"; then
+	echo "SKIP: server could not announce (no IP stack?):"; srvlog | sed 's/^/    /'; exit 0
+fi
+srvlog | grep -q "listening on" || { echo "interop: server failed to start:"; srvlog | sed 's/^/    /'; exit 1; }
+
+# Run the connecting node; it writes the pulled file to OUT (a real file, to
+# avoid relying on emu's fd wiring) which maps to a host path under CLIENT_ROOT.
+# emu does not always exit promptly once an export/mount channel is up, so we
+# run it in the background and finish the moment the transfer is reported done.
+OUT_INF="/tmp/interop_pulled_$$"
+OUT_HOST="${CLIENT_ROOT}${OUT_INF}"
+mkdir -p "$(dirname "$OUT_HOST")"	# /tmp may not exist in the client tree
+rm -f "$OUT_HOST"
+"$CLIENT_EMU" -c1 -r"$CLIENT_ROOT" /dis/interop_node_client.dis \
+	"$KEY_INF" "$ADDR" "/mnt" "$XFER" "$OUT_INF" >"$TMP/client.out" 2>"$TMP/client.err" &
+CLI_PID=$!
+clilog() { cat "$TMP/client.out" "$TMP/client.err" 2>/dev/null; }
+DONE=0
+for i in $(seq 1 100); do
+	clilog | grep -q "node_client: OK read" && { DONE=1; break; }
+	clilog | grep -qE "node_client: .*(:|failed)" && break   # an error line
+	kill -0 $CLI_PID 2>/dev/null || break
+	sleep 0.2
+done
+kill $CLI_PID 2>/dev/null
+{ srvlog; clilog; } | grep -E "node_(server|client):" | sed 's/^/    /'
+
+if [ "$DONE" != 1 ]; then echo "FAIL: client did not complete the transfer"; rm -f "$OUT_HOST"; exit 1; fi
+if cmp -s "$OUT_HOST" "$SRC_FILE"; then
+	echo "PASS: $(wc -c <"$OUT_HOST" | tr -d ' ') bytes transferred and verified byte-for-byte over cert-auth + PQC + ssl"
+	rm -f "$OUT_HOST"; exit 0
+else
+	echo "FAIL: transferred bytes differ from source $SRC_FILE"
+	rm -f "$OUT_HOST"; exit 1
+fi

--- a/tests/interop_test.b
+++ b/tests/interop_test.b
@@ -1,0 +1,304 @@
+implement InteropTest;
+
+#
+# Node-to-node interoperability over the native Inferno transport:
+# cert authentication + the hybrid post-quantum (ML-KEM-768) STS handshake
+# + ssl line encryption, then a real Styx/9P file transfer across the
+# encrypted channel.
+#
+# This is the end-to-end exercise the unit-level pqauth_test only approximates:
+# one proc plays the serving node (auth->server + sys->export), the other plays
+# the connecting node (auth->client + sys->mount), and the test asserts that a
+# real file read *through the mount* (i.e. marshalled as 9P, encrypted by the
+# ssl device, sent over a real TCP socket, decrypted and de-marshalled on the
+# far side) is byte-identical to the file read directly.
+#
+# Coverage:
+#   - InteropEd25519   classical ed25519 certificates over the PQ handshake
+#   - InteropMLDSA65   fully post-quantum: ML-DSA-65 certs + ML-KEM-768 KEM
+#
+# Both ride aes_256_cbc/sha256 line encryption -- the same default `mount -k`
+# and `styxlisten` negotiate between InferNode and NERVA3 nodes.
+#
+# Skips cleanly (not fails) where the host has no IP stack at all.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+InteropTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/interop_test.b";
+
+# The serving node exports this subtree; the connecting node mounts it at
+# MOUNTPT and reads XFER through the mount.  /lib is stable, read-only, and
+# present in both the InferNode and NERVA3 trees; /mnt is a pre-existing
+# mountpoint.  XFER is relative to the exported root.
+EXPORTTREE: con "/lib";
+MOUNTPT: con "/mnt";
+XFER: con "/ndb/inferno";
+
+# line-encryption algorithms (server offers a list, client a single spec) --
+# aes_256_cbc + sha256 is the default mount -k / styxlisten negotiates.
+CLIENTALG: con "aes_256_cbc sha256";
+
+serveralgs(): list of string
+{
+	return "aes_256_cbc" :: "sha256" :: nil;
+}
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	* =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+byteseq(a, b: array of byte): int
+{
+	if(len a != len b)
+		return 0;
+	for(i := 0; i < len a; i++)
+		if(a[i] != b[i])
+			return 0;
+	return 1;
+}
+
+readall(fd: ref Sys->FD): array of byte
+{
+	buf := array[0] of byte;
+	tmp := array[8192] of byte;
+	for(;;){
+		n := sys->read(fd, tmp, len tmp);
+		if(n < 0)
+			return nil;
+		if(n == 0)
+			break;
+		nb := array[len buf + n] of byte;
+		nb[0:] = buf;
+		nb[len buf:] = tmp[0:n];
+		buf = nb;
+	}
+	return buf;
+}
+
+readpath(path: string): array of byte
+{
+	fd := sys->open(path, Sys->OREAD);
+	if(fd == nil)
+		return nil;
+	return readall(fd);
+}
+
+# Build an Authinfo for `name`, certified by the given signer, sharing the
+# DH group.  Mirrors appl/cmd/auth/mkauthinfo.b and tests/pqauth_test.b.
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk;
+	ai.mypk = pk;
+	ai.cert = cert;
+	ai.spk = signerpk;
+	ai.alpha = alpha;
+	ai.p = p;
+	return ai;
+}
+
+# Create a signer and a mutually-trusting (server, client) authinfo pair.
+setupPair(t: ref T, signeralg: string): (ref Keyring->Authinfo, ref Keyring->Authinfo)
+{
+	signersk := kr->genSK(signeralg, "interop-signer", 0);
+	if(signersk == nil)
+		t.fatal("genSK signer (" + signeralg + ") failed");
+	signerpk := kr->sktopk(signersk);
+
+	(alpha, p) := kr->dhparams(2048);	# precomputed (RFC 3526), fast
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "servernode");
+	cli := mkauthinfo(signersk, signerpk, alpha, p, "clientnode");
+	return (srv, cli);
+}
+
+Srv: adt {
+	err:	string;	# non-nil on failure
+};
+
+# Serving node: accept the connection, authenticate + wrap in ssl, then
+# export this namespace as a 9P service over the encrypted channel.
+servernode(ac: Sys->Connection, ai: ref Keyring->Authinfo, ready: chan of string,
+		done: chan of ref Srv)
+{
+	s := ref Srv;
+	(lok, nc) := sys->listen(ac);
+	if(lok < 0){
+		s.err = sys->sprint("listen failed: %r");
+		ready <-= s.err;
+		done <-= s;
+		return;
+	}
+	dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil){
+		s.err = sys->sprint("open data failed: %r");
+		ready <-= s.err;
+		done <-= s;
+		return;
+	}
+
+	# authenticate the peer and push the negotiated cipher onto the line.
+	# setid=0: we are not establishing a host owner, just a secure channel.
+	(wrapped, who) := auth->server(serveralgs(), ai, dfd, 0);
+	if(wrapped == nil){
+		s.err = "server auth+ssl failed: " + who;
+		ready <-= s.err;
+		done <-= s;
+		return;
+	}
+
+	ready <-= nil;	# auth done; client may proceed
+
+	# serve the exported subtree over the encrypted channel until the peer leaves
+	sys->export(wrapped, EXPORTTREE, Sys->EXPWAIT);
+	done <-= s;
+}
+
+testInterop(t: ref T, label, signeralg: string, port: int)
+{
+	if(auth == nil)
+		t.fatal("auth module not loaded");
+	if((e := auth->init()) != nil)
+		t.fatal("auth init failed: " + e);
+
+	# the reference bytes, read straight from the local filesystem
+	want := readpath(EXPORTTREE + XFER);
+	if(want == nil)
+		t.fatal(sys->sprint("cannot read reference file %s: %r", EXPORTTREE + XFER));
+
+	addr := sys->sprint("tcp!127.0.0.1!%d", port);
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+
+	(srvai, cliai) := setupPair(t, signeralg);
+
+	ready := chan of string;
+	done := chan of ref Srv;
+	spawn servernode(ac, srvai, ready, done);
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){
+		t.skip(sys->sprint("dial failed (no loopback?): %r"));
+		return;
+	}
+
+	(wrapped, cerr) := auth->client(CLIENTALG, cliai, dc.dfd);
+	if(wrapped == nil)
+		t.fatal(label + ": client auth+ssl failed: " + cerr);
+
+	# wait for the server to finish its half of the handshake
+	serr := <-ready;
+	if(serr != nil)
+		t.fatal(label + ": " + serr);
+
+	# mount the remote node's exported tree over the encrypted channel
+	sys->unmount(nil, MOUNTPT);	# start from a clean mountpoint
+	if(sys->mount(wrapped, nil, MOUNTPT, Sys->MREPL, "") < 0)
+		t.fatal(sys->sprint("%s: mount over encrypted channel failed: %r", label));
+
+	# read the file *through the mount* -- this traffic is 9P, encrypted,
+	# over the real TCP socket, authenticated by the PQ handshake.
+	got := readpath(MOUNTPT + XFER);
+	if(got == nil){
+		sys->unmount(nil, MOUNTPT);
+		t.fatal(sys->sprint("%s: read through mount failed: %r", label));
+	}
+
+	t.asserteq(len got, len want, label + ": transferred length matches");
+	t.assert(byteseq(got, want), label + ": file bytes round-trip intact over cert-auth + PQC + ssl");
+	t.log(sys->sprint("%s: %d bytes of %s round-tripped over an encrypted 9P channel",
+		label, len got, EXPORTTREE + XFER));
+
+	sys->unmount(nil, MOUNTPT);
+}
+
+testEd25519(t: ref T)
+{
+	testInterop(t, "ed25519", "ed25519", 19811);
+}
+
+testMLDSA65(t: ref T)
+{
+	testInterop(t, "mldsa65", "mldsa65", 19812);
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(sys == nil || kr == nil || testing == nil){
+		raise "fail:cannot load core modules";
+	}
+	if(auth == nil){
+		sys->fprint(sys->fildes(2), "cannot load auth module: %r\n");
+		raise "fail:cannot load auth";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("InteropEd25519", testEd25519);
+	run("InteropMLDSA65", testMLDSA65);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -52,6 +52,7 @@ TARG=\
 	pdf_conformance_test.dis\
 	pdf_test.dis\
 	pqauth_test.dis\
+	interop_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\


### PR DESCRIPTION
## What this does
Verifies that nodes authenticate and talk to each other over the native transport (cert auth + the hybrid ML-KEM-768 STS handshake + `aes_256_cbc` ssl + 9P), and fixes the transport bug that was blocking it on IPv6-less hosts.

## Transport fix
`emu/port/ipif6-posix.c` created every socket with `socket(AF_INET6, …)` and had **no fallback**. On a host whose kernel lacks IPv6 (containers, CI runners, hardened deployments) that fails with `EAFNOSUPPORT`, so *all* emu networking died — `/net/tcp/clone`, `announce`, `dial`, every mount. Node-to-node cert auth + PQC couldn't even open a socket.

The device now detects an unavailable `AF_INET6` once (`EAFNOSUPPORT`/`EPROTONOSUPPORT`) and falls back to `AF_INET`, marshalling v4-mapped / unspecified addresses as `sockaddr_in`. **On a dual-stack host the `AF_INET6` path is byte-for-byte the original**, so IPv6 hosts are unaffected.

## Tests added
- **`tests/interop_test.b`** (auto-discovered by the runner): two procs over a real TCP socket do `auth->server`/`auth->client` with **ed25519 AND ML-DSA-65** certs, then a real `export`/`mount` **file transfer** verified byte-for-byte. Skips cleanly with no IP stack.
- **`tests/interop/{node_server,node_client}.b` + `run-interop.sh`**: a host harness that launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them.
- **`docs/NODE-INTEROP-TESTING.md`**: transport overview, run instructions, the fix, and a documented pre-existing finding.

## Verification
- `pqauth_test`: **7/7** — `HybridTcpChannel` now runs over a real socket (previously skipped "network unavailable").
- `interop_test`: **2/2** (ed25519 + ML-DSA-65).
- Cross-binary harness: **InferNode ⇄ NERVA3, both directions, both cert algorithms** — 722 bytes transferred and `cmp`-verified.
- Rest of the crypto battery clean (`crypto`, `ssl_transport`, `secstore_crypto`, `tls_pq`, `9p_export`).

## Follow-ups filed (not addressed here)
- **INFR-261** — pre-existing Dis-runtime cipher heap corruption (AES builtin → DES builtin). libsec is correct in C and the `ssl` transport uses libsec directly, so node comms are unaffected.
- **INFR-262** — `tcp_test` hangs offline (dials public hosts with no timeout).

https://claude.ai/code/session_01Ja8puA99PG4ttvnwnfXG7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ja8puA99PG4ttvnwnfXG7b)_