### PR TITLE
compliance: createsignerkey -c (CNSA ML-DSA-87) + NODEVS status correction

### DIFF
--- a/appl/cmd/auth/createsignerkey.b
+++ b/appl/cmd/auth/createsignerkey.b
@@ -41,7 +41,7 @@ init(nil: ref Draw->Context, argv: list of string)
 		loaderr(Arg->PATH);
 
 	arg->init(argv);
-	arg->setusage("createsignerkey [-a algorithm] [-f keyfile] [-e ddmmyyyy] [-b size-in-bits] name-of-owner");
+	arg->setusage("createsignerkey [-a algorithm] [-c] [-f keyfile] [-e ddmmyyyy] [-b size-in-bits] name-of-owner");
 	alg := algs[0];
 	filename := "/keydb/signerkey";
 	expire := SKexpire;
@@ -58,6 +58,9 @@ init(nil: ref Draw->Context, argv: list of string)
 				else if(alg == algs[i])
 					break;
 			}
+		'c' =>
+			# CNSA 2.0 mode: ML-DSA-87 signer (FIPS 204, NIST Category 5).
+			alg = "mldsa87";
 		'f' or 'k' =>
 			filename = arg->earg();
 		'e' =>

--- a/appl/veltro/SECURITY.md
+++ b/appl/veltro/SECURITY.md
@@ -608,26 +608,28 @@ This is where `nswalk` lives: not as a user-facing tool, but as a
 subroutine of the ground-truth check. Once it exists as a subroutine,
 exposing it as a user tool is cheap.
 
-### NODEVS short-term fix, independent of nsaudit
+### NODEVS device-attach gate (RESOLVED)
 
-`pctl(NODEVS)` is applied only in the spawned-child path
-(`spawn.b:576`). Top-level agents (`veltro.b:168`, `repl.b:169`,
-`tools9p.b:644`) call `pctl(FORKNS)` and `restrictns()` but leave
-`pgrp->nodevs == 0`. The kernel device gate is at
-`emu/port/chan.c:1041-1051`; with `nodevs` unset, `sys->bind("#sfactotum",
-"/tmp/veltro/x", MREPL)` succeeds and reaches factotum regardless of
-path-based restriction.
+`pctl(NODEVS)` is now applied at **every** agent FORKNS site — the spawned
+child (`spawn.b:1071`) **and** all three top-level entry points:
+`veltro.b:169`, `repl.b:170`, `tools9p.b:798`, each immediately after
+`pctl(FORKNS)`. The kernel device gate is at `emu/port/chan.c:1046-1053`;
+with `nodevs` set, `sys->bind("#sfactotum", "/tmp/veltro/x", MREPL)` (and any
+`#x` attach outside the `|esDa` allowlist) fails, so device-attach cannot
+bypass the path-based restriction.
 
-Today this is latent — top-level agents do not invoke `bind` on `#x`
-paths from model-driven code. It becomes exploitable the moment any tool
-or exec invocation does.
+This property is locked in by a regression test —
+`testNodevsBlocksDeviceAttach` in `tests/veltro_security_test.b` — which
+asserts that after `NODEVS`, `bind("#p", …)` and `bind("#sfactotum", …)`
+both fail (and that `#p` *succeeds* before `NODEVS`, so the test proves the
+gate, not an unrelated error).
 
-Fix: add `sys->pctl(Sys->NODEVS, nil)` to the three top-level FORKNS
-sites. The kernel gate is strictly stronger than the path gate for
-device-attach, and none of the top-level agents has a documented need for
-`#x` devices outside the `nodevs` allowlist (`|esDa`). Once fixed,
-`SUBAGENT_MISSING_NODEVS` plus an analogous `TOPLEVEL_MISSING_NODEVS`
-rule keep it fixed.
+The one remaining `FORKNS` without `NODEVS` is the throwaway introspection
+fork in `tools9p.b`'s `emitmanifestnow()`: it forks only to compute a
+namespace manifest for the UI and **discards** that namespace immediately —
+it runs no model-driven code and never execs, so it is not an agent
+sandbox and does not need the gate. The planned `nsaudit` rule
+`TOPLEVEL_MISSING_NODEVS` keeps the agent sites covered going forward.
 
 ### Sequencing
 

