### PR TITLE
ci: deterministic test-suite completion (non-gating, transitional)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,22 +137,49 @@ jobs:
         mkdir -p tmp
 
         echo "Running test suite inside Inferno emulator..."
-        # The emulator doesn't exit cleanly after the test runner finishes
-        # (kernel threads keep the process alive), so we capture output and
-        # parse the result instead of relying on exit code.
-        timeout 60 ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 || true
+        # Deterministic completion: emu never exits cleanly (kernel threads
+        # keep it alive) and the suite legitimately runs for minutes
+        # (crypto_test alone is ~170s), so a fixed `timeout` truncates it.
+        # Run emu in the background and wait for the runner's own "Total:"
+        # summary line, then stop it. The backstop (<< the job's
+        # timeout-minutes) only bounds a genuine hang. No `timeout` (absent
+        # on macOS) so the same shape works everywhere.
+        ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 &
+        EMU_PID=$!
+        START=$SECONDS
+        while kill -0 $EMU_PID 2>/dev/null; do
+          grep -q "^Total:" test-output.txt 2>/dev/null && break
+          [ $((SECONDS-START)) -ge 480 ] && { echo "Backstop hit (480s) with no Total: line — possible hang."; break; }
+          sleep 2
+        done
+        kill -9 $EMU_PID 2>/dev/null || true
+        wait $EMU_PID 2>/dev/null || true
 
         cat test-output.txt
 
-        # Check test results from output
-        if grep -q "^PASS$" test-output.txt; then
-          echo "Tests passed."
-        elif grep -q "^FAIL$" test-output.txt; then
-          echo "Tests failed."
-          exit 1
+        # Result handling. The old check grepped "^PASS$", which matches the
+        # per-module PASS line every test file emits — so the job could not
+        # actually fail on a test failure, and (with the 60s cap) silently
+        # truncated the suite while still reporting green. Now we key off the
+        # runner's single "Total:" completion line and the per-module
+        # "--- FAIL:" markers.
+        #
+        # TRANSITIONAL: gating is intentionally OFF. The cowfs deadlock that
+        # truncated the suite at ~test 7 of 127 is fixed, so the previously
+        # dark ~110 tests now run; this surfaces their true state in CI before
+        # we enforce it. Do NOT add `exit 1` here until the surfaced failures
+        # are triaged and an explicit skip-list is in place.
+        if grep -q "^Total:" test-output.txt; then
+          grep "^Total:" test-output.txt | tail -1
+          if grep -q "^--- FAIL:" test-output.txt; then
+            echo "::warning::Test suite has failing modules (NON-GATING, transitional):"
+            grep "^--- FAIL:" test-output.txt || true
+          else
+            echo "Test suite: all modules passed."
+          fi
         else
-          echo "No test result found in output — tests may not have run."
-          exit 1
+          echo "::warning::Runner did not reach a Total: line within the backstop (possible hang). Last test started:"
+          grep "^=== RUN" test-output.txt | tail -1 || true
         fi
 
     - name: Run wallet and secstore integration tests
@@ -390,19 +417,49 @@ jobs:
         mkdir -p tmp
 
         echo "Running test suite inside Inferno emulator..."
-        timeout 60 ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 || true
+        # Deterministic completion: emu never exits cleanly (kernel threads
+        # keep it alive) and the suite legitimately runs for minutes
+        # (crypto_test alone is ~170s), so a fixed `timeout` truncates it.
+        # Run emu in the background and wait for the runner's own "Total:"
+        # summary line, then stop it. The backstop (<< the job's
+        # timeout-minutes) only bounds a genuine hang. No `timeout` (absent
+        # on macOS) so the same shape works everywhere.
+        ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 &
+        EMU_PID=$!
+        START=$SECONDS
+        while kill -0 $EMU_PID 2>/dev/null; do
+          grep -q "^Total:" test-output.txt 2>/dev/null && break
+          [ $((SECONDS-START)) -ge 480 ] && { echo "Backstop hit (480s) with no Total: line — possible hang."; break; }
+          sleep 2
+        done
+        kill -9 $EMU_PID 2>/dev/null || true
+        wait $EMU_PID 2>/dev/null || true
 
         cat test-output.txt
 
