### PR TITLE
[codex] fix auth listener fail-closed and llmsrv bounds

### DIFF
--- a/appl/cmd/listen.b
+++ b/appl/cmd/listen.b
@@ -71,6 +71,10 @@ init(drawctxt: ref Draw->Context, argv: list of string)
 	}
 	if (doauth && algs == nil)
 		algs = getalgs();
+	if (doauth && algs == nil) {
+		sys->fprint(stderr(), "listen: authentication requested, but no SSL algorithms are available\n");
+		raise "fail:no auth algorithms";
+	}
 	if (algs != nil) {
 		if (keyfile == nil)
 			keyfile = "/usr/" + user() + "/keyring/default";

--- a/appl/cmd/llmsrv.b
+++ b/appl/cmd/llmsrv.b
@@ -154,6 +154,13 @@ sessions: array of ref LlmSession;
 nsessions: int;
 nextsid: int;
 
+MAXSESSIONS: con 128;
+MAXPROMPT: con 1048576;
+MAXSYSTEM: con 262144;
+MAXTOOLS: con 1048576;
+MAXPREFILL: con 65536;
+MAXSETTING: con 4096;
+
 # Backend configuration
 backend: string;      # "api" or "openai"
 apikey: string;
@@ -345,6 +352,8 @@ findsessionbyname(name: string): ref LlmSession
 
 newsession(): ref LlmSession
 {
+	if(nsessions >= MAXSESSIONS)
+		return nil;
 	tok := gentoken();
 	if(tok == nil)
 		return nil;
@@ -721,13 +730,23 @@ Serve:
 				# device splits one client write() into multiple <=iounit
 				# Twrites; generation is deferred to the following read so the
 				# whole prompt is assembled first (see triggerpending).
-				sess.pendingwrite = appendbytes(sess.pendingwrite, m.data);
+				(nb, aerr) := appendbyteslimit(sess.pendingwrite, m.data, MAXPROMPT);
+				if(aerr != nil) {
+					sess.pendingwrite = nil;
+					srv.reply(ref Rmsg.Error(m.tag, aerr));
+					break;
+				}
+				sess.pendingwrite = nb;
 				srv.reply(ref Rmsg.Write(m.tag, len m.data));
 
 			Qmodel =>
 				sess := findsession(sid);
 				if(sess == nil) {
 					srv.reply(ref Rmsg.Error(m.tag, Enotfound));
+					break;
+				}
+				if(len m.data > MAXSETTING) {
+					srv.reply(ref Rmsg.Error(m.tag, "model setting too large"));
 					break;
 				}
 				model := resolvemodel(strip(string m.data));
@@ -739,6 +758,10 @@ Serve:
 				sess := findsession(sid);
 				if(sess == nil) {
 					srv.reply(ref Rmsg.Error(m.tag, Enotfound));
+					break;
+				}
+				if(len m.data > MAXSETTING) {
+					srv.reply(ref Rmsg.Error(m.tag, "temperature setting too large"));
 					break;
 				}
 				tstr := strip(string m.data);
@@ -757,13 +780,23 @@ Serve:
 					break;
 				}
 				# Accumulate across write-fragments; committed on clunk.
-				c.data = appendbytes(c.data, m.data);
+				(nb, aerr) := appendbyteslimit(c.data, m.data, MAXSYSTEM);
+				if(aerr != nil) {
+					c.data = nil;
+					srv.reply(ref Rmsg.Error(m.tag, aerr));
+					break;
+				}
+				c.data = nb;
 				srv.reply(ref Rmsg.Write(m.tag, len m.data));
 
 			Qthinking =>
 				sess := findsession(sid);
 				if(sess == nil) {
 					srv.reply(ref Rmsg.Error(m.tag, Enotfound));
+					break;
+				}
+				if(len m.data > MAXSETTING) {
+					srv.reply(ref Rmsg.Error(m.tag, "thinking setting too large"));
 					break;
 				}
 				value := strip(string m.data);
@@ -790,6 +823,10 @@ Serve:
 				}
 				# Don't strip — prefill may have intentional trailing space
 				# But remove trailing newline since shell adds it
