### PR TITLE
Follow-up: sockaddr_storage out-param fix (CWE-787) + tcp_test bounded dials (INFR-262)

### DIFF
--- a/emu/port/ipif6-posix.c
+++ b/emu/port/ipif6-posix.c
@@ -212,40 +212,44 @@ so_recv(int sock, void *va, int len, void *hdr, int hdrlen)
 	if(hdr == 0)
 		r = read(sock, va, len);
 	else if(noipv6){
-		/* IPv4-only host: read into a sockaddr_in and rebuild the header
-		 * in the same layout the AF_INET6 path produces (v4-mapped). */
-		struct sockaddr_in rsin, lsin;
+		/* IPv4-only host: recvfrom into a sockaddr_storage (never hand the
+		 * kernel a smaller address buffer), then rebuild the header in the
+		 * same v4-mapped layout the AF_INET6 path produces. */
+		struct sockaddr_storage lsa;
 		uchar rip[IPaddrlen], lip[IPaddrlen];
+		ushort rport, lport;
 
-		memset(&rsin, 0, sizeof(rsin));
-		l = sizeof(rsin);
-		r = recvfrom(sock, va, len, 0, (struct sockaddr*)&rsin, &l);
+		l = sizeof(sa);
+		r = recvfrom(sock, va, len, 0, (struct sockaddr*)&sa, &l);
 		if(r >= 0){
 			memset(h, 0, sizeof(h));
-			v4tov6(rip, (uchar*)&rsin.sin_addr);
-			memset(&lsin, 0, sizeof(lsin));
-			l = sizeof(lsin);
-			getsockname(sock, (struct sockaddr*)&lsin, &l);
-			v4tov6(lip, (uchar*)&lsin.sin_addr);
+			ipfromsockaddr(&sa, rip, &rport);
+			memset(&lsa, 0, sizeof(lsa));
+			l = sizeof(lsa);
+			if(getsockname(sock, (struct sockaddr*)&lsa, &l) < 0){
+				memset(lip, 0, sizeof(lip));
+				lport = 0;
+			} else
+				ipfromsockaddr(&lsa, lip, &lport);
 			switch(hdrlen){
 			case OUdphdrlenv4:
-				memmove(h, (uchar*)&rsin.sin_addr, IPv4addrlen);
-				memmove(h+2*IPv4addrlen, &rsin.sin_port, 2);
-				memmove(h+IPv4addrlen, (uchar*)&lsin.sin_addr, IPv4addrlen);
-				memmove(h+2*IPv4addrlen+2, &lsin.sin_port, 2);
+				memmove(h, rip+IPv4off, IPv4addrlen);
+				hnputs((uchar*)h+2*IPv4addrlen, rport);
+				memmove(h+IPv4addrlen, lip+IPv4off, IPv4addrlen);
+				hnputs((uchar*)h+2*IPv4addrlen+2, lport);
 				break;
 			case OUdphdrlen:
 				memmove(h, rip, IPaddrlen);
-				memmove(h+2*IPaddrlen, &rsin.sin_port, 2);
+				hnputs((uchar*)h+2*IPaddrlen, rport);
 				memmove(h+IPaddrlen, lip, IPaddrlen);
-				memmove(h+2*IPaddrlen+2, &lsin.sin_port, 2);
+				hnputs((uchar*)h+2*IPaddrlen+2, lport);
 				break;
 			default:
 				memmove(h, rip, IPaddrlen);
-				memmove(h+3*IPaddrlen, &rsin.sin_port, 2);
+				hnputs((uchar*)h+3*IPaddrlen, rport);
 				memmove(h+IPaddrlen, lip, IPaddrlen);
 				memmove(h+2*IPaddrlen, lip, IPaddrlen);	/* ifcaddr */
-				memmove(h+3*IPaddrlen+2, &lsin.sin_port, 2);
+				hnputs((uchar*)h+3*IPaddrlen+2, lport);
 				break;
 			}
 			memmove(hdr, h, hdrlen);

--- a/tests/tcp_test.b
+++ b/tests/tcp_test.b
@@ -2,16 +2,14 @@ implement TcpTest;
 
 #
 # TCP/IP stack tests
-# Migrated from test-tcp-simple.b and test-tcp-ip.b
 #
-# Tests:
-# - TCP dial to remote host
-# - TCP write to connection
-# - TCP read from connection
-# - HTTP request/response
-#
-# Note: These tests require network connectivity.
-# Tests will be skipped if network is unavailable.
+# Two classes of test:
+#   - Loopback (always runs where any IP stack exists): announce/listen/dial/
+#     write/read against 127.0.0.1, fully self-contained. This is the
+#     authoritative "the TCP stack works" assertion.
+#   - Outbound Internet (opt-in): dial public hosts. These SKIP cleanly when
+#     the host is offline. Every outbound dial is bounded by a timeout so the
+#     suite never hangs on a network-isolated box (see INFR-262).
 #
 
 include "sys.m";
@@ -34,6 +32,9 @@ skipped := 0;
 
 # Source file path for clickable error addresses
 SRCFILE: con "/tests/tcp_test.b";
+
+# How long to wait for an outbound dial before giving up and skipping.
+DIALMS: con 3000;
 
 # Helper to run a test and track results
 run(name: string, testfn: ref fn(t: ref T))
@@ -58,100 +59,164 @@ run(name: string, testfn: ref fn(t: ref T))
 		failed++;
 }
 
-# Test basic TCP dial to an IP address
-testTcpDialIp(t: ref T)
+# ── bounded dial ──────────────────────────────────────────────────────────
+# sys->dial blocks in the host connect() until the kernel's SYN timeout, which
+# on an offline host is tens of seconds -- long enough to look like a hang and
+# stall the whole runner. Bound it: dial in a child proc, race it against a
+# timer, and report a timeout to the caller so the test can skip.
+
+Dialres: adt {
+	ok:	int;
+	c:	Sys->Connection;
+};
+
+dialer(addr: string, ch: chan of ref Dialres)
 {
-	# Connect to Google DNS on TCP port 53
-	(ok, c) := sys->dial("tcp!8.8.8.8!53", nil);
-	if(ok < 0) {
-		t.skip(sys->sprint("network unavailable: %r"));
+	r := ref Dialres;
+	(r.ok, r.c) = sys->dial(addr, nil);
+	ch <-= r;
+}
+
+timer(ch: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	ch <-= 1;
+}
+
+# returns (ok, connection, timedout). timedout=1 means the dial did not
+# complete within DIALMS (treat as "network unavailable", skip).
+dialTimeout(addr: string, ms: int): (int, Sys->Connection, int)
+{
+	dc := chan of ref Dialres;
+	tc := chan of int;
+	spawn dialer(addr, dc);
+	spawn timer(tc, ms);
+	alt {
+	r := <-dc =>
+		return (r.ok, r.c, 0);
+	<-tc =>
+		return (-1, Sys->Connection(nil, nil, nil), 1);
+	}
+}
+
+# ── loopback (self-contained, always runs with any IP stack) ────────────────
+acceptor(ac: Sys->Connection, res: chan of string)
+{
+	(lok, nc) := sys->listen(ac);
+	if(lok < 0){
+		res <-= sys->sprint("listen: %r");
+		return;
+	}
+	dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil){
+		res <-= sys->sprint("accept open data: %r");
+		return;
+	}
+	buf := array[64] of byte;
+	n := sys->read(dfd, buf, len buf);	# read request, echo it back
+	if(n > 0)
+		sys->write(dfd, buf, n);
+	res <-= nil;
+}
+
+testLoopback(t: ref T)
+{
+	addr := "tcp!127.0.0.1!18799";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		# no IP stack at all on this host -> skip, do not fail
+		t.skip(sys->sprint("no IP stack (announce failed): %r"));
 		return;
 	}
 
+	res := chan of string;
+	spawn acceptor(ac, res);
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){
+		t.fatal(sys->sprint("loopback dial failed: %r"));
+		return;
+	}
+
+	msg := array of byte "ping-over-loopback";
+	if(sys->write(dc.dfd, msg, len msg) != len msg){
+		t.fatal(sys->sprint("loopback write failed: %r"));
+		return;
+	}
+
+	buf := array[64] of byte;
+	n := sys->read(dc.dfd, buf, len buf);
+	if(n < 0){
+		t.fatal(sys->sprint("loopback read failed: %r"));
+		return;
+	}
+	t.asserteq(n, len msg, "loopback: echoed byte count matches");
+	t.assertseq(string buf[0:n], string msg, "loopback TCP echo round-trips");
+
+	if((e := <-res) != nil)
+		t.error("acceptor: " + e);
+}
+
+# ── outbound Internet (opt-in; skip cleanly when offline) ───────────────────
+testTcpDialIp(t: ref T)
+{
+	(ok, c, tout) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
+	if(tout){ t.skip("dial timed out (offline)"); return; }
+	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
 	t.assert(c.dfd != nil, "data fd should be valid");
 	t.log(sys->sprint("connected to 8.8.8.8:53, fd=%d", c.dfd.fd));
 }
 