-        # Check test results from output
-        if grep -q "^PASS$" test-output.txt; then
-          echo "Tests passed."
-        elif grep -q "^FAIL$" test-output.txt; then
-          echo "Tests failed."
-          exit 1
+        # Result handling. The old check grepped "^PASS$", which matches the
+        # per-module PASS line every test file emits — so the job could not
+        # actually fail on a test failure, and (with the 60s cap) silently
+        # truncated the suite while still reporting green. Now we key off the
+        # runner's single "Total:" completion line and the per-module
+        # "--- FAIL:" markers.
+        #
+        # TRANSITIONAL: gating is intentionally OFF. The cowfs deadlock that
+        # truncated the suite at ~test 7 of 127 is fixed, so the previously
+        # dark ~110 tests now run; this surfaces their true state in CI before
+        # we enforce it. Do NOT add `exit 1` here until the surfaced failures
+        # are triaged and an explicit skip-list is in place.
+        if grep -q "^Total:" test-output.txt; then
+          grep "^Total:" test-output.txt | tail -1
+          if grep -q "^--- FAIL:" test-output.txt; then
+            echo "::warning::Test suite has failing modules (NON-GATING, transitional):"
+            grep "^--- FAIL:" test-output.txt || true
+          else
+            echo "Test suite: all modules passed."
+          fi
         else
-          echo "No test result found in output — tests may not have run."
-          exit 1
+          echo "::warning::Runner did not reach a Total: line within the backstop (possible hang). Last test started:"
+          grep "^=== RUN" test-output.txt | tail -1 || true
         fi
 
     - name: Run wallet and secstore integration tests
@@ -554,19 +611,49 @@ jobs:
         mkdir -p tmp
 
         echo "Running test suite inside Inferno emulator..."
-        timeout 60 ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 || true
+        # Deterministic completion: emu never exits cleanly (kernel threads
+        # keep it alive) and the suite legitimately runs for minutes
+        # (crypto_test alone is ~170s), so a fixed `timeout` truncates it.
+        # Run emu in the background and wait for the runner's own "Total:"
+        # summary line, then stop it. The backstop (<< the job's
+        # timeout-minutes) only bounds a genuine hang. No `timeout` (absent
+        # on macOS) so the same shape works everywhere.
+        ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 &
+        EMU_PID=$!
+        START=$SECONDS
+        while kill -0 $EMU_PID 2>/dev/null; do
+          grep -q "^Total:" test-output.txt 2>/dev/null && break
+          [ $((SECONDS-START)) -ge 480 ] && { echo "Backstop hit (480s) with no Total: line — possible hang."; break; }
+          sleep 2
+        done
+        kill -9 $EMU_PID 2>/dev/null || true
+        wait $EMU_PID 2>/dev/null || true
 
         cat test-output.txt
 
-        # Check test results from output
-        if grep -q "^PASS$" test-output.txt; then
-          echo "Tests passed."
-        elif grep -q "^FAIL$" test-output.txt; then
-          echo "Tests failed."
-          exit 1
+        # Result handling. The old check grepped "^PASS$", which matches the
+        # per-module PASS line every test file emits — so the job could not
+        # actually fail on a test failure, and (with the 60s cap) silently
+        # truncated the suite while still reporting green. Now we key off the
+        # runner's single "Total:" completion line and the per-module
+        # "--- FAIL:" markers.
+        #
+        # TRANSITIONAL: gating is intentionally OFF. The cowfs deadlock that
+        # truncated the suite at ~test 7 of 127 is fixed, so the previously
+        # dark ~110 tests now run; this surfaces their true state in CI before
+        # we enforce it. Do NOT add `exit 1` here until the surfaced failures
+        # are triaged and an explicit skip-list is in place.
+        if grep -q "^Total:" test-output.txt; then
+          grep "^Total:" test-output.txt | tail -1
+          if grep -q "^--- FAIL:" test-output.txt; then
+            echo "::warning::Test suite has failing modules (NON-GATING, transitional):"
+            grep "^--- FAIL:" test-output.txt || true
+          else
+            echo "Test suite: all modules passed."
+          fi
         else
-          echo "No test result found in output — tests may not have run."
-          exit 1
+          echo "::warning::Runner did not reach a Total: line within the backstop (possible hang). Last test started:"
+          grep "^=== RUN" test-output.txt | tail -1 || true
         fi
 
     - name: Run wallet and secstore integration tests