+				if(len m.data > MAXPREFILL) {
+					srv.reply(ref Rmsg.Error(m.tag, "prefill too large"));
+					break;
+				}
 				pf := string m.data;
 				if(len pf > 0 && pf[len pf - 1] == '\n')
 					pf = pf[:len pf - 1];
@@ -800,6 +837,10 @@ Serve:
 				sess := findsession(sid);
 				if(sess == nil) {
 					srv.reply(ref Rmsg.Error(m.tag, Enotfound));
+					break;
+				}
+				if(len m.data > MAXSETTING) {
+					srv.reply(ref Rmsg.Error(m.tag, "maxtokens setting too large"));
 					break;
 				}
 				value := strip(string m.data);
@@ -817,6 +858,10 @@ Serve:
 				sess := findsession(sid);
 				if(sess == nil) {
 					srv.reply(ref Rmsg.Error(m.tag, Enotfound));
+					break;
+				}
+				if(len m.data > MAXSETTING) {
+					srv.reply(ref Rmsg.Error(m.tag, "reasoning setting too large"));
 					break;
 				}
 				value := strip(string m.data);
@@ -839,7 +884,13 @@ Serve:
 				# Accumulate the tool-defs JSON across write-fragments; parsed
 				# and committed on clunk (see finalizewrite). The whole array
 				# may exceed one iounit, so it cannot be parsed per-write.
-				c.data = appendbytes(c.data, m.data);
+				(nb, aerr) := appendbyteslimit(c.data, m.data, MAXTOOLS);
+				if(aerr != nil) {
+					c.data = nil;
+					srv.reply(ref Rmsg.Error(m.tag, aerr));
+					break;
+				}
+				c.data = nb;
 				srv.reply(ref Rmsg.Write(m.tag, len m.data));
 
 			Qcompact =>
@@ -906,19 +957,24 @@ Serve:
 # document. We deliberately do NOT index by absolute offset: the persistent
 # ORDWR /ask fid's write offset climbs across turns (queryllmfd never seeks 0),
 # which would make absolute-offset placement grow without bound.
-appendbytes(buf, data: array of byte): array of byte
+appendbyteslimit(buf, data: array of byte, limit: int): (array of byte, string)
 {
 	if(data == nil || len data == 0)
-		return buf;
+		return (buf, nil);
+	blen := 0;
+	if(buf != nil)
+		blen = len buf;
+	if(blen + len data > limit)
+		return (nil, sys->sprint("write too large: limit %d bytes", limit));
 	if(buf == nil) {
 		nb := array[len data] of byte;
 		nb[0:] = data;
-		return nb;
+		return (nb, nil);
 	}
 	nb := array[len buf + len data] of byte;
 	nb[0:] = buf;
 	nb[len buf:] = data;
-	return nb;
+	return (nb, nil);
 }
 
 # Start a generation turn if a fully-written prompt is pending and none is

--- a/appl/cmd/styxlisten.b
+++ b/appl/cmd/styxlisten.b
@@ -45,7 +45,7 @@ init(ctxt: ref Draw->Context, argv: list of string)
 	doauth := 1;
 	synchronous := 0;
 	trusted := 0;