-# Test TCP dial with hostname resolution
 testTcpDialHostname(t: ref T)
 {
-	(ok, c) := sys->dial("tcp!google.com!80", nil);
-	if(ok < 0) {
-		t.skip(sys->sprint("network unavailable or DNS failed: %r"));
-		return;
-	}
-
+	(ok, c, tout) := dialTimeout("tcp!google.com!80", DIALMS);
+	if(tout){ t.skip("dial timed out (offline)"); return; }
+	if(ok < 0){ t.skip(sys->sprint("network unavailable or DNS failed: %r")); return; }
 	t.assert(c.dfd != nil, "data fd should be valid");
 	t.log("connected to google.com:80");
 }
 
-# Test TCP write
 testTcpWrite(t: ref T)
 {
-	(ok, c) := sys->dial("tcp!8.8.8.8!53", nil);
-	if(ok < 0) {
-		t.skip(sys->sprint("network unavailable: %r"));
-		return;
-	}
-
-	# Write a single byte
+	(ok, c, tout) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
+	if(tout){ t.skip("dial timed out (offline)"); return; }
+	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
 	buf := array[1] of byte;
 	buf[0] = byte 0;
 	n := sys->write(c.dfd, buf, 1);
 	t.asserteq(n, 1, "write should return 1 byte written");
 }
 
