### PR TITLE
Node-to-node auth/networking integration test campaign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,4 @@ usr/inferno/keyring/interop-*
 tmp/interop_pulled_*
 dis/interop_node_server.dis
 dis/interop_node_client.dis
+/dis/tests/stress/

--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ tmp/interop_pulled_*
 dis/interop_node_server.dis
 dis/interop_node_client.dis
 /dis/tests/stress/
+/dis/tests/bench/

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -173,3 +173,27 @@ a property of the transport buffer, not a wire-format incompatibility:
 ed25519/RSA/ML-DSA certs (≤5 KB) and SLH-DSA-192s (~16 KB) stay under typical
 buffers. If a future transport with a <40 KB send buffer must carry SLH-DSA-256s
 certs, the handshake's send/read interleaving would need revisiting.
+
+## Stress / leak / DoS harness (hardware-run)
+
+`tests/stress/` holds a connection-churn leak/stability harness
+(`churn_node.b` + `run-churn.sh`) and a slowloris/handshake-stall DoS test
+(`dos_stall_test.b`). They are **not** wired into the auto-run suite — they
+churn many TCP connections for a long time and are meant to be driven by hand
+on real hardware. See `tests/stress/README.md`.
+
+**Why not in CI/sandbox.** In the cloud sandbox these were authored in, the
+host **SIGKILLs the emu process** once a per-session CPU/time budget is spent:
+a long churn dies with exit 137 partway through, and eventually even a trivial
+test is killed at exit. There was **no OOM** (`dmesg` clean, RAM free) and the
+emu's thread/process count stayed flat, so those deaths are a *host watchdog*,
+**not** an InferNode memory leak or crash. Host RSS introspection is also
+unreliable there (the emu forks a worker; the visible pid is a zombie stub).
+A trustworthy leak/stability verdict therefore needs a real host — tracked for
+hardware validation alongside the IPv6 task.
+
+One design observation surfaced by the DoS test: `node_server.b` spawns a
+per-connection handler, so a stalled handshake does **not** block the accept
+loop (good) — but `auth->server` has **no handshake-read deadline**, so a
+hostile peer that connects and never speaks pins a handler proc + fds for the
+life of the connection. A read timeout on the handshake would bound that.

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -38,6 +38,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 | `tests/interrupt_test.b` | in-emu unit (auto-discovered) | interruptibility: an abrupt TCP disconnect **mid-handshake** makes the peer error cleanly (`hungup`), and **mid-transfer** makes the reader hit EOF with the partial data — no crash, no hang (timeout-guarded) |
 | `tests/concurrent_auth_test.b` | in-emu unit (auto-discovered) | 12 clients authenticate to one spawn-per-connection server **simultaneously** (shared Authinfos both ends), each echoing a distinct 4 KiB payload; asserts every client gets its **own** bytes back — no cross-talk, no races, no hang |
 | `tests/interop/run-mount-auth.sh` | host harness | **real CLI path**: `auth/createsignerkey` -> on-disk keyfile -> `styxlisten -k ... export /lib` (server) <- `mount -k ... -C` (client), reading a file through the encrypted styx mount and verifying it; covers ed25519 + ML-DSA-65 and checks an anonymous `mount -A` is rejected |
+| `tests/handshake_fuzz_test.b` | in-emu unit (auto-discovered) | receiver robustness: 9 malformed inbound handshake streams (empty, garbage, bad/oversized/truncated length headers, zero-length flood, garbage payloads) over real TCP must each make `auth->server` fail closed — no secret, no crash, no hang |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -198,3 +198,14 @@ per-connection handler, so a stalled handshake does **not** block the accept
 loop (good) — but `auth->server` has **no handshake-read deadline**, so a
 hostile peer that connects and never speaks pins a handler proc + fds for the
 life of the connection. A read timeout on the handshake would bound that.
+
+## Performance baselines (hardware-run)
+
+`tests/bench/bench_node.b` measures keygen + STS-handshake latency per
+certificate algorithm and encrypted-channel throughput per `ssl` cipher
+(`sys->millisec()` timing, no host introspection). Not auto-run — slow and
+environment-dependent. See `tests/bench/README.md`. The shape it reveals: the
+handshake is dominated by the shared DH-2048 + ML-KEM-768 key agreement (so
+ed25519/ML-DSA/RSA/DSA land within ~10% of each other), ElGamal verify is ~3×
+heavier, and SLH-DSA signing is in a different league (~9 s+, a conservative
+backup not a default); line encryption costs ~7× vs plaintext with AES ≳ IDEA.

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -32,6 +32,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 |-------|------|----------------|
 | `tests/pqauth_test.b` | in-emu unit (auto-discovered by the runner) | the hybrid handshake itself: happy path (ed25519 + ML-DSA-65 signers), real-TCP encrypted channel, and the negatives (downgrade, tampered/malformed ML-KEM key) |
 | `tests/interop_test.b` | in-emu unit (auto-discovered) | end-to-end: real TCP + cert auth + PQ handshake + `aes_256_cbc` ssl + a real `export`/`mount` **file transfer**, across the full fast certificate range: ed25519, ML-DSA-65, ML-DSA-87, RSA-2048, **DSA-1024**, ElGamal-2048 |
+| `tests/cipher_matrix_test.b` | in-emu unit (auto-discovered) | every `ssl` line-encryption cipher (`aes_256_cbc`, `aes_128_cbc`, `ideacbc`, `ideaecb`) and MAC (`sha256`, `sha1`, `md5`, `md4`), plus the unencrypted `none` path, negotiated through a real `auth->server`/`auth->client` handshake and verified to round-trip a payload byte-for-byte |
 | `tests/authneg_test.b` | in-emu unit (auto-discovered) | the trust + integrity layer must **fail closed**: untrusted signer rejected, expired certificate rejected, a cipher the server did not offer refused, and a one-byte tamper on the encrypted channel caught by the ssl record MAC |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -35,6 +35,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 | `tests/cipher_matrix_test.b` | in-emu unit (auto-discovered) | every `ssl` line-encryption cipher (`aes_256_cbc`, `aes_128_cbc`, `ideacbc`, `ideaecb`) and MAC (`sha256`, `sha1`, `md5`, `md4`), plus the unencrypted `none` path, negotiated through a real `auth->server`/`auth->client` handshake and verified to round-trip a payload byte-for-byte |
 | `tests/authneg_test.b` | in-emu unit (auto-discovered) | the trust + integrity layer must **fail closed**: untrusted signer rejected, expired certificate rejected, a cipher the server did not offer refused, and a one-byte tamper on the encrypted channel caught by the ssl record MAC |
 | `tests/crypto_props_test.b` | in-emu unit (auto-discovered) | protocol crypto guarantees: two handshakes with the same certs derive **different** 64-byte secrets (ephemeral key agreement / forward-secrecy proxy), a reflected `alpha**r0` is caught by the replay check, and a one-byte-corrupted certificate signature is rejected |
+| `tests/interrupt_test.b` | in-emu unit (auto-discovered) | interruptibility: an abrupt TCP disconnect **mid-handshake** makes the peer error cleanly (`hungup`), and **mid-transfer** makes the reader hit EOF with the partial data — no crash, no hang (timeout-guarded) |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -36,6 +36,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 | `tests/authneg_test.b` | in-emu unit (auto-discovered) | the trust + integrity layer must **fail closed**: untrusted signer rejected, expired certificate rejected, a cipher the server did not offer refused, and a one-byte tamper on the encrypted channel caught by the ssl record MAC |
 | `tests/crypto_props_test.b` | in-emu unit (auto-discovered) | protocol crypto guarantees: two handshakes with the same certs derive **different** 64-byte secrets (ephemeral key agreement / forward-secrecy proxy), a reflected `alpha**r0` is caught by the replay check, and a one-byte-corrupted certificate signature is rejected |
 | `tests/interrupt_test.b` | in-emu unit (auto-discovered) | interruptibility: an abrupt TCP disconnect **mid-handshake** makes the peer error cleanly (`hungup`), and **mid-transfer** makes the reader hit EOF with the partial data — no crash, no hang (timeout-guarded) |
+| `tests/concurrent_auth_test.b` | in-emu unit (auto-discovered) | 12 clients authenticate to one spawn-per-connection server **simultaneously** (shared Authinfos both ends), each echoing a distinct 4 KiB payload; asserts every client gets its **own** bytes back — no cross-talk, no races, no hang |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -34,6 +34,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 | `tests/interop_test.b` | in-emu unit (auto-discovered) | end-to-end: real TCP + cert auth + PQ handshake + `aes_256_cbc` ssl + a real `export`/`mount` **file transfer**, across the full fast certificate range: ed25519, ML-DSA-65, ML-DSA-87, RSA-2048, **DSA-1024**, ElGamal-2048 |
 | `tests/cipher_matrix_test.b` | in-emu unit (auto-discovered) | every `ssl` line-encryption cipher (`aes_256_cbc`, `aes_128_cbc`, `ideacbc`, `ideaecb`) and MAC (`sha256`, `sha1`, `md5`, `md4`), plus the unencrypted `none` path, negotiated through a real `auth->server`/`auth->client` handshake and verified to round-trip a payload byte-for-byte |
 | `tests/authneg_test.b` | in-emu unit (auto-discovered) | the trust + integrity layer must **fail closed**: untrusted signer rejected, expired certificate rejected, a cipher the server did not offer refused, and a one-byte tamper on the encrypted channel caught by the ssl record MAC |
+| `tests/crypto_props_test.b` | in-emu unit (auto-discovered) | protocol crypto guarantees: two handshakes with the same certs derive **different** 64-byte secrets (ephemeral key agreement / forward-secrecy proxy), a reflected `alpha**r0` is caught by the replay check, and a one-byte-corrupted certificate signature is rejected |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -37,6 +37,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 | `tests/crypto_props_test.b` | in-emu unit (auto-discovered) | protocol crypto guarantees: two handshakes with the same certs derive **different** 64-byte secrets (ephemeral key agreement / forward-secrecy proxy), a reflected `alpha**r0` is caught by the replay check, and a one-byte-corrupted certificate signature is rejected |
 | `tests/interrupt_test.b` | in-emu unit (auto-discovered) | interruptibility: an abrupt TCP disconnect **mid-handshake** makes the peer error cleanly (`hungup`), and **mid-transfer** makes the reader hit EOF with the partial data — no crash, no hang (timeout-guarded) |
 | `tests/concurrent_auth_test.b` | in-emu unit (auto-discovered) | 12 clients authenticate to one spawn-per-connection server **simultaneously** (shared Authinfos both ends), each echoing a distinct 4 KiB payload; asserts every client gets its **own** bytes back — no cross-talk, no races, no hang |
+| `tests/interop/run-mount-auth.sh` | host harness | **real CLI path**: `auth/createsignerkey` -> on-disk keyfile -> `styxlisten -k ... export /lib` (server) <- `mount -k ... -C` (client), reading a file through the encrypted styx mount and verifying it; covers ed25519 + ML-DSA-65 and checks an anonymous `mount -A` is rejected |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/docs/NODE-INTEROP-TESTING.md
+++ b/docs/NODE-INTEROP-TESTING.md
@@ -32,6 +32,7 @@ headless LLM daemon (`serve-llm.sh`) and any node-to-node mount.
 |-------|------|----------------|
 | `tests/pqauth_test.b` | in-emu unit (auto-discovered by the runner) | the hybrid handshake itself: happy path (ed25519 + ML-DSA-65 signers), real-TCP encrypted channel, and the negatives (downgrade, tampered/malformed ML-KEM key) |
 | `tests/interop_test.b` | in-emu unit (auto-discovered) | end-to-end: real TCP + cert auth + PQ handshake + `aes_256_cbc` ssl + a real `export`/`mount` **file transfer**, across the full fast certificate range: ed25519, ML-DSA-65, ML-DSA-87, RSA-2048, **DSA-1024**, ElGamal-2048 |
+| `tests/authneg_test.b` | in-emu unit (auto-discovered) | the trust + integrity layer must **fail closed**: untrusted signer rejected, expired certificate rejected, a cipher the server did not offer refused, and a one-byte tamper on the encrypted channel caught by the ssl record MAC |
 | `tests/interop/run-interop.sh` | host harness | **cross-binary**: launches two *separate* emu processes (optionally from different InferNode/NERVA3 trees) and transfers a file between them, verifying it byte-for-byte |
 
 ### Running the in-emu tests