--- a/doc/compliance/CNSA-2.0.md
+++ b/doc/compliance/CNSA-2.0.md
@@ -89,9 +89,9 @@ implementation and the regression test.
 | Implementation | `libsec/mldsa.c`, `mldsa_ntt.c`, `mldsa_poly.c`; **both** ML-DSA-65 and ML-DSA-87 present |
 | Keyring binding | `libkeyring/mldsaalg.c` — registered as `SigAlgVec` slots `mldsa65`, `mldsa87` (`libinterp/keyring.c:2403`–`:2406`) |
 | X.509 | OIDs `id-ML-DSA-65` 2.16.840.1.101.3.4.3.18, `id-ML-DSA-87` …3.19 (`appl/lib/crypt/pkcs.b`, `appl/lib/crypt/x509.b`) |
-| Key generation | `auth/createsignerkey -a mldsa87 <name>` (`appl/cmd/auth/createsignerkey.b`) |
+| Key generation | `auth/createsignerkey -a mldsa87 <name>`, or the **`-c` CNSA flag** (selects ML-DSA-87 in one option) (`appl/cmd/auth/createsignerkey.b`) |
 | Evidence | `tests/mldsa_test.b` (KAT, sign/verify, wrong-key rejection, cert verify), `tests/mldsa_stress_test.b`, `tests/pqauth_test.b` *HybridHandshakeMLDSA* (fully-PQ handshake) |
-| Status | **Substantially met** — ML-DSA-87 implemented, tested, and selectable; the *recommended/default* signer parameter is ML-DSA-65 (Category 3). See Gap G2. |
+| Status | **Substantially met** — ML-DSA-87 implemented, tested, and now a one-flag CNSA selection (`createsignerkey -c`). The *system-wide* default signer remains ed25519 (non-CNSA deployments unchanged); a global "CNSA mode" across all signing surfaces is the remainder of Gap G2. |
 
 ### 3.5 Software/firmware signing — LMS/XMSS ⚠ substitute present
 
@@ -133,7 +133,7 @@ stricter, transition-safe posture.
 | ID | Gap | CNSA 2.0 requirement | Effort | Tracking |
 |----|-----|----------------------|--------|----------|
 | **G1** | Negotiated key exchange uses ML-KEM-768 (Cat 3); CNSA 2.0 mandates **ML-KEM-1024** (Cat 5). The -1024 primitive already exists — this is a parameter/negotiation selection, not new crypto. | ML-KEM-1024 | Small (wire a hybrid group / native-STS option using the existing `mlkem1024_*` calls) | INFR-329 |
-| **G2** | Default/recommended signer is ML-DSA-65 (Cat 3); CNSA 2.0 mandates **ML-DSA-87** (Cat 5). The -87 algorithm is implemented and selectable. | ML-DSA-87 default in CNSA mode | Small (default selection / "CNSA mode" flag) | INFR-330 |
+| **G2** | CNSA 2.0 mandates **ML-DSA-87** (Cat 5). *Partially closed:* `createsignerkey -c` now selects ML-DSA-87 in one flag. Remainder: a system-wide "CNSA mode" making Cat-5 the default across all signing surfaces. | ML-DSA-87 across all surfaces | Small | INFR-330 |
 | **G3** | No LMS/XMSS (SP 800-208) for software/firmware signing. SLH-DSA is present as a hash-based substitute. | LMS or XMSS | Medium (new primitive) — or a documented accreditor waiver accepting SLH-DSA | INFR-331 |
 
 None of G1–G3 require architectural change; G1/G2 are selection of already-implemented