-# Test HTTP request and response
 testHttpRequest(t: ref T)
 {
-	(ok, c) := sys->dial("tcp!google.com!80", nil);
-	if(ok < 0) {
-		t.skip(sys->sprint("network unavailable: %r"));
-		return;
-	}
+	(ok, c, tout) := dialTimeout("tcp!google.com!80", DIALMS);
+	if(tout){ t.skip("dial timed out (offline)"); return; }
+	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
 
-	# Send HTTP request
 	request := "GET / HTTP/1.0\r\nHost: google.com\r\n\r\n";
 	buf := array of byte request;
 	n := sys->write(c.dfd, buf, len buf);
-	if(n < 0) {
+	if(n < 0){
 		t.fatal(sys->sprint("write failed: %r"));
 		return;
 	}
 	t.assert(n > 0, "write should succeed");
 	t.log(sys->sprint("sent %d bytes", n));
 
-	# Read response
 	rbuf := array[512] of byte;
 	n = sys->read(c.dfd, rbuf, len rbuf);
-	if(n < 0) {
+	if(n < 0){
 		t.fatal(sys->sprint("read failed: %r"));
 		return;
 	}
 	t.assert(n > 0, "should receive response");
 	t.log(sys->sprint("received %d bytes", n));
 
-	# Verify response starts with HTTP
 	response := string rbuf[0:n];
-	if(len response >= 4 && response[0:4] == "HTTP") {
+	if(len response >= 4 && response[0:4] == "HTTP")
 		t.log("response is HTTP");
-	} else {
+	else
 		t.error("response does not start with HTTP");
-	}
-}
-
-# Test connection to localhost (may or may not work)
-testLocalhostConnect(t: ref T)
-{
-	# Try to connect to localhost:9999 - typically fails but tests the code path
-	(ok, nil) := sys->dial("tcp!127.0.0.1!9999", nil);
-	if(ok >= 0) {
-		t.log("localhost:9999 was unexpectedly reachable");
-	} else {
-		# This is expected - no server on 9999
-		t.log("localhost:9999 unreachable (expected)");
-	}
-	# This test always passes - it just exercises the dial code
 }
 
 init(nil: ref Draw->Context, args: list of string)
@@ -172,12 +237,14 @@ init(nil: ref Draw->Context, args: list of string)
 			testing->verbose(1);
 	}
 
-	# Run tests
+	# Always-on, self-contained assertion first.
+	run("Loopback", testLoopback);
+
+	# Opt-in outbound tests; each skips (does not hang) when offline.
 	run("TcpDialIp", testTcpDialIp);
 	run("TcpDialHostname", testTcpDialHostname);
 	run("TcpWrite", testTcpWrite);
 	run("HttpRequest", testHttpRequest);
-	run("LocalhostConnect", testLocalhostConnect);
 
 	# Print summary
 	if(testing->summary(passed, failed, skipped) > 0)


### PR DESCRIPTION
Follow-up to #217, which merged at its first two commits — these two fixes were pushed after that merge and are not yet in `master`. Cherry-picked onto current `master` as a clean two-commit branch.

## 1. Security fix — `sockaddr_storage` for IPv4 recv/getsockname out-params (CWE-787)
`so_recv()`'s IPv4 fallback (added in #217) passed a 16-byte `struct sockaddr_in` as the address out-parameter to `recvfrom()`/`getsockname()` instead of a `struct sockaddr_storage` — the classic out-of-bounds-write footgun for socket-address out-params. The AF_INET6 branch and `so_accept`/`so_getsockname` already use `sockaddr_storage`; `so_recv`'s v4 branch was the lone deviation. Now receives into `sockaddr_storage` and reuses the existing `ipfromsockaddr()` helper (also drops the duplicated address handling). Header byte-layout unchanged.

## 2. INFR-262 — bound tcp_test outbound dials + add a loopback assertion
`tcp_test` dialed public hosts (8.8.8.8, google.com) with no timeout, so on an offline/isolated host it hung for the kernel SYN timeout and stalled the runner. Adds `dialTimeout()` (dial in a child proc raced against a timer → SKIP within 3s), and a self-contained **Loopback** test (announce/listen/dial/write/read on 127.0.0.1) as the authoritative "the TCP stack works" assertion that runs on any IP stack — including IPv6-less hosts after the AF_INET fallback.

## Verification (rebuilt on current master)
- `pqauth_test`: **7/7** (incl. real-TCP `HybridTcpChannel`)
- `interop_test`: **2/2** (ed25519 + ML-DSA-65)
- `tcp_test`: offline → `1 passed, 4 skipped`, no hang; UDP loopback round-trip intact
- Static analyzers (CodeQL/Flawfinder/cppcheck/Source Hardening) were green on these changes in #217's run.

Refs: INFR-262

https://claude.ai/code/session_01Ja8puA99PG4ttvnwnfXG7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ja8puA99PG4ttvnwnfXG7b)_