--- a/tests/authneg_test.b
+++ b/tests/authneg_test.b
@@ -1,0 +1,432 @@
+implement AuthNegTest;
+
+#
+# Negative / adversarial node-authentication tests: the native STS handshake
+# and the ssl line-encryption it pushes must FAIL CLOSED.  Where pqauth_test
+# covers handshake-mechanics negatives (downgrade, tampered/malformed ML-KEM
+# key), this covers the trust- and integrity-layer negatives that a real
+# node-to-node deployment depends on:
+#
+#   - UntrustedSigner    peer certificate signed by a different (untrusted)
+#                        signer must be rejected ("pk doesn't match certificate")
+#   - ExpiredCert        a certificate past its expiry must be rejected
+#   - CipherMismatch     a client cipher the server did not offer must be refused
+#   - TamperedCiphertext flipping one byte on the encrypted channel must be
+#                        detected by the ssl record MAC (read fails), not
+#                        delivered as if valid
+#
+# A NotExpiredSucceeds positive control guards the ExpiredCert case against
+# passing for the wrong reason.  Every case asserts the security-relevant
+# *failure*, with a timeout safety net so a hang is reported rather than
+# wedging the suite.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+AuthNegTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/authneg_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	* =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# ---- helpers -------------------------------------------------------------
+
+contains(hay, needle: string): int
+{
+	n := len needle;
+	if(n == 0)
+		return 1;
+	for(i := 0; i + n <= len hay; i++)
+		if(hay[i:i+n] == needle)
+			return 1;
+	return 0;
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+# Build an Authinfo for `name`, certified by `signersk`/`signerpk`, sharing the
+# DH group, with certificate expiry `exp` (0 == never expires).
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string, exp: int): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, exp, state, "sha256");
+
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk;
+	ai.mypk = pk;
+	ai.cert = cert;
+	ai.spk = signerpk;
+	ai.alpha = alpha;
+	ai.p = p;
+	return ai;
+}
+
+newsigner(t: ref T): (ref Keyring->SK, ref Keyring->PK)
+{
+	sk := kr->genSK("ed25519", "neg-signer", 0);
+	if(sk == nil)
+		t.fatal(sys->sprint("genSK signer failed: %r"));
+	return (sk, kr->sktopk(sk));
+}
+
+dhgroup(t: ref T): (ref Keyring->IPint, ref Keyring->IPint)
+{
+	(alpha, p) := kr->dhparams(2048);	# precomputed RFC 3526, fast
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+	return (alpha, p);
+}
+
+Result: adt {
+	owner:	string;
+	secret:	array of byte;
+};
+
+rawauthproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Result)
+{
+	(owner, secret) := kr->auth(fd, ai, 0);
+	c <-= ref Result(owner, secret);
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# Run kr->auth on both ends of a pipe; return both Results, or nil on timeout.
+rawHandshake(t: ref T, a, b: ref Keyring->Authinfo, ms: int): (ref Result, ref Result)
+{
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	ca := chan of ref Result;
+	cb := chan of ref Result;
+	tmo := chan of int;
+	spawn rawauthproc(fds[0], a, ca);
+	spawn rawauthproc(fds[1], b, cb);
+	spawn timerproc(tmo, ms);
+
+	ra, rb: ref Result;
+	for(got := 0; got < 2;){
+		alt {
+		r := <-ca => ra = r; got++;
+		r := <-cb => rb = r; got++;
+		<-tmo => return (nil, nil);
+		}
+	}
+	return (ra, rb);
+}
+
+# ---- UntrustedSigner -----------------------------------------------------
+
+testUntrustedSigner(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(skA, pkA) := newsigner(t);		# signer A
+	(skB, pkB) := newsigner(t);		# signer B (independent / untrusted)
+
+	# client certified by A and trusting A; server certified by B and trusting B.
+	# Each verifies the peer's cert with its OWN spk, so neither accepts the
+	# other -> no mutual secret.
+	client := mkauthinfo(skA, pkA, alpha, p, "client", 0);
+	server := mkauthinfo(skB, pkB, alpha, p, "server", 0);
+
+	(rc, rs) := rawHandshake(t, client, server, 15000);
+	if(rc == nil || rs == nil)
+		t.fatal("handshake hung (timeout)");
+
+	t.assert(rc.secret == nil, "client must NOT trust a peer signed by an unknown signer");
+	t.assert(rs.secret == nil, "server must NOT trust a peer signed by an unknown signer");
+	t.log(sys->sprint("client rejected with: %s", rc.owner));
+	t.log(sys->sprint("server rejected with: %s", rs.owner));
+}
+
+# ---- ExpiredCert ---------------------------------------------------------
+
+testExpiredCert(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);		# one shared, trusted signer
+
+	# both identity certs expired in the distant past (epoch secs; 2001-09-09)
+	past := 1000000000;
+	client := mkauthinfo(sk, pk, alpha, p, "client", past);
+	server := mkauthinfo(sk, pk, alpha, p, "server", past);
+
+	(rc, rs) := rawHandshake(t, client, server, 15000);
+	if(rc == nil || rs == nil)
+		t.fatal("handshake hung (timeout)");
+
+	t.assert(rc.secret == nil, "peer must reject an expired certificate (client side)");
+	t.assert(rs.secret == nil, "peer must reject an expired certificate (server side)");
+	t.assert(contains(rc.owner, "expired") || contains(rs.owner, "expired"),
+		sys->sprint("rejection cites expiry (client=%q server=%q)", rc.owner, rs.owner));
+}
+
+# sanity: with a future expiry the SAME setup must SUCCEED (guards against the
+# expired test passing for the wrong reason).
+testNotExpiredSucceeds(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	future := 2000000000;	# 2033 (fits in int32)
+	client := mkauthinfo(sk, pk, alpha, p, "client", future);
+	server := mkauthinfo(sk, pk, alpha, p, "server", future);
+
+	(rc, rs) := rawHandshake(t, client, server, 15000);
+	if(rc == nil || rs == nil)
+		t.fatal("handshake hung (timeout)");
+	t.assert(rc.secret != nil && rs.secret != nil, "valid (unexpired, shared-signer) certs authenticate");
+}
+
+# ---- CipherMismatch ------------------------------------------------------
+
+cipherServer(fd: ref Sys->FD, ai: ref Keyring->Authinfo, rc: chan of (ref Sys->FD, string))
+{
+	# server offers ONLY aes_256_cbc/sha256
+	(wrapped, err) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, fd, 0);
+	rc <-= (wrapped, err);
+}
+
+testCipherMismatch(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	client := mkauthinfo(sk, pk, alpha, p, "client", 0);
+	server := mkauthinfo(sk, pk, alpha, p, "server", 0);
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	rc := chan of (ref Sys->FD, string);
+	spawn cipherServer(fds[0], server, rc);
+
+	# client requests aes_128_cbc, which the server did not offer
+	(cwrapped, cerr) := auth->client("aes_128_cbc sha256", client, fds[1]);
+
+	tmo := chan of int;
+	spawn timerproc(tmo, 15000);
+	swrapped: ref Sys->FD;
+	serr: string;
+	alt {
+	(w, e) := <-rc => swrapped = w; serr = e;
+	<-tmo => t.fatal("server hung (timeout)");
+	}
+
+	t.assert(swrapped == nil, "server must refuse a cipher it did not offer");
+	t.assert(contains(serr, "unsupported") || contains(serr, "algorithm"),
+		sys->sprint("server cites the unsupported algorithm (got %q)", serr));
+	t.log(sys->sprint("client side: wrapped=%d err=%q", cwrapped != nil, cerr));
+}
+
+# ---- TamperedCiphertext --------------------------------------------------
+
+# Relay one byte-stream src->dst.  Once `arm` fires, flip the first byte of the
+# next chunk forwarded (corrupting one ssl record on the encrypted channel).
+tamperRelay(src, dst: ref Sys->FD, arm: chan of int, done: chan of int)
+{
+	armed := 0;
+	flipped := 0;
+	buf := array[8192] of byte;
+	for(;;){
+		n := sys->read(src, buf, len buf);
+		if(n <= 0)
+			break;
+		# check the arm signal AFTER the read, before forwarding, so the
+		# flip lands on the data chunk that arrives once armed (arm is
+		# buffered, so the producer never blocks on a read-blocked relay).
+		if(!armed){
+			alt {
+			<-arm => armed = 1;
+			* => ;
+			}
+		}
+		if(armed && !flipped){
+			# corrupt the LAST byte (ssl record MAC/ciphertext body, not
+			# the length header) so the record framing stays intact and
+			# the receiver fails the digest check rather than desyncing.
+			buf[n-1] = byte (int buf[n-1] ^ 16r80);
+			flipped = 1;
+		}
+		if(sys->write(dst, buf[0:n], n) != n)
+			break;
+	}
+	done <-= flipped;
+}
+
+tamperServer(fd: ref Sys->FD, ai: ref Keyring->Authinfo, expect: int,
+		ready: chan of int, rc: chan of (int, int))
+{
+	(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, fd, 0);
+	if(wrapped == nil){
+		ready <-= 0;
+		rc <-= (-1, 0);
+		return;
+	}
+	ready <-= 1;		# our half of the handshake + ssl is up
+	buf := array[expect] of byte;
+	n := readn(wrapped, buf, expect);
+	# report (bytes read, whether they equal the canonical payload)
+	ok := 1;
+	if(n != expect)
+		ok = 0;
+	else
+		for(i := 0; i < expect; i++)
+			if(int buf[i] != ('A' + (i % 26)))
+				ok = 0;
+	rc <-= (n, ok);
+}
+
+testTamperedCiphertext(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	client := mkauthinfo(sk, pk, alpha, p, "client", 0);
+	server := mkauthinfo(sk, pk, alpha, p, "server", 0);
+
+	pc := array[2] of ref Sys->FD;	# client <-> relay
+	ps := array[2] of ref Sys->FD;	# relay  <-> server
+	if(sys->pipe(pc) < 0 || sys->pipe(ps) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	armc := chan[1] of int;	# client -> relay: start corrupting (buffered)
+	rdone := chan of int;
+	spawn tamperRelay(pc[1], ps[1], armc, rdone);	# client -> server (corrupting)
+	spawn tamperRelay(ps[1], pc[1], chan of int, rdone);	# server -> client (clean)
+
+	ready := chan of int;
+	rc := chan of (int, int);
+	spawn tamperServer(ps[0], server, 260, ready, rc);
+
+	(cwrapped, cerr) := auth->client("aes_256_cbc sha256", client, pc[0]);
+	if(cwrapped == nil)
+		t.fatal("client auth+ssl failed: " + cerr);
+
+	# wait for the server's half before sending data, so the byte the relay
+	# flips is guaranteed to be encrypted *data*, not a handshake frame.
+	tmo := chan of int;
+	spawn timerproc(tmo, 20000);
+	alt {
+	sok := <-ready =>
+		if(!sok)
+			t.fatal("server auth+ssl failed");
+	<-tmo =>
+		t.fatal("server handshake hung (timeout)");
+	}
+
+	armc <-= 1;	# arm the corruption for the next client->server bytes
+
+	msg := array[260] of byte;
+	for(i := 0; i < len msg; i++)
+		msg[i] = byte ('A' + (i % 26));
+	sys->write(cwrapped, msg, len msg);
+
+	tmo2 := chan of int;
+	spawn timerproc(tmo2, 20000);
+	n, ok: int;
+	alt {
+	(rn, rok) := <-rc => n = rn; ok = rok;
+	<-tmo2 => t.fatal("server read hung (timeout)");
+	}
+
+	t.assert(ok == 0, "ssl record MAC must reject a tampered ciphertext (corrupt data not delivered intact)");
+	t.log(sys->sprint("server saw n=%d intact=%d after one flipped ciphertext byte", n, ok));
+}
+
+# NB: handshake-mechanics negatives (protocol downgrade, tampered/malformed
+# ML-KEM key, truncated frames) are covered by pqauth_test, which uses a
+# man-in-the-middle relay between two real peers -- the correct way to drive
+# those paths.  This file deliberately stays on the trust + integrity layer.
+
+# ---- entry point ---------------------------------------------------------
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil){
+		sys->fprint(sys->fildes(2), "cannot load auth module: %r\n");
+		raise "fail:cannot load auth";
+	}
+	if((e := auth->init()) != nil){
+		sys->fprint(sys->fildes(2), "auth init failed: %s\n", e);
+		raise "fail:auth init";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("UntrustedSigner", testUntrustedSigner);
+	run("ExpiredCert", testExpiredCert);
+	run("NotExpiredSucceeds", testNotExpiredSucceeds);
+	run("CipherMismatch", testCipherMismatch);
+	run("TamperedCiphertext", testTamperedCiphertext);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,69 @@
+# Node-auth performance baselines (hardware-run)
+
+`bench_node.b` measures the cost of the node-to-node auth path and prints three
+things:
+
+1. **keygen latency** per certificate signature algorithm (one `genSK`)
+2. **handshake latency** per algorithm — a full `Keyring->auth` STS handshake
+   (classical DH + ML-KEM-768 + cert sign/verify), averaged over N iterations,
+   reusing one keypair
+3. **encrypted-channel throughput** per `ssl` cipher (MB/s pushing a payload
+   through a negotiated `auth->client`/`auth->server` channel)
+
+Timing is `sys->millisec()` inside the emu — no host introspection. It is **not**
+wired into the auto-run suite (it's slow and the numbers are environment-
+dependent). Absolute figures vary with host speed / emu build / JIT; the value
+is the **relative** cost between algorithms and ciphers and a repeatable method.
+Run on the target hardware for real numbers.
+
+```sh
+# build, then run from the repo root:
+limbo -I module -o dis/tests/bench/bench_node.dis tests/bench/bench_node.b
+./emu/Linux/o.emu -c1 -r$PWD /dis/tests/bench/bench_node.dis [mode [iters [MiB]]]
+#   mode  : all (default) | lat | tp
+#   iters : fast-alg handshake samples (default 10; SLH-DSA capped at 2)
+#   MiB   : throughput payload size (default 8)
+```
+
+> **Note on SLH-DSA + host watchdogs.** SLH-DSA signing is extremely CPU-heavy
+> (millions of SHAKE calls per signature). In a sandbox with a CPU watchdog it
+> can get the emu SIGKILLed mid-run. Use `mode=tp` to capture throughput on its
+> own, and `mode=lat` (ideally on hardware) for the full latency table.
+
+## Illustrative output
+
+From the (slow, shared) sandbox these were authored in — **relative** costs only,
+not representative absolute numbers:
+
+```
+== keygen + handshake latency (ms) ==
+  ed25519      keygen=0      handshake_avg=334    ms  (n=5)
+  mldsa65      keygen=1      handshake_avg=337    ms  (n=5)
+  mldsa87      keygen=1      handshake_avg=337    ms  (n=5)
+  rsa          keygen=10685  handshake_avg=368    ms  (n=5)
+  dsa          keygen=2329   handshake_avg=346    ms  (n=5)
+  elgamal      keygen=75     handshake_avg=942    ms  (n=5)
+  slhdsa192s   keygen=986    handshake_avg=9330   ms  (n=2)
+  slhdsa256s   (even slower; trips the sandbox CPU watchdog — run on hardware)
+
+== encrypted-channel throughput (8 MiB payload) ==
+  none          500.00 MB/s     <- raw pipe ceiling (no ssl)
+  aes_256_cbc    68.96 MB/s
+  aes_128_cbc    72.72 MB/s
+  ideacbc        36.36 MB/s
+  ideaecb        44.19 MB/s
+```
+
+What the shape tells you (independent of the slow host):
+
+- **The handshake is dominated by the shared classical-DH-2048 + ML-KEM-768 key
+  agreement (~340 ms here), not the signature** — ed25519, ML-DSA-65/87, RSA and
+  DSA all land within ~10% of each other. ElGamal cert verify is visibly heavier
+  (~3×), and SLH-DSA is in a different league entirely (signing dominates, ~9 s+)
+  — fine as a conservative hash-based backup, not a default.
+- **keygen** is effectively free for ed25519/ML-DSA/SLH-DSA, seconds for RSA-2048
+  and DSA-1024 — so for those, generate the signer keyfile once and reuse it
+  (which `createsignerkey` / `serve-llm.sh` already do).
+- **Line encryption** costs ~7× vs plaintext on this build; AES-128 ≳ AES-256 >
+  IDEA. AES has no hardware path in this emu build, so a host with AES-NI wired
+  through would shift these substantially — another reason to measure on target.

--- a/tests/bench/bench_node.b
+++ b/tests/bench/bench_node.b
@@ -1,0 +1,291 @@
+implement BenchNode;
+
+#
+# Performance baselines for the node-to-node auth path.  Prints three tables:
+#
+#   1. keygen latency per certificate signature algorithm (one genSK)
+#   2. full STS handshake latency per algorithm (auth->client/server over a
+#      pipe, averaged over N iterations, reusing one keypair)
+#   3. encrypted-channel throughput per ssl cipher (MB/s pushing a fixed
+#      payload through a negotiated channel)
+#
+# Measured with sys->millisec() inside the emu (no host introspection).  These
+# are *baselines*: absolute numbers are environment-dependent (host speed, emu
+# build, JIT) -- the value is the relative cost between algorithms/ciphers and
+# a repeatable methodology.  Run on the target hardware for real figures.
+#
+# Usage:  bench_node [handshake_iters [throughput_MB]]
+#   handshake_iters  fast-alg handshake samples (default 10; SLH-DSA uses 2)
+#   throughput_MB    payload size per cipher in MiB (default 8)
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+BenchNode: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+stderr: ref Sys->FD;
+
+fail(s: string)
+{
+	sys->fprint(stderr, "bench_node: %s\n", s);
+	raise "fail:error";
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+Res: adt { owner: string; secret: array of byte; };
+
+authproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Res)
+{
+	(owner, secret) := kr->auth(fd, ai, 0);
+	c <-= ref Res(owner, secret);
+}
+
+# one raw STS handshake over a fresh pipe; returns elapsed ms, or -1 on failure
+handshakeOnce(a, b: ref Keyring->Authinfo): int
+{
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		return -1;
+	ca := chan of ref Res;
+	cb := chan of ref Res;
+	t0 := sys->millisec();
+	spawn authproc(fds[0], a, ca);
+	spawn authproc(fds[1], b, cb);
+	ra := <-ca;
+	rb := <-cb;
+	t1 := sys->millisec();
+	if(ra.secret == nil || rb.secret == nil)
+		return -1;
+	return t1 - t0;
+}
+
+algbits(alg: string): int
+{
+	case alg {
+	"rsa" => return 2048;
+	"dsa" => return 1024;
+	"elgamal" => return 2048;
+	* => return 0;	# ed25519 / ML-DSA / SLH-DSA ignore the size
+	}
+}
+
+isslow(alg: string): int
+{
+	return alg == "slhdsa192s" || alg == "slhdsa256s";
+}
+
+benchAlg(alg: string, signerpk: ref Keyring->PK, signersk: ref Keyring->SK,
+		alpha, p: ref Keyring->IPint, iters: int)
+{
+	# keygen: one sample (genSK of a fresh signer of this alg)
+	t0 := sys->millisec();
+	ksk := kr->genSK(alg, "bench", algbits(alg));
+	t1 := sys->millisec();
+	if(ksk == nil){
+		sys->print("  %-11s  genSK FAILED\n", alg);
+		return;
+	}
+
+	# handshake: reuse one (server, client) keypair derived from this signer
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cli := mkauthinfo(signersk, signerpk, alpha, p, "client");
+
+	n := iters;
+	if(isslow(alg) && n > 2)
+		n = 2;
+
+	tot := 0;
+	good := 0;
+	for(i := 0; i < n; i++){
+		ms := handshakeOnce(srv, cli);
+		if(ms >= 0){ tot += ms; good++; }
+	}
+	if(good == 0){
+		sys->print("  %-11s  keygen=%-6d handshake=FAILED\n", alg, t1-t0);
+		return;
+	}
+	sys->print("  %-11s  keygen=%-6d handshake_avg=%-6d ms  (n=%d)\n",
+		alg, t1-t0, tot/good, good);
+}
+
+# ---- throughput ----------------------------------------------------------
+
+drainproc(fd: ref Sys->FD, total: int, done: chan of int)
+{
+	buf := array[65536] of byte;
+	got := 0;
+	while(got < total){
+		m := sys->read(fd, buf, len buf);
+		if(m <= 0)
+			break;
+		got += m;
+	}
+	done <-= got;
+}
+
+# returns MB/s * 100 (fixed-point, 2 decimals) or -1
+throughputOnce(srv, cli: ref Keyring->Authinfo, cipher: string, total: int): int
+{
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		return -1;
+
+	# server side runs in a proc: authenticate, then drain `total` bytes.
+	# offer the matching algs; for "none" offer nil so the server accepts the
+	# client's unencrypted request rather than rejecting an unoffered cipher.
+	serverAlgs: list of string;
+	if(cipher != "none")
+		serverAlgs = cipher :: "sha256" :: nil;
+	rc := chan of (ref Sys->FD, string);
+	spawn serverWrap(fds[0], srv, serverAlgs, rc);
+
+	clientalg := cipher;
+	if(cipher != "none")
+		clientalg = cipher + " sha256";
+	(wc, cerr) := auth->client(clientalg, cli, fds[1]);
+	if(wc == nil)
+		return -1;
+	(ws, serr) := <-rc;
+	if(ws == nil)
+		return -1;
+
+	done := chan of int;
+	spawn drainproc(ws, total, done);
+
+	chunk := array[65536] of byte;
+	for(i := 0; i < len chunk; i++)
+		chunk[i] = byte i;
+
+	t0 := sys->millisec();
+	sent := 0;
+	while(sent < total){
+		n := total - sent;
+		if(n > len chunk)
+			n = len chunk;
+		if(sys->write(wc, chunk, n) != n)
+			return -1;
+		sent += n;
+	}
+	got := <-done;
+	t1 := sys->millisec();
+	if(got != total)
+		return -1;
+	dt := t1 - t0;
+	if(dt <= 0)
+		dt = 1;
+	# MB/s*100 = total bytes / dt(ms) * 1000 / 1048576 * 100
+	return (total / dt) * 100000 / 1048576;
+}
+
+serverWrap(fd: ref Sys->FD, ai: ref Keyring->Authinfo, algs: list of string,
+		rc: chan of (ref Sys->FD, string))
+{
+	(w, who) := auth->server(algs, ai, fd, 0);
+	rc <-= (w, who);
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	stderr = sys->fildes(2);
+	if(kr == nil || auth == nil)
+		fail(sys->sprint("load core modules: %r"));
+	if((e := auth->init()) != nil)
+		fail("auth init: " + e);
+
+	# mode: "all" (default), "lat" (keygen+handshake only), "tp" (throughput
+	# only).  SLH-DSA's signing is so slow it can trip a host CPU watchdog
+	# mid-run, so "tp" lets the throughput numbers be captured on their own.
+	mode := "all";
+	iters := 10;
+	tmib := 8;
+	args = tl args;
+	if(args != nil && (hd args == "all" || hd args == "lat" || hd args == "tp")){
+		mode = hd args; args = tl args;
+	}
+	if(args != nil){ iters = int hd args; args = tl args; }
+	if(args != nil){ tmib = int hd args; }
+
+	# shared DH group + an ed25519 signer for the throughput section
+	(alpha, p) := kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		fail("dhparams failed");
+
+	algs := array[] of {
+		"ed25519", "mldsa65", "mldsa87", "rsa", "dsa", "elgamal",
+		"slhdsa192s", "slhdsa256s"
+	};
+
+	i: int;
+	if(mode == "all" || mode == "lat"){
+		sys->print("== keygen + handshake latency (ms) ==\n");
+		for(i = 0; i < len algs; i++){
+			alg := algs[i];
+			sk := kr->genSK(alg, "signer", algbits(alg));
+			if(sk == nil){
+				sys->print("  %-11s  signer genSK FAILED\n", alg);
+				continue;
+			}
+			benchAlg(alg, kr->sktopk(sk), sk, alpha, p, iters);
+		}
+	}
+
+	if(mode == "all" || mode == "tp"){
+		sys->print("\n== encrypted-channel throughput (%d MiB payload) ==\n", tmib);
+		esk := kr->genSK("ed25519", "tp-signer", 0);
+		epk := kr->sktopk(esk);
+		srv := mkauthinfo(esk, epk, alpha, p, "server");
+		cli := mkauthinfo(esk, epk, alpha, p, "client");
+		total := tmib * 1048576;
+		ciphers := array[] of { "none", "aes_256_cbc", "aes_128_cbc", "ideacbc", "ideaecb" };
+		for(i = 0; i < len ciphers; i++){
+			c := ciphers[i];
+			mbps100 := throughputOnce(srv, cli, c, total);
+			if(mbps100 < 0)
+				sys->print("  %-12s  FAILED\n", c);
+			else
+				sys->print("  %-12s  %d.%2.2d MB/s\n", c, mbps100/100, mbps100%100);
+		}
+	}
+
+	sys->print("\nDONE\n");
+}

--- a/tests/cipher_matrix_test.b
+++ b/tests/cipher_matrix_test.b
@@ -1,0 +1,235 @@
+implement CipherMatrixTest;
+
+#
+# Line-encryption negotiation matrix for node-to-node sessions.
+#
+# pqauth_test / interop_test only exercise the default aes_256_cbc/sha256.
+# This sweeps every cipher and MAC the ssl device offers (devssl.c
+# encrypttab/hashtab) plus the unencrypted ("none") path, driving each through
+# a real auth->server / auth->client handshake and a data round-trip, and
+# asserting the payload survives byte-for-byte.
+#
+#   ciphers: aes_256_cbc, aes_128_cbc, ideacbc, ideaecb
+#   MACs:    sha256, sha1, md5, md4
+#   plus:    none (auth succeeds, no ssl pushed)
+#
+# Runs over a pipe (no TCP ports needed); each case has a timeout safety net.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+CipherMatrixTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/cipher_matrix_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+byteseq(a, b: array of byte): int
+{
+	if(len a != len b)
+		return 0;
+	for(i := 0; i < len a; i++)
+		if(a[i] != b[i])
+			return 0;
+	return 1;
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+# shared signer + (server, client) Authinfos, generated once
+signerpk: ref Keyring->PK;
+alpha, p: ref Keyring->IPint;
+
+setup(): (ref Keyring->Authinfo, ref Keyring->Authinfo)
+{
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cli := mkauthinfo(signersk, signerpk, alpha, p, "client");
+	return (srv, cli);
+}
+
+# signer state is module-global so every case shares one trust root
+signersk: ref Keyring->SK;
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# server half: authenticate, push the offered ssl, read `expect` bytes, and
+# report whether they match the canonical payload.
+serverside(fd: ref Sys->FD, ai: ref Keyring->Authinfo, algs: list of string,
+		expect: int, rc: chan of (int, string))
+{
+	(wrapped, who) := auth->server(algs, ai, fd, 0);
+	if(wrapped == nil){
+		rc <-= (0, "server auth failed: " + who);
+		return;
+	}
+	buf := array[expect] of byte;
+	n := readn(wrapped, buf, expect);
+	if(n != expect){
+		rc <-= (0, sys->sprint("short read %d != %d", n, expect));
+		return;
+	}
+	ok := 1;
+	for(i := 0; i < expect; i++)
+		if(int buf[i] != ('A' + (i % 26)))
+			ok = 0;
+	rc <-= (ok, nil);
+}
+
+# Drive one (serverAlgs, clientAlg) negotiation and assert a 256-byte payload
+# round-trips intact across the negotiated channel.
+roundtrip(t: ref T, label: string, serverAlgs: list of string, clientAlg: string)
+{
+	(srv, cli) := setup();
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	rc := chan of (int, string);
+	spawn serverside(fds[0], srv, serverAlgs, 256, rc);
+
+	(wrapped, cerr) := auth->client(clientAlg, cli, fds[1]);
+	if(wrapped == nil)
+		t.fatal(label + ": client auth failed: " + cerr);
+
+	msg := array[256] of byte;
+	for(i := 0; i < len msg; i++)
+		msg[i] = byte ('A' + (i % 26));
+	if(sys->write(wrapped, msg, len msg) != len msg)
+		t.fatal(sys->sprint("%s: encrypted write failed: %r", label));
+
+	tmo := chan of int;
+	spawn timerproc(tmo, 15000);
+	ok: int;
+	serr: string;
+	alt {
+	(rok, re) := <-rc => ok = rok; serr = re;
+	<-tmo => t.fatal(label + ": server hung (timeout)");
+	}
+	if(serr != nil)
+		t.fatal(label + ": " + serr);
+	t.assert(ok != 0, label + ": payload survives the negotiated channel intact");
+	t.log(sys->sprint("%s: 256 bytes round-tripped", label));
+}
+
+# ---- cipher sweep (sha256 MAC) ----
+testAes256(t: ref T)  { roundtrip(t, "aes_256_cbc/sha256", "aes_256_cbc"::"sha256"::nil, "aes_256_cbc sha256"); }
+testAes128(t: ref T)  { roundtrip(t, "aes_128_cbc/sha256", "aes_128_cbc"::"sha256"::nil, "aes_128_cbc sha256"); }
+testIdeaCbc(t: ref T) { roundtrip(t, "ideacbc/sha256", "ideacbc"::"sha256"::nil, "ideacbc sha256"); }
+testIdeaEcb(t: ref T) { roundtrip(t, "ideaecb/sha256", "ideaecb"::"sha256"::nil, "ideaecb sha256"); }
+
+# ---- MAC sweep (aes_256_cbc cipher) ----
+testSha1(t: ref T) { roundtrip(t, "aes_256_cbc/sha1", "aes_256_cbc"::"sha1"::nil, "aes_256_cbc sha1"); }
+testMd5(t: ref T)  { roundtrip(t, "aes_256_cbc/md5", "aes_256_cbc"::"md5"::nil, "aes_256_cbc md5"); }
+testMd4(t: ref T)  { roundtrip(t, "aes_256_cbc/md4", "aes_256_cbc"::"md4"::nil, "aes_256_cbc md4"); }
+
+# ---- unencrypted path ----
+testNone(t: ref T) { roundtrip(t, "none", nil, "none"); }
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil)
+		raise "fail:cannot load auth";
+	if((e := auth->init()) != nil){
+		sys->fprint(sys->fildes(2), "auth init: %s\n", e);
+		raise "fail:auth init";
+	}
+
+	# one shared trust root for every case
+	signersk = kr->genSK("ed25519", "matrix-signer", 0);
+	if(signersk == nil){
+		sys->fprint(sys->fildes(2), "genSK signer: %r\n");
+		raise "fail:genSK";
+	}
+	signerpk = kr->sktopk(signersk);
+	(alpha, p) = kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		raise "fail:dhparams";
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("Aes256Sha256", testAes256);
+	run("Aes128Sha256", testAes128);
+	run("IdeaCbcSha256", testIdeaCbc);
+	run("IdeaEcbSha256", testIdeaEcb);
+	run("Aes256Sha1", testSha1);
+	run("Aes256Md5", testMd5);
+	run("Aes256Md4", testMd4);
+	run("NoEncryption", testNone);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/concurrent_auth_test.b
+++ b/tests/concurrent_auth_test.b
@@ -1,0 +1,226 @@
+implement ConcurrentAuthTest;
+
+#
+# Concurrency correctness: many legitimate clients authenticating to ONE server
+# at the same time must each get their OWN data back -- no cross-talk between
+# connections, no races in the shared auth + ssl machinery, no hang/crash.
+#
+# The server is spawn-per-connection (like node_server.b) and shares one
+# Authinfo across all handlers; every client shares one Authinfo too -- the
+# realistic case (a node has one keyfile, many simultaneous peers).  Each
+# client sends a 4 KiB payload whose every byte is a function of its client
+# index and echoes it back; the client asserts the echo equals exactly what it
+# sent.  A mixed-up connection (wrong secret / shared ssl state) would corrupt
+# the echo and fail.
+#
+# Skips cleanly where the host has no IP stack.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+ConcurrentAuthTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/concurrent_auth_test.b";
+
+NCLIENTS: con 12;
+MSGLEN:   con 4096;
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# distinct 4 KiB payload for a client index
+payload(index: int): array of byte
+{
+	a := array[MSGLEN] of byte;
+	for(j := 0; j < MSGLEN; j++)
+		a[j] = byte ((index * 7 + j) & 16rff);
+	return a;
+}
+
+# server: accept forever, spawn a per-connection echo handler
+server(ac: Sys->Connection, ai: ref Keyring->Authinfo)
+{
+	for(;;){
+		(lok, nc) := sys->listen(ac);
+		if(lok < 0)
+			return;
+		dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+		if(dfd == nil)
+			continue;
+		spawn serve(ai, dfd);
+	}
+}
+
+serve(ai: ref Keyring->Authinfo, dfd: ref Sys->FD)
+{
+	(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, dfd, 0);
+	if(wrapped == nil)
+		return;
+	buf := array[MSGLEN] of byte;
+	if(readn(wrapped, buf, MSGLEN) == MSGLEN)
+		sys->write(wrapped, buf, MSGLEN);	# echo this connection's own bytes
+}
+
+# client: dial, auth, send its distinct payload, verify the echo is identical.
+# reports its index on success, or -1 on any failure.
+clientproc(addr: string, ai: ref Keyring->Authinfo, index: int, rc: chan of int)
+{
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){ rc <-= -1; return; }
+	(wrapped, nil) := auth->client("aes_256_cbc sha256", ai, dc.dfd);
+	if(wrapped == nil){ rc <-= -1; return; }
+
+	msg := payload(index);
+	if(sys->write(wrapped, msg, len msg) != len msg){ rc <-= -1; return; }
+
+	echo := array[MSGLEN] of byte;
+	if(readn(wrapped, echo, MSGLEN) != MSGLEN){ rc <-= -1; return; }
+	for(j := 0; j < MSGLEN; j++)
+		if(echo[j] != msg[j]){ rc <-= -1; return; }	# cross-talk / corruption
+	rc <-= index;
+}
+
+testConcurrentAuth(t: ref T)
+{
+	signersk := kr->genSK("ed25519", "conc-signer", 0);
+	if(signersk == nil)
+		t.fatal(sys->sprint("genSK: %r"));
+	signerpk := kr->sktopk(signersk);
+	(alpha, p) := kr->dhparams(2048);
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cli := mkauthinfo(signersk, signerpk, alpha, p, "client");
+
+	addr := "tcp!127.0.0.1!19630";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+	spawn server(ac, srv);
+
+	# launch all clients (near-)simultaneously
+	rc := chan of int;
+	i: int;
+	for(i = 0; i < NCLIENTS; i++)
+		spawn clientproc(addr, cli, i, rc);
+
+	tmo := chan of int;
+	spawn timerproc(tmo, 30000);
+
+	seen := array[NCLIENTS] of { * => 0 };
+	ok := 0;
+	bad := 0;
+	for(got := 0; got < NCLIENTS;){
+		alt {
+		idx := <-rc =>
+			got++;
+			if(idx < 0)
+				bad++;
+			else { seen[idx]++; ok++; }
+		<-tmo =>
+			t.fatal(sys->sprint("only %d/%d clients finished (deadlock/hang under concurrency)", got, NCLIENTS));
+		}
+	}
+
+	t.asserteq(ok, NCLIENTS, "all concurrent clients authenticated and got their own data back");
+	t.asserteq(bad, 0, "no client saw a corrupted / cross-talked echo");
+	dups := 0;
+	miss := 0;
+	for(i = 0; i < NCLIENTS; i++){
+		if(seen[i] > 1) dups++;
+		if(seen[i] == 0) miss++;
+	}
+	t.asserteq(dups, 0, "no client index completed twice");
+	t.asserteq(miss, 0, "every client index completed exactly once");
+	t.log(sys->sprint("%d concurrent authenticated echo sessions, no cross-talk", NCLIENTS));
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil)
+		raise "fail:cannot load auth";
+	auth->init();
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("ConcurrentAuth", testConcurrentAuth);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/crypto_props_test.b
+++ b/tests/crypto_props_test.b
@@ -1,0 +1,309 @@
+implement CryptoPropsTest;
+
+#
+# Cryptographic-property tests for the node auth handshake -- the security
+# guarantees the protocol is supposed to provide, asserted directly:
+#
+#   - SecretUniqueness   two handshakes with the SAME certificates derive
+#                        DIFFERENT 64-byte session secrets (ephemeral DH +
+#                        ML-KEM => a forward-secrecy proxy: a reused long-term
+#                        key never yields a reused session key), and both peers
+#                        independently agree on the same secret each time
+#   - ReplayRejected     a reflection (the peer's own alpha**r0 echoed back as
+#                        the response) is caught by the protocol's replay check
+#                        ("possible replay attack"), not turned into a session
+#   - CorruptedCert      a single flipped byte in an otherwise-valid identity
+#                        certificate's signature is rejected ("pk doesn't match
+#                        certificate"); the handshake fails closed
+#
+# Runs over pipes; each case has a timeout safety net.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+CryptoPropsTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/crypto_props_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+byteseq(a, b: array of byte): int
+{
+	if(len a != len b)
+		return 0;
+	for(i := 0; i < len a; i++)
+		if(a[i] != b[i])
+			return 0;
+	return 1;
+}
+
+allzero(a: array of byte): int
+{
+	for(i := 0; i < len a; i++)
+		if(a[i] != byte 0)
+			return 0;
+	return 1;
+}
+
+contains(hay, needle: string): int
+{
+	n := len needle;
+	if(n == 0)
+		return 1;
+	for(i := 0; i + n <= len hay; i++)
+		if(hay[i:i+n] == needle)
+			return 1;
+	return 0;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+newsigner(t: ref T): (ref Keyring->SK, ref Keyring->PK)
+{
+	sk := kr->genSK("ed25519", "props-signer", 0);
+	if(sk == nil)
+		t.fatal(sys->sprint("genSK signer: %r"));
+	return (sk, kr->sktopk(sk));
+}
+
+dhgroup(t: ref T): (ref Keyring->IPint, ref Keyring->IPint)
+{
+	(alpha, p) := kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		t.fatal("dhparams failed");
+	return (alpha, p);
+}
+
+Result: adt {
+	owner:	string;
+	secret:	array of byte;
+};
+
+authproc(fd: ref Sys->FD, ai: ref Keyring->Authinfo, c: chan of ref Result)
+{
+	(owner, secret) := kr->auth(fd, ai, 0);
+	c <-= ref Result(owner, secret);
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# kr->auth on both ends of a fresh pipe; returns both Results, or (nil,nil) on timeout
+runHandshake(t: ref T, a, b: ref Keyring->Authinfo, ms: int): (ref Result, ref Result)
+{
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+	ca := chan of ref Result;
+	cb := chan of ref Result;
+	tmo := chan of int;
+	spawn authproc(fds[0], a, ca);
+	spawn authproc(fds[1], b, cb);
+	spawn timerproc(tmo, ms);
+	ra, rb: ref Result;
+	for(got := 0; got < 2;){
+		alt {
+		r := <-ca => ra = r; got++;
+		r := <-cb => rb = r; got++;
+		<-tmo => return (nil, nil);
+		}
+	}
+	return (ra, rb);
+}
+
+# ---- SecretUniqueness ----------------------------------------------------
+
+testSecretUniqueness(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	alice := mkauthinfo(sk, pk, alpha, p, "alice");
+	bob := mkauthinfo(sk, pk, alpha, p, "bob");
+
+	(a1, b1) := runHandshake(t, alice, bob, 15000);
+	if(a1 == nil || b1 == nil)
+		t.fatal("handshake 1 hung (timeout)");
+	(a2, b2) := runHandshake(t, alice, bob, 15000);
+	if(a2 == nil || b2 == nil)
+		t.fatal("handshake 2 hung (timeout)");
+
+	if(a1.secret == nil || b1.secret == nil || a2.secret == nil || b2.secret == nil)
+		t.fatal("a handshake failed to derive a secret");
+
+	t.asserteq(len a1.secret, 64, "session secret is 64 bytes (SHA3-512)");
+	t.assert(!allzero(a1.secret), "session secret is non-zero");
+	t.assert(byteseq(a1.secret, b1.secret), "run 1: both peers derive the same secret");
+	t.assert(byteseq(a2.secret, b2.secret), "run 2: both peers derive the same secret");
+	t.assert(!byteseq(a1.secret, a2.secret),
+		"two handshakes with the same certs derive DIFFERENT secrets (ephemeral key agreement)");
+}
+
+# ---- ReplayRejected ------------------------------------------------------
+
+# Echo everything the peer sends straight back to it, so its own alpha**r0
+# returns as the "response".  A read-blocked echo over a full-duplex pipe end.
+reflector(fd: ref Sys->FD, done: chan of int)
+{
+	buf := array[8192] of byte;
+	for(;;){
+		n := sys->read(fd, buf, len buf);
+		if(n <= 0)
+			break;
+		if(sys->write(fd, buf[0:n], n) != n)
+			break;
+	}
+	done <-= 1;
+}
+
+testReplayRejected(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	alice := mkauthinfo(sk, pk, alpha, p, "alice");
+
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		t.fatal(sys->sprint("pipe failed: %r"));
+
+	rdone := chan[1] of int;
+	spawn reflector(fds[1], rdone);
+
+	cr := chan of ref Result;
+	spawn authproc(fds[0], alice, cr);
+	tmo := chan of int;
+	spawn timerproc(tmo, 15000);
+
+	alt {
+	r := <-cr =>
+		t.assert(r.secret == nil, "a reflected handshake must NOT yield a session secret");
+		t.assert(contains(r.owner, "replay"),
+			sys->sprint("reflection rejected as a replay (got %q)", r.owner));
+	<-tmo =>
+		t.fatal("peer hung on a reflected handshake");
+	}
+}
+
+# ---- CorruptedCert -------------------------------------------------------
+
+# Flip the last base64 character of a serialised certificate to a different
+# valid base64 character: keeps the structure parseable but changes the
+# decoded signature bytes, so verification must fail.
+corruptB64(s: string): string
+{
+	a := array of byte s;
+	for(i := len a - 1; i >= 0; i--){
+		c := int a[i];
+		isb64 := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			 (c >= '0' && c <= '9') || c == '+' || c == '/';
+		if(isb64){
+			if(c == 'A')
+				a[i] = byte 'B';
+			else
+				a[i] = byte 'A';
+			return string a;
+		}
+	}
+	return string a;
+}
+
+testCorruptedCert(t: ref T)
+{
+	(alpha, p) := dhgroup(t);
+	(sk, pk) := newsigner(t);
+	alice := mkauthinfo(sk, pk, alpha, p, "alice");
+	bob := mkauthinfo(sk, pk, alpha, p, "bob");
+
+	# corrupt bob's identity certificate signature, keeping it parseable
+	cs := kr->certtostr(bob.cert);
+	bad := kr->strtocert(corruptB64(cs));
+	if(bad == nil)
+		t.fatal("strtocert of the corrupted cert returned nil (corruption broke parsing, not the test intent)");
+	bob.cert = bad;
+
+	(ra, rb) := runHandshake(t, alice, bob, 15000);
+	if(ra == nil || rb == nil)
+		t.fatal("handshake hung (timeout)");
+
+	# alice verifies bob's (corrupted) cert against the trusted signer key and
+	# must reject it; the handshake fails closed.
+	t.assert(ra.secret == nil, "a one-byte-corrupted certificate is rejected (no secret derived)");
+	t.assert(contains(ra.owner, "certificate") || contains(ra.owner, "match"),
+		sys->sprint("rejection cites the bad certificate (got %q)", ra.owner));
+}
+
+# ---- entry point ---------------------------------------------------------
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth != nil)
+		auth->init();
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("SecretUniqueness", testSecretUniqueness);
+	run("ReplayRejected", testReplayRejected);
+	run("CorruptedCert", testCorruptedCert);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/handshake_fuzz_test.b
+++ b/tests/handshake_fuzz_test.b
@@ -1,0 +1,269 @@
+implement HandshakeFuzzTest;
+
+#
+# Handshake wire fuzzing (receiver robustness): a hostile client connects and
+# sends malformed handshake bytes, then drops the connection.  The server's
+# auth->server must FAIL CLOSED on every input -- return an error, never derive
+# a secret, never crash, never hang.  This is the remote-protocol-attacker
+# property (threat-model #2): a peer feeding garbage must not be able to wedge,
+# crash, or fool the node.
+#
+# Real loopback TCP (so the malformed stream and its close behave exactly as on
+# the wire), driving the production auth->server directly.  pqauth_test already
+# covers two MITM negatives (flipped / truncated ML-KEM key mid-handshake);
+# this sweeps a family of malformed *inbound* streams against the server.
+#
+# Each case is timeout-guarded so a HANG is reported as a failure.  Skips
+# cleanly where the host has no IP stack.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+HandshakeFuzzTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/handshake_fuzz_test.b";
+
+# server outcome codes
+CLEAN, ACCEPTED, CRASHED: con iota;	# 0 errored cleanly, 1 wrongly succeeded, 2 raised
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# server: accept one connection, run auth->server, report the outcome.  A
+# wrapped exception handler guarantees a crash is reported, not silently lost.
+serveOnce(ai: ref Keyring->Authinfo, dfd: ref Sys->FD, rc: chan of int)
+{
+	outcome := CLEAN;
+	{
+		(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, dfd, 0);
+		if(wrapped != nil)
+			outcome = ACCEPTED;
+	} exception {
+	"*" =>
+		outcome = CRASHED;
+	}
+	rc <-= outcome;
+}
+
+server(ac: Sys->Connection, ai: ref Keyring->Authinfo, rc: chan of int)
+{
+	for(;;){
+		(lok, nc) := sys->listen(ac);
+		if(lok < 0)
+			return;
+		dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+		if(dfd == nil)
+			continue;
+		spawn serveOnce(ai, dfd, rc);
+	}
+}
+
+# hostile client: dial, write the malformed stream, drop the connection.
+attacker(addr: string, data: array of byte)
+{
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0)
+		return;
+	if(len data > 0)
+		sys->write(dc.dfd, data, len data);
+	# returning drops dc -> socket closes, server sees the bytes then EOF
+}
+
+frame(len4: int, payload: array of byte): array of byte
+{
+	hdr := array of byte sys->sprint("%4.4d\n", len4);
+	out := array[len hdr + len payload] of byte;
+	out[0:] = hdr;
+	out[len hdr:] = payload;
+	return out;
+}
+
+# deterministic pseudo-random fill
+fill(n, seed: int): array of byte
+{
+	a := array[n] of byte;
+	s := seed;
+	for(i := 0; i < n; i++){
+		s = (s * 1103515245 + 12345) & 16r7fffffff;
+		a[i] = byte (s >> 16);
+	}
+	return a;
+}
+
+# build malformed inbound stream `i`; returns (name, bytes) or (nil, nil) past the end
+fuzzcase(i: int): (string, array of byte)
+{
+	case i {
+	0 =>
+		return ("empty", array[0] of byte);
+	1 =>
+		return ("garbage-512", fill(512, 1));
+	2 =>
+		return ("nonnumeric-header", array of byte "abcd\nhello world padding bytes here");
+	3 =>		# claims 100 bytes, sends 10, then closes (truncated payload)
+		return ("truncated-payload", frame(100, fill(10, 3)));
+	4 =>		# claims 9000 bytes, sends 32, then closes (under-delivered)
+		return ("underdelivered-len", frame(9000, fill(32, 4)));
+	5 =>		# many zero-length frames then close
+		{
+			z := array of byte "";
+			out := array[0] of byte;
+			for(k := 0; k < 64; k++)
+				out = concat(out, frame(0, z));
+			return ("zerolen-flood", out);
+		}
+	6 =>
+		return ("partial-header", array of byte "01");	# 2 bytes then close
+	7 =>		# a plausible version frame, then garbage where alpha**r0 goes
+		return ("garbage-after-version", concat(frame(1, array of byte "2"), frame(64, fill(64, 7))));
+	8 =>		# well-formed framing, but every payload byte is 0xff
+		{
+			ff := array[200] of byte;
+			for(k := 0; k < len ff; k++) ff[k] = byte 16rff;
+			return ("allones-frames", concat(frame(200, ff), frame(200, ff)));
+		}
+	* =>
+		return (nil, nil);
+	}
+}
+
+concat(a, b: array of byte): array of byte
+{
+	out := array[len a + len b] of byte;
+	out[0:] = a;
+	out[len a:] = b;
+	return out;
+}
+
+testFuzz(t: ref T)
+{
+	signersk := kr->genSK("ed25519", "fuzz-signer", 0);
+	if(signersk == nil)
+		t.fatal(sys->sprint("genSK: %r"));
+	signerpk := kr->sktopk(signersk);
+	(alpha, p) := kr->dhparams(2048);
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "server");
+
+	addr := "tcp!127.0.0.1!19660";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+	rc := chan of int;
+	spawn server(ac, srv, rc);
+
+	hangs := 0;
+	accepts := 0;
+	crashes := 0;
+	total := 0;
+	for(i := 0; ; i++){
+		(name, data) := fuzzcase(i);
+		if(name == nil)
+			break;
+		total++;
+		spawn attacker(addr, data);
+
+		tmo := chan of int;
+		spawn timerproc(tmo, 15000);
+		alt {
+		outcome := <-rc =>
+			case outcome {
+			ACCEPTED =>
+				accepts++;
+				t.log(sys->sprint("%s: server ACCEPTED malformed input (derived a secret!)", name));
+			CRASHED =>
+				crashes++;
+				t.log(sys->sprint("%s: server auth->server raised an exception", name));
+			* =>
+				; # clean error -- good
+			}
+		<-tmo =>
+			hangs++;
+			t.log(sys->sprint("%s: server hung (no result within timeout)", name));
+		}
+	}
+
+	t.asserteq(accepts, 0, "no malformed inbound stream is accepted as a valid handshake");
+	t.asserteq(crashes, 0, "no malformed inbound stream crashes auth->server");
+	t.asserteq(hangs, 0, "no malformed inbound stream hangs the server");
+	t.log(sys->sprint("fuzzed %d malformed inbound streams: all failed closed cleanly", total));
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil)
+		raise "fail:cannot load auth";
+	auth->init();
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("HandshakeFuzz", testFuzz);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/interop/run-mount-auth.sh
+++ b/tests/interop/run-mount-auth.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Real production-path node-auth test: exercises the actual CLI + on-disk
+# keyfile flow that nodes use, not the in-emu auth->client/server shortcut.
+#
+# For each signer algorithm it runs, inside one emu over loopback:
+#   auth/createsignerkey -a <alg> -f <keyfile>      (writes a signer keyfile)
+#   styxlisten -a aes_256_cbc -a sha256 -k <keyfile> tcp!*!PORT export /lib
+#                                                   (cert-auth + ssl server)
+#   mount -k <keyfile> -C 'aes_256_cbc sha256' tcp!127.0.0.1!PORT /n/remote
+#                                                   (cert-auth + ssl client)
+# then reads a file through the encrypted mount and cmp's it byte-for-byte.
+#
+# Also checks enforcement: an anonymous `mount -A` against the cert-requiring
+# server must be rejected.
+#
+# The same path backs `mount -k <keyfile> tcp!host!5640 /mnt/llm` against the
+# headless LLM daemon (serve-llm.sh).
+#
+# Usage:  run-mount-auth.sh [alg ...]      (default: ed25519 mldsa65)
+# Exit:   0 = all pass, 1 = a failure, 2 = skipped (no emu)
+#
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ALGS=("$@"); [ ${#ALGS[@]} -eq 0 ] && ALGS=(ed25519 mldsa65)
+
+EMU=""
+for c in "$ROOT/emu/Linux/o.emu" "$ROOT/emu/MacOSX/o.emu"; do
+	[ -x "$c" ] && { EMU="$c"; break; }
+done
+[ -n "$EMU" ] || { echo "run-mount-auth: no emu binary under $ROOT" >&2; exit 2; }
+
+mkdir -p "$ROOT/tmp" "$ROOT/n"
+XFER="/ndb/inferno"          # a stable file present under /lib
+SRC="$ROOT/lib$XFER"
+rc_run() {                   # $1 = rc text  -> emu stdout (137-at-teardown ignored)
+	local rc="$ROOT/tmp/mountauth-$$.rc"
+	printf '%s\n' "$1" > "$rc"
+	timeout 90 "$EMU" -c1 -r"$ROOT" /dis/sh.dis "/tmp/$(basename "$rc")" 2>&1
+	rm -f "$rc"
+}
+
+fails=0
+port=19650
+
+for alg in "${ALGS[@]}"; do
+	port=$((port+1))
+	key="/tmp/mauth-$port"
+	pulled="/tmp/mauth-pulled-$port"
+	mnt="/n/mauth$port"
+	mkdir -p "$ROOT$mnt"        # mountpoint must exist in the emu namespace
+	out="$(rc_run "load std
+if {auth/createsignerkey -a $alg -f $key mauthowner} {echo KEY-OK} {echo KEY-FAIL; raise 'fail:key'}
+styxlisten -a aes_256_cbc -a sha256 -k $key tcp!*!$port export /lib &
+sleep 2
+if {mount -k $key -C 'aes_256_cbc sha256' tcp!127.0.0.1!$port $mnt} {echo MOUNT-OK} {echo MOUNT-FAIL; raise 'fail:mount'}
+if {cp $mnt$XFER $pulled} {echo COPY-OK} {echo COPY-FAIL; raise 'fail:copy'}
+if {cmp $pulled /lib$XFER} {echo MOUNTAUTH-PASS-$alg} {echo MOUNTAUTH-DIFF-$alg}")"
+	if echo "$out" | grep -q "MOUNTAUTH-PASS-$alg"; then
+		echo "PASS: mount -k over $alg cert auth + ssl + styx (file verified)"
+	else
+		echo "FAIL: $alg mount-auth path:"; echo "$out" | grep -vE '^fs:|^$' | sed 's/^/    /'
+		fails=$((fails+1))
+	fi
+done
+
+# enforcement: an anonymous mount against a cert-requiring server is rejected
+port=$((port+1))
+key="/tmp/mauth-neg-$port"
+out="$(rc_run "load std
+auth/createsignerkey -a ed25519 -f $key mauthowner
+styxlisten -a aes_256_cbc -a sha256 -k $key tcp!*!$port export /lib &
+sleep 2
+if {mount -A tcp!127.0.0.1!$port /n/manon$port} {echo ANON-ACCEPTED-BAD} {echo ANON-REJECTED-GOOD}")"
+if echo "$out" | grep -q "ANON-REJECTED-GOOD"; then
+	echo "PASS: anonymous mount against a cert-requiring server is rejected"
+else
+	echo "FAIL: server did not enforce auth:"; echo "$out" | grep -vE '^fs:|^$' | sed 's/^/    /'
+	fails=$((fails+1))
+fi
+
+[ "$fails" -eq 0 ] && { echo "ALL MOUNT-AUTH CHECKS PASSED"; exit 0; } || exit 1

--- a/tests/interrupt_test.b
+++ b/tests/interrupt_test.b
@@ -1,0 +1,256 @@
+implement InterruptTest;
+
+#
+# Interruptibility: an abrupt connection drop during the auth handshake or
+# during an encrypted data transfer must make the peer fail/EOF cleanly --
+# never crash, never hang forever.  Uses real TCP sockets (loopback); the
+# "disconnect" is dropping every reference to the socket so it closes and the
+# OS delivers the hangup to the peer.  Each case has a timeout safety net so a
+# HANG is reported as a failure rather than wedging the suite.
+#
+#   - DropMidHandshake   the peer aborts the connection part-way through the
+#                        handshake; the other side's auth must return an error
+#                        (not block)
+#   - DropMidTransfer    the writer aborts after a successful handshake, part
+#                        way through a transfer; the reader must hit EOF and
+#                        stop with the partial data (not block, not crash)
+#
+# Skips cleanly where the host has no IP stack.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+InterruptTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/interrupt_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+setup(t: ref T): (ref Keyring->Authinfo, ref Keyring->Authinfo)
+{
+	signersk := kr->genSK("ed25519", "intr-signer", 0);
+	if(signersk == nil)
+		t.fatal(sys->sprint("genSK: %r"));
+	signerpk := kr->sktopk(signersk);
+	(alpha, p) := kr->dhparams(2048);
+	srv := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cli := mkauthinfo(signersk, signerpk, alpha, p, "client");
+	return (srv, cli);
+}
+
+# ---- DropMidHandshake ----------------------------------------------------
+
+# Accept a connection, read a little of the peer's handshake, then drop the
+# socket (return) so it closes mid-handshake.
+abortingServer(ac: Sys->Connection, ready: chan of int)
+{
+	ready <-= 1;
+	(lok, nc) := sys->listen(ac);
+	if(lok < 0)
+		return;
+	dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil)
+		return;
+	buf := array[64] of byte;
+	sys->read(dfd, buf, len buf);	# consume a bit, then drop dfd -> close
+}
+
+clientAuthProc(dfd: ref Sys->FD, ai: ref Keyring->Authinfo, rc: chan of string)
+{
+	(wrapped, err) := auth->client("aes_256_cbc sha256", ai, dfd);
+	if(wrapped == nil)
+		rc <-= "err:" + err;	# clean failure (expected)
+	else
+		rc <-= "ok";		# unexpectedly succeeded
+}
+
+testDropMidHandshake(t: ref T)
+{
+	(nil, cli) := setup(t);
+
+	addr := "tcp!127.0.0.1!19620";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+	ready := chan of int;
+	spawn abortingServer(ac, ready);
+	<-ready;
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){
+		t.skip(sys->sprint("dial failed: %r"));
+		return;
+	}
+
+	rc := chan of string;
+	spawn clientAuthProc(dc.dfd, cli, rc);
+	tmo := chan of int;
+	spawn timerproc(tmo, 15000);
+
+	alt {
+	r := <-rc =>
+		t.assertsne(r, "ok", "client auth must fail (not succeed) when the peer drops mid-handshake");
+		t.assert(r != "ok", "client returns a clean error on mid-handshake disconnect");
+		t.log(sys->sprint("client result: %s", r));
+	<-tmo =>
+		t.fatal("client hung on a mid-handshake disconnect (should error within the timeout)");
+	}
+}
+
+# ---- DropMidTransfer -----------------------------------------------------
+
+# Authenticate, then read the encrypted channel until EOF, reporting how many
+# bytes arrived before the writer vanished.
+drainingServer(ac: Sys->Connection, ai: ref Keyring->Authinfo, rc: chan of int)
+{
+	(lok, nc) := sys->listen(ac);
+	if(lok < 0){ rc <-= -1; return; }
+	dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil){ rc <-= -1; return; }
+	(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, dfd, 0);
+	if(wrapped == nil){ rc <-= -1; return; }
+
+	buf := array[65536] of byte;
+	got := 0;
+	for(;;){
+		n := sys->read(wrapped, buf, len buf);
+		if(n <= 0)
+			break;		# EOF / error when the writer aborts
+		got += n;
+	}
+	rc <-= got;			# reaching here means we did NOT hang
+}
+
+testDropMidTransfer(t: ref T)
+{
+	(srv, cli) := setup(t);
+
+	addr := "tcp!127.0.0.1!19621";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("network unavailable: %r"));
+		return;
+	}
+	rc := chan of int;
+	spawn drainingServer(ac, srv, rc);
+
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0){
+		t.skip(sys->sprint("dial failed: %r"));
+		return;
+	}
+
+	(wrapped, cerr) := auth->client("aes_256_cbc sha256", cli, dc.dfd);
+	if(wrapped == nil)
+		t.fatal("client auth failed: " + cerr);
+
+	# write a partial transfer (3 x 64 KiB) of an intended-much-larger stream
+	chunk := array[65536] of byte;
+	for(i := 0; i < len chunk; i++)
+		chunk[i] = byte i;
+	partial := 0;
+	for(k := 0; k < 3; k++){
+		if(sys->write(wrapped, chunk, len chunk) != len chunk)
+			break;
+		partial += len chunk;
+	}
+
+	# abrupt disconnect: drop every reference to the socket so it closes and
+	# the server's read sees EOF.
+	wrapped = nil;
+	dc.dfd = nil;
+	dc.cfd = nil;
+
+	tmo := chan of int;
+	spawn timerproc(tmo, 15000);
+	alt {
+	got := <-rc =>
+		t.assert(got >= 0, "server returned (did not hang) after a mid-transfer disconnect");
+		t.assert(got <= partial, "server received at most the bytes actually sent before the drop");
+		t.log(sys->sprint("server drained %d of %d sent bytes, then EOF cleanly", got, partial));
+	<-tmo =>
+		t.fatal("server hung reading after a mid-transfer disconnect (should EOF within the timeout)");
+	}
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil)
+		raise "fail:cannot load auth";
+	auth->init();
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("DropMidHandshake", testDropMidHandshake);
+	run("DropMidTransfer", testDropMidTransfer);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -58,6 +58,7 @@ TARG=\
 	cipher_matrix_test.dis\
 	crypto_props_test.dis\
 	interrupt_test.dis\
