### PR TITLE
test(tool_schema): assert valid JSON type, not string-only (INFR-312)

### DIFF
--- a/tests/tool_schema_test.b
+++ b/tests/tool_schema_test.b
@@ -237,11 +237,27 @@ testRequiredKeysAreDeclared(t: ref T)
 	}
 }
 
-# String-only convention: V1 schemas use string-typed properties so the
-# bridge's insertion-order space-join produces a valid ctl-line. A
-# non-string property would be silently dropped by the current
-# extracttoolargs() collapse. Flag this so future contributors notice.
-testPropertiesAreStringTyped(t: ref T)
+# Every schema property must declare a valid JSON Schema type.
+#
+# This originally asserted "string" specifically — a V1 text-bridge
+# constraint from when a non-string property would be silently dropped by
+# extracttoolargs()'s space-join into a ctl-line. That no longer holds:
+# extracttoolargs() now stringifies non-string properties via .text(), and
+# JSON-native tools parse their raw JSON args directly (e.g. spawn detects a
+# leading '{' and runs parsejsonspecs() on its `agents` array). So a
+# structured type like array/object is legitimate; assert validity, not
+# string-ness.
+validjsontype(ty: string): int
+{
+	case ty {
+	"string" or "number" or "integer" or "boolean" or "array" or "object" or "null" =>
+		return 1;
+	* =>
+		return 0;
+	}
+}
+
+testPropertiesAreTyped(t: ref T)
 {
 	for(i := 0; i < len TOOLS; i++) {
 		name := TOOLS[i];
@@ -266,9 +282,9 @@ testPropertiesAreStringTyped(t: ref T)
 			for(ml := po.mem; ml != nil; ml = tl ml) {
 				(pname, pval) := hd ml;
 				ptype := getstring(pval, "type");
-				t.assertseq(ptype, "string",
-					sys->sprint("%s.%s: property type is 'string'",
-						name, pname));
+				t.assert(validjsontype(ptype),
+					sys->sprint("%s.%s: declares a valid JSON type (got %q)",
+						name, pname, ptype));
 			}
 		}
 	}
@@ -482,7 +498,7 @@ init(nil: ref Draw->Context, args: list of string)
 
 	run("SchemaShapeAllTools", testSchemaShapeAllTools);
 	run("RequiredKeysAreDeclared", testRequiredKeysAreDeclared);
-	run("PropertiesAreStringTyped", testPropertiesAreStringTyped);
+	run("PropertiesAreTyped", testPropertiesAreTyped);
 	run("SchemaEndpointMatchesToolSchema", testSchemaEndpointMatchesToolSchema);
 	run("BuildToolDefsUsesPerToolSchemas", testBuildToolDefsUsesPerToolSchemas);
 	run("CtlRoundtripStillWorks", testCtlRoundtripStillWorks);


### PR DESCRIPTION
## Summary

`tool_schema_test::testPropertiesAreStringTyped` asserted that **every** property in **every** tool's JSON schema has `"type": "string"`. The `spawn` tool legitimately declares `"agents": {"type": "array"}` (its required param — a list of 1–5 subagent specs), so the test failed: `spawn.agents: got "array", want "string"`. This was the one genuine, non-environmental Limbo failure left in the first full-suite baseline (INFR-312).

The schema is correct; the test's invariant is stale. The "string-only" rule was a V1 text-bridge constraint from when a non-string property was silently dropped by `extracttoolargs()`'s space-join into a ctl-line. Two things made it obsolete:
- `extracttoolargs()` (`appl/veltro/agentlib.b:642`) now stringifies non-string properties via `.text()` rather than dropping them;
- JSON-native tools parse their raw JSON args directly — `spawn.exec()` detects a leading `{` and runs `parsejsonspecs()` over the `agents` array.

## Change
- Renamed `testPropertiesAreStringTyped` → `testPropertiesAreTyped`; it now asserts each property declares a *valid* JSON Schema type (`string`/`number`/`integer`/`boolean`/`array`/`object`/`null`) instead of literally `string`. Comment updated to record the history.

## Test plan
`-c0` and `-c1`: **3 passed, 3 skipped** (was 2 passed, 1 failed, 3 skipped). The 3 skips are the tools9p-gated cases (clean skips via the guard hardening in #239).

🤖 Generated with [Claude Code](https://claude.com/claude-code)