--- a/doc/compliance/SP800-207-zero-trust.md
+++ b/doc/compliance/SP800-207-zero-trust.md
@@ -82,15 +82,17 @@ functions verified map directly to the namespace syscalls (`pgrpcpy`, `cmount`,
 | `tests/veltro_security_test.b` | allowlist visibility, exclusion of non-granted items, `restrictns()` full policy, `verifyns()` violation detection, audit logging, negative assertions on `/.env`/`/.git`/`/CLAUDE.md`/`/n/local` |
 | `tests/veltro_concurrent_test.b` | concurrent init / restrictdir / restrictns (race safety) |
 
-## 5. Residual notes (not gaps in posture; hardening / observability)
+## 5. Residual notes (observability / future hardening)
 
-- **Top-level `NODEVS`.** `pctl(NODEVS)` is unconditional in spawned children; for
-  top-level agents the device-attach gate is currently latent rather than set (no
-  top-level agent invokes `#x` binds from model-driven code today). Hardening item and a
-  proposed `nsaudit` rule (`TOPLEVEL_MISSING_NODEVS`) are described in
-  `appl/veltro/SECURITY.md` §"NODEVS short-term fix". *Does not weaken the Zero Trust
-  claim* (path-based restriction already hides host resources), but closing it makes the
-  kernel gate strictly enforce it. Recommend tracking as its own task.
+- **`NODEVS` device-attach gate — applied.** `pctl(NODEVS)` is set at every agent
+  FORKNS site: the spawned child (`spawn.b:1071`) and all three top-level entry points
+  (`veltro.b:169`, `repl.b:170`, `tools9p.b:798`), each right after `FORKNS`. The kernel
+  gate (`emu/port/chan.c:1046-1053`) then blocks any `#x` attach outside the `|esDa`
+  allowlist, so device-attach cannot bypass path restriction. Locked in by
+  `testNodevsBlocksDeviceAttach` in `tests/veltro_security_test.b` (asserts `#p` /
+  `#sfactotum` bind fails after `NODEVS`). The only un-gated `FORKNS` is the throwaway
+  manifest fork in `tools9p.b`'s `emitmanifestnow()`, whose namespace is discarded and
+  which runs no agent code — not a sandbox. (INFR-341 — verified already implemented.)
 - **`nsaudit`** (config-time authority linter) is in progress (`appl/cmd/nsaudit.b`) — a
   *pre-flight* check that a shipped capability set grants only intended authority. It
   strengthens tenet 7 evidence; the namespace remains the enforcer regardless.
@@ -99,8 +101,9 @@ functions verified map directly to the namespace syscalls (`pgrpcpy`, `cmount`,
 
 SP 800-207's tenets are satisfied by the default runtime posture, the mechanism is
 documented and tested, and the underlying kernel isolation is formally verified. **Met**
-for the architectural posture. The two residual items above are hardening/observability,
-not posture defects; recommend a tracking task for top-level `NODEVS`.
+for the architectural posture. The `NODEVS` device-attach gate is applied at all agent
+sites and test-locked; `nsaudit` (pre-flight config linter) is the remaining
+observability enhancement, not a posture defect.
 
 ## 7. References
 


### PR DESCRIPTION
## Summary

The lean compliance code follow-ups from epic **INFR-328**. Kept deliberately minimal and true to Inferno conventions (no JSON, no namespace-boundary changes).

### 1. `createsignerkey -c` — CNSA 2.0 signer (INFR-330)
Adds a `-c` flag that selects **ML-DSA-87** (FIPS 204, NIST Category 5) in one option. Additive and **non-breaking**: the system-wide default signer stays `ed25519`; non-CNSA deployments are unaffected. The algorithm was already implemented/registered/selectable (`-a mldsa87`) — this just makes the CNSA-strict choice a single flag. Partially closes CNSA 2.0 gap **G2**.

### 2. NODEVS status correction (INFR-341) — docs only
Faithful correction: `pctl(NODEVS)` is in fact already set at **every** agent FORKNS site (`spawn.b:1071`, `veltro.b:169`, `repl.b:170`, `tools9p.b:798`), and the property is locked in by the existing `testNodevsBlocksDeviceAttach` regression test (`tests/veltro_security_test.b`). The only un-gated `FORKNS` is the throwaway manifest fork in `emitmanifestnow()` (namespace discarded, runs no agent code — not a sandbox). Updates `appl/veltro/SECURITY.md` (was framed as a not-yet-done "short-term fix") and the SP 800-207 evidence residual note. **INFR-341 verified already implemented — no code change.**

## What I deliberately did NOT do
- **SBOM in `release.yml` (INFR-340)** — it only runs on a release tag, so PR CI can't exercise it. Deferred to a CI-verifiable follow-up rather than merge unverified.
- **No namespace-boundary changes.** The device-attach gate was already in place; this PR only documents that accurately and adds an opt-in signer flag.

## Test plan
- CI "Linux AMD64 Build & Test" bootstraps the full build (compiles `appl/cmd`, incl. `createsignerkey.b`) and runs the in-emu `runner.dis` suite, which includes `testNodevsBlocksDeviceAttach`.
- The `-c` flag is a bare option setting `alg = "mldsa87"` (already a valid entry in `algs[]`), so `genSK` accepts it unchanged.
- Local native-toolchain build was not feasible in this environment (macOS-oriented bootstrap); relying on CI as the verification gate.

Refs: INFR-330, INFR-341 · epic INFR-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk

---
_Generated by [Claude Code](https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk)_