+	concurrent_auth_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -54,6 +54,7 @@ TARG=\
 	pdf_test.dis\
 	pqauth_test.dis\
 	interop_test.dis\
+	authneg_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -55,6 +55,7 @@ TARG=\
 	pqauth_test.dis\
 	interop_test.dis\
 	authneg_test.dis\
+	cipher_matrix_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -59,6 +59,7 @@ TARG=\
 	crypto_props_test.dis\
 	interrupt_test.dis\
 	concurrent_auth_test.dis\
+	handshake_fuzz_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -57,6 +57,7 @@ TARG=\
 	authneg_test.dis\
 	cipher_matrix_test.dis\
 	crypto_props_test.dis\
+	interrupt_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -56,6 +56,7 @@ TARG=\
 	interop_test.dis\
 	authneg_test.dis\
 	cipher_matrix_test.dis\
+	crypto_props_test.dis\
 	regex_test.dis\
 	render_registry_test.dis\
 	runner.dis\

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,0 +1,67 @@
+# Node-auth stress / leak / DoS harness (hardware-run)
+
+These assets stress the node-to-node authentication path under load. They are
+**deliberately not wired into the auto-discovered test suite** (`tests/mkfile`
+/ `tests/runner.dis`): they run for a long time, churn many TCP connections,
+and are meant to be driven by hand on real hardware where their result is
+trustworthy.
+
+> **Sandbox caveat (read this first).** In the CI / cloud sandbox these were
+> authored in, the host **SIGKILLs the emu process** once a per-session
+> CPU/time budget is exhausted — a long churn run dies with exit 137 partway
+> through, and eventually even a trivial test is killed at exit. There was
+> **no OOM** (`dmesg` clean, RAM free) and the thread/proc count stayed flat,
+> so those deaths are a *sandbox watchdog*, **not** an InferNode leak or
+> crash. Host RSS introspection is also unreliable there because the emu forks
+> a worker and the visible pid is a zombie stub. **Run these on a real host
+> (bare metal / VM you control) to get a real verdict.** Tracked for hardware
+> validation alongside the IPv6 task.
+
+## churn — connection-churn leak / stability
+
+`churn_node.b` runs a serving node and a connecting node in one emu over
+loopback and performs N sequential `dial -> auth (hybrid PQ STS + ssl) ->
+write -> read echo -> drop` cycles, with the server spawning a per-connection
+handler exactly like `node_server.b`. The signer + Authinfos are generated
+once and reused, so any per-iteration footprint growth isolates a
+per-connection leak in the socket / handshake / ssl / fd lifecycle.
+
+`run-churn.sh` launches it and samples the emu's RSS and open-fd count against
+the `iter N` markers it prints, then checks that both **plateau** (a leak
+shows as monotonic growth).
+
+```sh
+# from the repo root, on real hardware:
+tests/stress/run-churn.sh [count] [alg] [port]
+# e.g. 5000 cycles with a post-quantum signer:
+tests/stress/run-churn.sh 5000 mldsa65 19500
+```
+
+Expected healthy output ends with `PASS: <count> cycles, RSS and fd count
+plateaued`. A leak ends with `FAIL: resource growth ...` and the RSS/fd trace.
+
+Run it across a couple of signer algorithms (e.g. `ed25519` and `mldsa65`):
+their per-connection allocation profiles differ.
+
+## dos_stall — slowloris / handshake-stall resistance
+
+`dos_stall_test.b` is written as a `*_test.b` (testing-framework shape) but
+lives here so it is not auto-run. It opens clients that dial and then **never
+send a handshake byte**, pinning the server's per-connection handler in
+`auth->server`, and asserts a legitimate client still authenticates and is
+served — i.e. one (or many) stalled peers do not wedge the accept loop. This
+confirms the spawn-per-connection design in `node_server.b` and would catch a
+regression to an inline `accept -> auth` loop, which a single staller would
+block.
+
+```sh
+# build with the native limbo, then run directly:
+limbo -I module -o dis/tests/stress/dos_stall_test.dis tests/stress/dos_stall_test.b
+./emu/Linux/o.emu -c1 -r$PWD /dis/tests/stress/dos_stall_test.dis -v
+```
+
+Note: the server's per-connection handler has **no handshake timeout**, so
+stalled peers accumulate blocked handlers and fds for the life of the
+connection. The accept loop is not blocked (good), but a handshake-read
+deadline on `auth->server` would bound the resource a hostile peer can pin —
+worth considering if these nodes are exposed to untrusted networks.