-	keyfile := "";
+	keyfile: string;
 
 	while ((opt := arg->opt()) != 0) {
 		case opt {
@@ -76,6 +76,8 @@ init(ctxt: ref Draw->Context, argv: list of string)
 	arg = nil;
 	if (doauth && algs == nil)
 		algs = getalgs();
+	if (doauth && algs == nil)
+		error("authentication requested, but no SSL algorithms are available");
 	addr := netmkaddr(hd argv, "tcp", "styx");
 	cmd := tl argv;
 

--- a/tests/llmsrv_test.b
+++ b/tests/llmsrv_test.b
@@ -192,6 +192,11 @@ init(nil: ref Draw->Context, args: list of string)
 	run("AutoCompactAbove", testAutoCompactAbove);
 	run("AutoCompactCtlParse", testAutoCompactCtlParse);
 
+	# Bounded write-reassembly tests
+	run("AppendBytesLimitEmpty", testAppendBytesLimitEmpty);
+	run("AppendBytesLimitAppend", testAppendBytesLimitAppend);
+	run("AppendBytesLimitReject", testAppendBytesLimitReject);
+
 	# Float parser tests
 	run("ParseFloatInteger", testParseFloatInteger);
 	run("ParseFloatDecimal", testParseFloatDecimal);
@@ -786,6 +791,31 @@ testAutoCompactCtlParse(t: ref T)
 	t.asserteq(autocompactarg("autocompact xyz"), -1, "garbage arg -> invalid");
 }
 
+# ==================== Bounded Write Reassembly Tests ====================
+
+testAppendBytesLimitEmpty(t: ref T)
+{
+	(nb, err) := appendbyteslimit(nil, nil, 4);
+	t.assertnil(err, "empty append succeeds");
+	t.assert(nb == nil, "empty append stays nil");
+}
+
+testAppendBytesLimitAppend(t: ref T)
+{
+	(nb, err) := appendbyteslimit(nil, array of byte "ab", 4);
+	t.assertnil(err, "initial append succeeds");
+	(nb, err) = appendbyteslimit(nb, array of byte "cd", 4);
+	t.assertnil(err, "second append at limit succeeds");
+	t.assertseq(string nb, "abcd", "buffer content");
+}
+
+testAppendBytesLimitReject(t: ref T)
+{
+	(nb, err) := appendbyteslimit(array of byte "abc", array of byte "de", 4);
+	t.assertnotnil(err, "append beyond limit rejected");
+	t.assert(nb == nil, "rejected append returns nil buffer");
+}
+
 # ==================== Float Parser Tests ====================
 
 testParseFloatInteger(t: ref T)
@@ -935,6 +965,27 @@ autocompactarg(cmd: string): int
 	if(len cmd < len prefix || cmd[0:len prefix] != prefix)
 		return -1;
 	return strtoint(strip(cmd[len prefix:]));
+}
+
+# Bounded write reassembly (replicates llmsrv.b appendbyteslimit).
+appendbyteslimit(buf, data: array of byte, limit: int): (array of byte, string)
+{
+	if(data == nil || len data == 0)
+		return (buf, nil);
+	blen := 0;
+	if(buf != nil)
+		blen = len buf;
+	if(blen + len data > limit)
+		return (nil, "write too large");
+	if(buf == nil) {
+		nb := array[len data] of byte;
+		nb[0:] = data;
+		return (nb, nil);
+	}
+	nb := array[len buf + len data] of byte;
+	nb[0:] = buf;
+	nb[len buf:] = data;
+	return (nb, nil);
 }
 
 # Integer parser (replicates llmsrv.b strtoint: -1 on empty/non-digit)


### PR DESCRIPTION
## Summary

- make authenticated listen and styxlisten fail closed when SSL/auth algorithms cannot be discovered
- fix styxlisten default keyfile handling so the default keyring path is used correctly
- add llmsrv bounds for session count and aggregate write reassembly across prompt, system, tools, prefill, and scalar settings
- add llmsrv regression coverage for bounded write reassembly

## Security Impact

This removes a fail-open listener mode where requested authentication could silently degrade to anonymous service if SSL algorithm discovery failed. It also limits authenticated llmsrv clients from growing server memory without bound through fragmented 9P writes or unbounded session creation.

## Validation

- rebuilt listen.dis, styxlisten.dis, and llmsrv.dis with the repo Limbo toolchain
- rebuilt llmsrv_test.dis
- ran /tests/llmsrv_test.dis -v: PASS, 62 passed
- git diff --check