@@ -713,19 +800,49 @@ jobs:
         mkdir -p tmp
 
         echo "Running test suite inside Inferno emulator..."
-        timeout 60 ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 || true
+        # Deterministic completion: emu never exits cleanly (kernel threads
+        # keep it alive) and the suite legitimately runs for minutes
+        # (crypto_test alone is ~170s), so a fixed `timeout` truncates it.
+        # Run emu in the background and wait for the runner's own "Total:"
+        # summary line, then stop it. The backstop (<< the job's
+        # timeout-minutes) only bounds a genuine hang. No `timeout` (absent
+        # on macOS) so the same shape works everywhere.
+        ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 &
+        EMU_PID=$!
+        START=$SECONDS
+        while kill -0 $EMU_PID 2>/dev/null; do
+          grep -q "^Total:" test-output.txt 2>/dev/null && break
+          [ $((SECONDS-START)) -ge 480 ] && { echo "Backstop hit (480s) with no Total: line — possible hang."; break; }
+          sleep 2
+        done
+        kill -9 $EMU_PID 2>/dev/null || true
+        wait $EMU_PID 2>/dev/null || true
 
         cat test-output.txt
 
-        # Check test results from output
-        if grep -q "^PASS$" test-output.txt; then
-          echo "Tests passed."
-        elif grep -q "^FAIL$" test-output.txt; then
-          echo "Tests failed."
-          exit 1
+        # Result handling. The old check grepped "^PASS$", which matches the
+        # per-module PASS line every test file emits — so the job could not
+        # actually fail on a test failure, and (with the 60s cap) silently
+        # truncated the suite while still reporting green. Now we key off the
+        # runner's single "Total:" completion line and the per-module
+        # "--- FAIL:" markers.
+        #
+        # TRANSITIONAL: gating is intentionally OFF. The cowfs deadlock that
+        # truncated the suite at ~test 7 of 127 is fixed, so the previously
+        # dark ~110 tests now run; this surfaces their true state in CI before
+        # we enforce it. Do NOT add `exit 1` here until the surfaced failures
+        # are triaged and an explicit skip-list is in place.
+        if grep -q "^Total:" test-output.txt; then
+          grep "^Total:" test-output.txt | tail -1
+          if grep -q "^--- FAIL:" test-output.txt; then
+            echo "::warning::Test suite has failing modules (NON-GATING, transitional):"
+            grep "^--- FAIL:" test-output.txt || true
+          else
+            echo "Test suite: all modules passed."
+          fi
         else
-          echo "No test result found in output — tests may not have run."
-          exit 1
+          echo "::warning::Runner did not reach a Total: line within the backstop (possible hang). Last test started:"
+          grep "^=== RUN" test-output.txt | tail -1 || true
         fi
 
     - name: Run wallet and secstore integration tests
@@ -923,25 +1040,44 @@ jobs:
         # The emulator doesn't exit cleanly after the test runner finishes
         # (kernel threads keep the process alive), so we capture output and
         # parse the result instead of relying on exit code.
-        # macOS doesn't have timeout; use background process with kill
+        # Deterministic completion (see Linux jobs): wait for the runner's
+        # own "Total:" summary line rather than a fixed timeout, then stop emu.
         ./emu/MacOSX/o.emu -r . /tests/runner.dis -v > test-output.txt 2>&1 &
         EMU_PID=$!
-        ( sleep 60; kill $EMU_PID 2>/dev/null ) &
-        WATCHDOG=$!
+        START=$SECONDS
+        while kill -0 $EMU_PID 2>/dev/null; do
+          grep -q "^Total:" test-output.txt 2>/dev/null && break
+          [ $((SECONDS-START)) -ge 480 ] && { echo "Backstop hit (480s) with no Total: line — possible hang."; break; }
+          sleep 2
+        done
+        kill -9 $EMU_PID 2>/dev/null || true
         wait $EMU_PID 2>/dev/null || true
-        kill $WATCHDOG 2>/dev/null || true
 
         cat test-output.txt
 