--- a/tests/stress/churn_node.b
+++ b/tests/stress/churn_node.b
@@ -1,0 +1,181 @@
+implement ChurnNode;
+
+#
+# Connection-churn driver for leak / stability testing of the node-auth path.
+#
+# Runs a serving node and a connecting node in ONE emu process over loopback
+# TCP, then performs `count` sequential connection cycles, each of which:
+#
+#   dial -> auth->client (hybrid PQ STS + ssl) -> write a message ->
+#   read the echo -> drop the connection
+#
+# with the server spawning a per-connection handler exactly like the real
+# node_server.b.  The signer + Authinfos are generated ONCE and reused (as a
+# real keyfile would be), so a per-iteration footprint increase isolates a
+# per-connection leak in the socket / handshake / ssl / fd lifecycle rather
+# than keygen.
+#
+# It prints "iter N" progress markers and a final "DONE" line; the host
+# harness (run-churn.sh) samples the emu's RSS and open-fd count alongside
+# those markers to decide whether memory and descriptors plateau.
+#
+# Usage:  churn_node [count [port [alg]]]
+#   count  number of connection cycles      (default 500)
+#   port   loopback TCP port                 (default 19500)
+#   alg    signer cert algorithm            (default ed25519)
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+ChurnNode: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+stderr: ref Sys->FD;
+
+fail(s: string)
+{
+	sys->fprint(stderr, "churn_node: %s\n", s);
+	raise "fail:error";
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk;
+	ai.mypk = pk;
+	ai.cert = cert;
+	ai.spk = signerpk;
+	ai.alpha = alpha;
+	ai.p = p;
+	return ai;
+}
+
+# per-connection server handler, mirroring node_server.b's spawn-per-conn model
+serve(ai: ref Keyring->Authinfo, dfd: ref Sys->FD)
+{
+	(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, dfd, 0);
+	if(wrapped == nil)
+		return;
+	buf := array[256] of byte;
+	n := sys->read(wrapped, buf, len buf);
+	if(n > 0)
+		sys->write(wrapped, buf[0:n], n);	# echo
+}
+
+server(ac: Sys->Connection, ai: ref Keyring->Authinfo)
+{
+	for(;;){
+		(lok, nc) := sys->listen(ac);
+		if(lok < 0)
+			return;
+		dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+		if(dfd == nil)
+			continue;
+		spawn serve(ai, dfd);
+	}
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	stderr = sys->fildes(2);
+	if(kr == nil || auth == nil)
+		fail(sys->sprint("load core modules: %r"));
+	if((e := auth->init()) != nil)
+		fail("auth init: " + e);
+
+	count := 500;
+	port := 19500;
+	alg := "ed25519";
+	args = tl args;
+	if(args != nil){ count = int hd args; args = tl args; }
+	if(args != nil){ port = int hd args; args = tl args; }
+	if(args != nil){ alg = hd args; }
+
+	signersk := kr->genSK(alg, "churn-signer", 0);
+	if(signersk == nil)
+		fail(sys->sprint("genSK(%s): %r", alg));
+	signerpk := kr->sktopk(signersk);
+	(alpha, p) := kr->dhparams(2048);
+	if(alpha == nil || p == nil)
+		fail("dhparams failed");
+
+	srvai := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cliai := mkauthinfo(signersk, signerpk, alpha, p, "client");
+
+	addr := sys->sprint("tcp!127.0.0.1!%d", port);
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		sys->print("SKIP: announce %s failed: %r\n", addr);
+		return;
+	}
+	spawn server(ac, srvai);
+
+	sys->print("START churn count=%d port=%d alg=%s\n", count, port, alg);
+
+	msg := array of byte "churn-ping-0123456789";
+	echo := array[len msg] of byte;
+
+	for(i := 1; i <= count; i++){
+		(dok, dc) := sys->dial(addr, nil);
+		if(dok < 0){
+			sys->print("dial failed at iter %d: %r\n", i);
+			break;
+		}
+		(wrapped, cerr) := auth->client("aes_256_cbc sha256", cliai, dc.dfd);
+		if(wrapped == nil){
+			sys->print("client auth failed at iter %d: %s\n", i, cerr);
+			break;
+		}
+		if(sys->write(wrapped, msg, len msg) != len msg){
+			sys->print("write failed at iter %d: %r\n", i);
+			break;
+		}
+		if(readn(wrapped, echo, len echo) != len echo){
+			sys->print("echo read short at iter %d\n", i);
+			break;
+		}
+		# drop all per-connection references so the fds/ssl state are
+		# reclaimable; the next iteration must not inherit them.
+		wrapped = nil;
+		dc.dfd = nil;
+		dc.cfd = nil;
+
+		if(i % 100 == 0)
+			sys->print("iter %d\n", i);
+	}
+
+	sys->print("DONE %d iterations\n", count);
+}

