### PR TITLE
Crypto correctness: ML-DSA FIPS-204 boundary fix, DSAprimes LP64 stack smash, PRNG entropy; test-runner unwedging (INFR-108/261/310)

### DIFF
--- a/libinterp/link.c
+++ b/libinterp/link.c
@@ -42,7 +42,8 @@ linkm(Module *m, Modlink *ml, int i, Import *ldt)
 		if(strcmp(ldt->name, l->name) == 0)
 			break;
 
-	if(l == nil) {
+	/* the loop ends on the nil-name terminator, never a nil l */
+	if(l->name == nil) {
 		snprint(e, sizeof(e), "link failed fn %s->%s() not implemented", m->name, ldt->name);
 		goto bad;
 	}

--- a/libsec/dsaprimes.c
+++ b/libsec/dsaprimes.c
@@ -12,7 +12,10 @@
 static void
 Hrand(uchar *s)
 {
-	ulong *u = (ulong*)s;
+	/* s is the 20-byte (5 x 32-bit) seed buffer. ulong is 8 bytes on
+	 * LP64, so the original ulong* stores wrote 40 bytes -- a 20-byte
+	 * stack smash on every DSA keygen (caught by __stack_chk_fail). */
+	u32int *u = (u32int*)s;
 	*u++ = fastrand();
 	*u++ = fastrand();
 	*u++ = fastrand();

--- a/libsec/genrandom.c
+++ b/libsec/genrandom.c
@@ -41,10 +41,13 @@ X917init(void)
 	int n;
 	uchar mix[128];
 	uchar key3[3][8];
-	ulong *ulp;
+	u32int *ulp;
 
-	ulp = (ulong*)key3;
-	for(n = 0; n < sizeof(key3)/sizeof(ulong); n++)
+	/* truerand() yields 32 bits. Filling ulong-sized (8-byte on LP64)
+	 * slots left the high half of every slot zero -- 12 of the 24 key
+	 * bytes -- halving the X9.17 PRNG's 3DES key entropy. */
+	ulp = (u32int*)key3;
+	for(n = 0; n < sizeof(key3)/sizeof(u32int); n++)
 		ulp[n] = truerand();
 	setupDES3state(&x917state.des3, key3, nil);
 	X917(mix, sizeof mix);

--- a/libsec/mldsa_poly.c
+++ b/libsec/mldsa_poly.c
@@ -54,8 +54,14 @@ mldsa_decompose(int32 *a1, int32 *a0, int32 a, int32 gamma2)
 		*a0 -= 2 * gamma2;
 
 	if(a - *a0 == MLDSA_Q - 1){
+		/* FIPS 204 Alg 36: r1 = 0, r0 = r0 - 1 (i.e. a - q).
+		 * Pinning r0 to -1 here understated |r0| for every a in the
+		 * top gamma2-sized window below q-1, so the signer's
+		 * ||r0|| < gamma2 - beta rejection check passed signatures
+		 * it must reject -- rare data-dependent verify failures
+		 * (INFR-108). */
 		*a1 = 0;
-		*a0 = -1;
+		*a0 -= 1;
 	} else {
 		t = a - *a0;
 		*a1 = t / (2 * gamma2);

--- a/tests/awk_test.b
+++ b/tests/awk_test.b
@@ -23,12 +23,24 @@ include "testing.m";
 AwkTest: module
 {
 	init: fn(nil: ref Draw->Context, args: list of string);
+
+	# INFR-310 workaround: keep this module type structurally distinct
+	# from Cmd below. The compiler shares one LDT between structurally
+	# identical module types, and the ref-fn'd test functions pollute
+	# it -- making `load Cmd "/dis/awk.dis"` demand that awk implement
+	# the test functions ("link typecheck Awk->testArithmetic()"),
+	# which silently skipped every test in this file.
+	ldtworkaround: fn();
 };
 
 Cmd: module
 {
 	init: fn(ctxt: ref Draw->Context, args: list of string);
 };
+
+ldtworkaround()
+{
+}
 
 passed := 0;
 failed := 0;
@@ -118,6 +130,10 @@ runawk(args: list of string, input: string): string
 
 runawkproc(args: list of string, stdout: ref Sys->FD, done: chan of int)
 {
+	# Save the real stdout: the fd table is shared across spawn, so
+	# parking /dev/null in slot 1 (the previous EOF fix here) silenced
+	# every test-result line printed after the first runawk call.
+	origout := sys->fildes(1);
 	sys->dup(stdout.fd, 1);
 	stdout = nil;
 
@@ -129,8 +145,8 @@ runawkproc(args: list of string, stdout: ref Sys->FD, done: chan of int)
 	"*" =>
 		;
 	}
-	# Close the dup'd write end so the parent's read gets EOF
-	sys->dup(sys->open("/dev/null", Sys->OWRITE).fd, 1);
+	# Restore fd 1 so the pipe's write end closes (parent's read EOFs)
+	sys->dup(origout.fd, 1);
 	done <-= 1;
 }
 

--- a/tests/cut_test.b
+++ b/tests/cut_test.b
@@ -23,12 +23,23 @@ include "testing.m";
 CutTest: module
 {
 	init: fn(nil: ref Draw->Context, args: list of string);
+
+	# INFR-310 workaround: keep this module type structurally distinct
+	# from Cmd below. The compiler shares one LDT between structurally
+	# identical module types, and the ref-fn'd test functions pollute
+	# it -- making `load Cmd "/dis/cut.dis"` demand that cut implement
+	# the test functions ("link typecheck Cut->testChars()").
+	ldtworkaround: fn();
 };
 
 Cmd: module
 {
 	init: fn(ctxt: ref Draw->Context, args: list of string);
 };
+
+ldtworkaround()
+{
+}
 
 passed := 0;
 failed := 0;
@@ -137,7 +148,13 @@ runcut(args: list of string, input: string): string
 
 runcutproc(args: list of string, stdout: ref Sys->FD, done: chan of int)
 {
-	# Redirect stdout
+	# Save the real stdout, then redirect fd 1 at the pipe. The fd
+	# table is shared across spawn, so fd 1 MUST be restored before
+	# this proc exits: while the pipe's write end sits in slot 1 the
+	# parent's read loop can never see EOF (the original version of
+	# this test deadlocked here), and parking /dev/null there instead
+	# would swallow every later test-result line.
+	origout := sys->fildes(1);
 	sys->dup(stdout.fd, 1);
 	stdout = nil;
 
@@ -149,6 +166,7 @@ runcutproc(args: list of string, stdout: ref Sys->FD, done: chan of int)
 	"*" =>
 		;
 	}
+	sys->dup(origout.fd, 1);
 	done <-= 1;
 }
 


### PR DESCRIPTION
## Summary

Release-prep crypto sweep. Three genuine defects fixed in libsec, one runtime-linker misreport fixed, and the in-emu test runner unwedged (which is what let us reach and validate the crypto fixes).

### INFR-108 — ML-DSA-65 rare verify-of-own-signature failures (root-caused, fixed)
- `mldsa_decompose()` mishandled the FIPS 204 Alg 36 boundary case: it pinned `r0` to `−1` instead of preserving the value (`r0 − 1` = `a − q`), silently disabling part of the signer's `‖r0‖∞ < γ2−β` rejection check (~3% of coefficients fall in the affected window)
- Pure-C harness (ASan+UBSan clean — rules out memory corruption and the JIT): 7/5000 failures before → **0/50,000** after
- Limbo `mldsa_stress_test` on the rebuilt emu: **0/10 `-c0`, 0/10 `-c1`** (was 6/10 and 2/10)
- Also resolves INFR-109: the claimed ARM64-JIT amplification does not reproduce — the bug was mode-independent

### INFR-261 — "AES→DES keyring heap corruption" (explained, fixed at root)
- `DSAprimes`' `Hrand()` filled a 20-byte seed buffer through `ulong*` — 8 bytes on LP64 — a **20-byte stack smash on every DSA keygen**. macOS arm64's stack protector aborts the emu (SIGABRT mid-suite at `InteropDSA`); where the canary survives, the smash corrupts `DSAprimes`' own `mpint` pointers → wild heap writes. `keyring_test` runs DSA keygen in-process before its AES/DES cases — the reported "layout-dependent corruption of an unrelated DES state" profile
- `genrandom`'s X9.17 init left **12 of 24 3DES key bytes zero** on LP64 (32-bit `truerand()` into 8-byte slots) — halved PRNG key entropy
- Both are pre-LP64 Plan 9 code; upstream Inferno has the same defects on 64-bit Unix
- With these fixed (plus a stale `libkeyring.a` rebuilt — the #227 DSA serialisation fix had never been linked into the emu): `interop_test` **6/6** incl. the formerly-aborting `InteropDSA`, and the full-suite run passes the exact `keyring_test` `AES256`/`DESCBC` cases INFR-261 reported (27 passed / 1 skipped)

### INFR-310 — test runner permanently wedged at cut_test
- Worked around the limbo compiler LDT-pollution bug (filed with full mechanism on the ticket): `ref fn`'d local test functions leak into the LDT shared between structurally identical module types, so `load Cmd "/dis/cut.dis"` demanded cut implement the test functions. awk_test's tests had **never executed** (masked by skip guards); cut_test deadlocked
- Fixed the fd-1 handling in both tests' run helpers (shared fd table: pipe write end parked in slot 1 starved the parent of EOF; the previous `/dev/null` parking silenced all subsequent output)
- `libinterp/link.c`: missing functions now report "not implemented" instead of a bogus `typecheck 0/<sig>` (dead branch — `l` is never nil)
- cut/awk tests now genuinely run and expose latent defects in the ported commands (cut 3, awk 12 failures) — tracked as follow-up on INFR-310, pre-existing since the port

## Test plan
- [x] Pure-C ML-DSA harness: 0/50,000, sanitizers clean
- [x] `mldsa_stress_test`: 0/10 `-c0` + 0/10 `-c1` (rebuilt emu)
- [x] `interop_test` 6/6 (DSA no longer aborts the emu)
- [x] DSA probes: sign/verify incl. pk/cert string round-trips
- [x] Full in-emu suite run: passes `cut` (no wedge), `interop`, `keyring` 27/1 incl. AES256+DESCBC
- [x] Regression battery: crypto_props 20/20 soak, x509 21/21, crypto 17/17, jit_test 298/298

🤖 Generated with [Claude Code](https://claude.com/claude-code)