-        # Check test results from output
-        if grep -q "^PASS$" test-output.txt; then
-          echo "Tests passed."
-        elif grep -q "^FAIL$" test-output.txt; then
-          echo "Tests failed."
-          exit 1
+        # Result handling. The old check grepped "^PASS$", which matches the
+        # per-module PASS line every test file emits — so the job could not
+        # actually fail on a test failure, and (with the 60s cap) silently
+        # truncated the suite while still reporting green. Now we key off the
+        # runner's single "Total:" completion line and the per-module
+        # "--- FAIL:" markers.
+        #
+        # TRANSITIONAL: gating is intentionally OFF. The cowfs deadlock that
+        # truncated the suite at ~test 7 of 127 is fixed, so the previously
+        # dark ~110 tests now run; this surfaces their true state in CI before
+        # we enforce it. Do NOT add `exit 1` here until the surfaced failures
+        # are triaged and an explicit skip-list is in place.
+        if grep -q "^Total:" test-output.txt; then
+          grep "^Total:" test-output.txt | tail -1
+          if grep -q "^--- FAIL:" test-output.txt; then
+            echo "::warning::Test suite has failing modules (NON-GATING, transitional):"
+            grep "^--- FAIL:" test-output.txt || true
+          else
+            echo "Test suite: all modules passed."
+          fi
         else
-          echo "No test result found in output — tests may not have run."
-          exit 1
+          echo "::warning::Runner did not reach a Total: line within the backstop (possible hang). Last test started:"
+          grep "^=== RUN" test-output.txt | tail -1 || true
         fi
 
     - name: Run port verification


### PR DESCRIPTION
## Summary

Makes the in-emulator test suite **complete deterministically** instead of being cut off by a fixed `timeout 60`, and fixes the result check. **Gating is intentionally OFF (transitional)** — the goal of this PR is to make the true state of the full suite *visible in CI* before we enforce it.

## The two problems with the old step

```sh
timeout 60 ./emu/Linux/o.emu -c1 -r . /tests/runner.dis -v > test-output.txt 2>&1 || true
... if grep -q "^PASS$" test-output.txt; then echo "Tests passed."; ...
```

1. **60s is a ~3× shortfall.** The suite legitimately runs for *minutes* — `crypto_test` alone is **~170s** locally. Before the cowfs deadlock fix (#232) it truncated at test 7 of 127; even now it can't finish in 60s. So **~110 tests — the entire crypto / PQ / namespace-security battery — were never exercised in CI.**
2. **The check can't fail.** `^PASS$` matches the **per-module** PASS line every test file prints, so the job went green even on a truncated/failed run.

The CI logs confirm both: the "Run test suite" step has been hitting exactly 60s and the output stops mid-suite, yet the job is green.

## The fix

emu never exits cleanly (kernel threads keep it alive), so we can't rely on process exit or a fixed timeout. Instead: run emu in the background and **wait for the runner's own single `Total:` completion line**, then stop it. A **480s backstop** (≪ the 30-min job cap) only bounds a genuine hang. Same shape on Linux and macOS (portable — no `timeout`, which macOS lacks). Applied to all five gating jobs; the informational Windows step is unchanged.

The result check now keys off the `Total:` line (did the suite *complete*) and the per-module `--- FAIL:` markers.

## Why non-gating, for now

Turning the dark half on will surface its genuine state. A **local full run** shows it's mostly healthy:
- **Green:** mldsa, mlkem, pqauth, secp256k1, sha3, ssl/tls_crypto/tls_pq/tls_protocol, keyring, ethcrypto, bioauth, **veltro_security** (RestrictNs passes).
- **Triage before re-gating:** `x509` (3 fails — almost certainly **INFR-72**, KeyUsage/SubjectKeyId parsing), env-dependent `factotum` / `wallet9p`, and the slow `slhdsa` / `pqc_fuzz` (need a bound/iteration cap, not a fix).

So this PR lands the mechanism + honest reporting (`::warning::` with the failing modules and the `Total:` line), but **does not `exit 1`**. Follow-up: triage the surfaced list, add an explicit skip-list for env/known-tracked cases, then flip gating on.

## Note
CI will now take longer per job (the suite actually runs to completion, ~minutes), well within the existing `timeout-minutes: 30`.

https://claude.ai/code/session_015DPPUvVfkJmyxLfmffDq8s

---
_Generated by [Claude Code](https://claude.ai/code/session_015DPPUvVfkJmyxLfmffDq8s)_