--- a/tests/stress/dos_stall_test.b
+++ b/tests/stress/dos_stall_test.b
@@ -1,0 +1,252 @@
+implement DosStallTest;
+
+#
+# Denial-of-service resistance: a server must keep serving legitimate clients
+# while misbehaving peers hold connections open without completing the
+# authentication handshake (a slowloris-style stall).
+#
+# The server mirrors node_server.b: an accept loop that spawns a per-connection
+# handler which runs auth->server.  A stalled client dials but never sends a
+# handshake byte, pinning its handler proc in auth->server forever.  The test
+# asserts that:
+#
+#   - StalledDoesNotBlock   one legitimate client still authenticates and is
+#                           served while a stalled client holds a connection
+#   - ManyStallsDoNotBlock  a legitimate client still succeeds with many
+#                           stalled connections outstanding (the accept loop
+#                           is not serialised behind a slow handshake)
+#
+# This documents the design property (spawn-per-connection isolates a slow/
+# hostile handshake) and would catch a regression to an inline accept->auth
+# loop, which a single staller would wedge.
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "keyring.m";
+	kr: Keyring;
+
+include "security.m";
+	auth: Auth;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+DosStallTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/stress/dos_stall_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+readn(fd: ref Sys->FD, buf: array of byte, n: int): int
+{
+	tot := 0;
+	while(tot < n){
+		m := sys->read(fd, buf[tot:], n - tot);
+		if(m <= 0)
+			break;
+		tot += m;
+	}
+	return tot;
+}
+
+mkauthinfo(signersk: ref Keyring->SK, signerpk: ref Keyring->PK,
+		alpha, p: ref Keyring->IPint, name: string): ref Keyring->Authinfo
+{
+	sk := kr->genSKfromPK(signerpk, name);
+	pk := kr->sktopk(sk);
+	pkbuf := array of byte kr->pktostr(pk);
+	state := kr->sha256(pkbuf, len pkbuf, nil, nil);
+	cert := kr->sign(signersk, 0, state, "sha256");
+	ai := ref Keyring->Authinfo;
+	ai.mysk = sk; ai.mypk = pk; ai.cert = cert;
+	ai.spk = signerpk; ai.alpha = alpha; ai.p = p;
+	return ai;
+}
+
+# spawn-per-connection server, mirroring node_server.b
+serve(ai: ref Keyring->Authinfo, dfd: ref Sys->FD)
+{
+	(wrapped, nil) := auth->server("aes_256_cbc" :: "sha256" :: nil, ai, dfd, 0);
+	if(wrapped == nil)
+		return;
+	buf := array[256] of byte;
+	n := sys->read(wrapped, buf, len buf);
+	if(n > 0)
+		sys->write(wrapped, buf[0:n], n);	# echo
+}
+
+server(ac: Sys->Connection, ai: ref Keyring->Authinfo)
+{
+	for(;;){
+		(lok, nc) := sys->listen(ac);
+		if(lok < 0)
+			return;
+		dfd := sys->open(nc.dir + "/data", Sys->ORDWR);
+		if(dfd == nil)
+			continue;
+		spawn serve(ai, dfd);
+	}
+}
+
+timerproc(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= 1;
+}
+
+# Hold a dialled connection open without ever sending a handshake byte.
+# Keeps the ref alive until told to release, so the server handler stays
+# pinned in auth->server.
+staller(addr: string, hold: chan of int)
+{
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0)
+		return;
+	<-hold;			# block, keeping dc (and the connection) alive
+	dc.dfd = nil;
+}
+
+# A legitimate client: full handshake + echo round-trip.  Returns "" on
+# success or an error string.
+legit(addr: string, ai: ref Keyring->Authinfo): string
+{
+	(dok, dc) := sys->dial(addr, nil);
+	if(dok < 0)
+		return sys->sprint("dial: %r");
+	(wrapped, cerr) := auth->client("aes_256_cbc sha256", ai, dc.dfd);
+	if(wrapped == nil)
+		return "client auth: " + cerr;
+	msg := array of byte "legit-ping";
+	if(sys->write(wrapped, msg, len msg) != len msg)
+		return sys->sprint("write: %r");
+	echo := array[len msg] of byte;
+	if(readn(wrapped, echo, len echo) != len echo)
+		return "short echo";
+	return nil;
+}
+
+legitproc(addr: string, ai: ref Keyring->Authinfo, rc: chan of string)
+{
+	rc <-= legit(addr, ai);
+}
+
+setup(t: ref T, port: int): (string, ref Keyring->Authinfo)
+{
+	signersk := kr->genSK("ed25519", "dos-signer", 0);
+	if(signersk == nil)
+		t.fatal(sys->sprint("genSK: %r"));
+	signerpk := kr->sktopk(signersk);
+	(alpha, p) := kr->dhparams(2048);
+	srvai := mkauthinfo(signersk, signerpk, alpha, p, "server");
+	cliai := mkauthinfo(signersk, signerpk, alpha, p, "client");
+
+	addr := sys->sprint("tcp!127.0.0.1!%d", port);
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0)
+		t.skip(sys->sprint("announce failed: %r"));
+	spawn server(ac, srvai);
+	return (addr, cliai);
+}
+
+# run a legit client with a timeout; returns (err, ok) where ok=0 means it
+# hung (server wedged).
+legitWithTimeout(addr: string, ai: ref Keyring->Authinfo, ms: int): (string, int)
+{
+	rc := chan of string;
+	tmo := chan of int;
+	spawn legitproc(addr, ai, rc);
+	spawn timerproc(tmo, ms);
+	alt {
+	e := <-rc => return (e, 1);
+	<-tmo => return ("timeout", 0);
+	}
+}
+
+testStalledDoesNotBlock(t: ref T)
+{
+	(addr, cliai) := setup(t, 19610);
+
+	hold := chan of int;
+	spawn staller(addr, hold);
+	sys->sleep(200);		# let the staller's connection land + pin a handler
+
+	(e, ok) := legitWithTimeout(addr, cliai, 15000);
+	hold <-= 1;			# release the staller
+	if(!ok)
+		t.fatal("legitimate client hung while a stalled client held a connection (server serialised?)");
+	t.assertnil(e, "legitimate client authenticates despite a stalled peer: " + e);
+}
+
+testManyStallsDoNotBlock(t: ref T)
+{
+	(addr, cliai) := setup(t, 19611);
+
+	NSTALL: con 25;
+	holds := array[NSTALL] of chan of int;
+	i: int;
+	for(i = 0; i < NSTALL; i++){
+		holds[i] = chan of int;
+		spawn staller(addr, holds[i]);
+	}
+	sys->sleep(500);		# let them land
+
+	(e, ok) := legitWithTimeout(addr, cliai, 20000);
+	for(i = 0; i < NSTALL; i++)
+		holds[i] <-= 1;		# release all
+	if(!ok)
+		t.fatal(sys->sprint("legitimate client hung with %d stalled connections outstanding", NSTALL));
+	t.assertnil(e, "legitimate client authenticates with many stalled peers: " + e);
+	t.log(sys->sprint("served a legit client while %d stalled handshakes were pinned", NSTALL));
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	kr = load Keyring Keyring->PATH;
+	auth = load Auth Auth->PATH;
+	testing = load Testing Testing->PATH;
+	if(sys == nil || kr == nil || testing == nil)
+		raise "fail:cannot load core modules";
+	if(auth == nil)
+		raise "fail:cannot load auth";
+	auth->init();
+	testing->init();
+
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("StalledDoesNotBlock", testStalledDoesNotBlock);
+	run("ManyStallsDoNotBlock", testManyStallsDoNotBlock);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/stress/run-churn.sh
+++ b/tests/stress/run-churn.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#
+# Connection-churn leak / stability harness for the node-auth path.
+#
+# Launches one emu running churn_node (a serving node + a connecting node that
+# performs `count` sequential authenticated connection cycles over loopback),
+# and samples the emu process's resident memory (VmRSS) and open file
+# descriptors against the iteration markers it prints.  A healthy run plateaus:
+# RSS reaches a steady state after warmup and the descriptor count stays flat.
+# A leak in the socket / handshake / ssl / fd lifecycle shows as monotonic
+# growth.
+#
+# Usage:  run-churn.sh [count [alg [port]]]
+#   count  connection cycles      (default 800)
+#   alg    signer cert algorithm  (default ed25519; e.g. mldsa65)
+#   port   loopback TCP port       (default 19500)
+#
+# Exit status: 0 = plateau (PASS), 1 = leak/instability (FAIL), 2 = skipped.
+#
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COUNT="${1:-800}"
+ALG="${2:-ed25519}"
+PORT="${3:-19500}"
+
+emu_bin() {
+	for c in "$ROOT/emu/Linux/o.emu" "$ROOT/emu/MacOSX/o.emu"; do
+		[ -x "$c" ] && { echo "$c"; return; }
+	done
+	echo ""
+}
+EMU="$(emu_bin)"
+[ -n "$EMU" ] || { echo "run-churn: no emu binary under $ROOT" >&2; exit 2; }
+
+LIMBO=""
+for c in "$ROOT/Linux/amd64/bin/limbo" "$ROOT/Linux/arm64/bin/limbo" "$ROOT/MacOSX/arm64/bin/limbo"; do
+	[ -x "$c" ] && { LIMBO="$c"; break; }
+done
+DIS="$ROOT/dis/tests/stress/churn_node.dis"
+if [ -n "$LIMBO" ]; then
+	mkdir -p "$ROOT/dis/tests/stress"
+	"$LIMBO" -I "$ROOT/module" -o "$DIS" "$(dirname "$0")/churn_node.b" 2>/dev/null
+fi
+[ -f "$DIS" ] || { echo "run-churn: churn_node.dis missing (build with native limbo)" >&2; exit 2; }
+
+TMP="$(mktemp -d)"
+OUT="$TMP/out"
+trap 'kill $PID 2>/dev/null; rm -rf "$TMP"' EXIT
+
+echo "=== churn: $COUNT cycles, $ALG signer, $EMU ==="
+"$EMU" -c1 -r"$ROOT" /dis/tests/stress/churn_node.dis "$COUNT" "$PORT" "$ALG" >"$OUT" 2>&1 &
+PID=$!
+
+rss_kb()  { awk '/^VmRSS:/{print $2}' "/proc/$1/status" 2>/dev/null; }
+fd_count(){ ls "/proc/$1/fd" 2>/dev/null | wc -l; }
+
+# samples: "iter rss fd"
+SAMPLES="$TMP/samples"
+: >"$SAMPLES"
+
+# Wait for START (or a clean skip)
+for _ in $(seq 1 100); do
+	grep -q "START" "$OUT" 2>/dev/null && break
+	if grep -q "SKIP:" "$OUT" 2>/dev/null; then
+		echo "SKIP: $(grep SKIP: "$OUT")"; exit 2
+	fi
+	kill -0 $PID 2>/dev/null || break
+	sleep 0.1
+done
+
+# Sample until the process prints DONE or exits.
+last_iter=0
+while kill -0 $PID 2>/dev/null; do
+	r="$(rss_kb $PID)"; f="$(fd_count $PID)"
+	it="$(awk '/^iter /{n=$2} END{print n+0}' "$OUT")"
+	[ -n "$r" ] && echo "$it $r $f" >>"$SAMPLES"
+	last_iter="$it"
+	grep -q "^DONE" "$OUT" && break
+	sleep 0.3
+done
+# brief settle + final sample while still alive
+sleep 0.5
+r="$(rss_kb $PID)"; f="$(fd_count $PID)"
+[ -n "$r" ] && echo "$COUNT $r $f" >>"$SAMPLES"
+wait $PID 2>/dev/null
+
+echo "--- node output ---"
+sed 's/^/    /' "$OUT"
+
+if ! grep -q "^DONE" "$OUT"; then
+	echo "FAIL: churn did not complete $COUNT cycles (instability under churn)"
+	exit 1
+fi
+# any explicit error line is an instability failure
+if grep -qiE "failed|short" "$OUT"; then
+	echo "FAIL: churn reported a per-connection error"
+	exit 1
+fi
+
+# ---- leak analysis -------------------------------------------------------
+# Warmup baseline = first sample taken at/after iter 100 (steady-state heap);
+# compare RSS + fd against the final sample.
+analyze() {
+	awk '
+	{ iter[NR]=$1; rss[NR]=$2; fd[NR]=$3; n=NR }
+	END{
+		if(n < 2){ print "INSUFFICIENT"; exit }
+		# warmup index: first sample with iter>=100, else first sample
+		wi=1;
+		for(i=1;i<=n;i++){ if(iter[i]>=100){ wi=i; break } }
+		rss_warm=rss[wi]; fd_warm=fd[wi]; it_warm=iter[wi];
+		rss_end=rss[n]; fd_end=fd[n];
+		# peak fd over the whole run
+		fdpeak=0; rsspeak=0;
+		for(i=1;i<=n;i++){ if(fd[i]>fdpeak)fdpeak=fd[i]; if(rss[i]>rsspeak)rsspeak=rss[i] }
+		dr=rss_end-rss_warm; if(dr<0)dr=0;
+		printf "warmup@iter%d: rss=%dkB fd=%d | end: rss=%dkB fd=%d | peakfd=%d peakrss=%dkB\n",
+			it_warm, rss_warm, fd_warm, rss_end, fd_end, fdpeak, rsspeak;
+		printf "post-warmup RSS growth: %d kB; fd delta: %d\n", dr, fd_end-fd_warm;
+		# thresholds: fds must stay flat; RSS must not grow more than 24 MB
+		# after warmup (a real per-connection leak grows linearly and blows
+		# well past this over hundreds of cycles).
+		fdleak = (fd_end > fd_warm + 8) || (fdpeak > fd_warm + 16);
+		rssleak = (dr > 24000);
+		if(fdleak){ print "VERDICT FAIL (fd leak)"; exit }
+		if(rssleak){ print "VERDICT FAIL (rss growth)"; exit }
+		print "VERDICT PASS";
+	}' "$SAMPLES"
+}
+echo "--- leak analysis ---"
+RESULT="$(analyze)"
+echo "$RESULT" | sed 's/^/    /'
+
+if echo "$RESULT" | grep -q "VERDICT PASS"; then
+	echo "PASS: $COUNT cycles, RSS and fd count plateaued"
+	exit 0
+else
+	echo "FAIL: resource growth across $COUNT cycles — see analysis above"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

A comprehensive integration-test campaign for how two InferNode/NERVA3 nodes authenticate and talk over the native Inferno transport — cert auth + hybrid post-quantum handshake (`Keyring->auth`) + `ssl` line encryption + Styx. **This PR is now purely additive: new test suites, harnesses, and docs.**

> **Note (rebased):** the DSA certificate fix this campaign found — `dsa_str2sk`/`dsa_str2pk` reading every field from the original `str` cursor instead of advancing through `p`, plus `eg_gen`/`rsa_gen` tiny-size hardening and the `genSK` nil-on-failure contract — **already landed on `master` separately as #227**, so it was dropped from this branch on rebase. The suites here *verify* it (`interop_test`'s `InteropDSA` passes against the fixed core).

## New test suites (auto-discovered by the runner, all green)

- **authneg** — trust/integrity must fail closed: untrusted signer, expired cert, a cipher the server didn't offer, and a one-byte ciphertext tamper caught by the ssl record MAC
- **crypto_props** — two handshakes with the same certs derive *different* 64-byte secrets (forward-secrecy proxy), reflected `alpha**r0` caught as a replay, corrupted cert signature rejected
- **cipher_matrix** — every ssl cipher (`aes_256_cbc`/`aes_128_cbc`/`ideacbc`/`ideaecb`) × MAC (`sha256`/`sha1`/`md5`/`md4`) + the `none` path, byte-for-byte round-trip
- **interrupt** — abrupt TCP disconnect mid-handshake / mid-transfer → clean error / EOF, no crash, no hang
- **concurrent_auth** — 12 clients authenticate to one server simultaneously, each gets its own data back, no cross-talk/races
- **handshake_fuzz** — 9 malformed inbound streams → `auth->server` fails closed (no secret, no crash, no hang)

## New harnesses (manual / hardware-run)

- **tests/interop/run-mount-auth.sh** — the *real* CLI path: `auth/createsignerkey` → on-disk keyfile → `styxlisten -k … export /lib` ← `mount -k … -C`, reading a file through the encrypted styx mount and verifying it; covers ed25519 + ML-DSA-65 and asserts an anonymous `mount -A` is rejected
- **tests/stress/** — connection-churn leak + slowloris-DoS harness (hardware-run; the cloud sandbox's CPU watchdog SIGKILLs long emu runs, so the leak verdict needs real hardware — details in the README)
- **tests/bench/** — keygen + handshake-latency per algorithm and cipher throughput baselines

These extend the pre-existing `pqauth_test`/`interop_test`, which already cover the happy path and handshake-mechanics negatives.

## Notes

- All in-emu suites **skip cleanly** with no IP stack and are timeout-guarded so a hang is reported, not wedged.
- Hardware-deferred items are tracked: IPv6 on real hardware (INFR-289), high-count stress/leak (INFR-300).
- Security review of the crypto-core diff: clean, no required fixes.
- Diff is purely `tests/`, `docs/NODE-INTEROP-TESTING.md`, and `.gitignore` (16 files, +2861).

https://claude.ai/code/session_019pBz5sWwtQ8XdjgkATBTKg