### PR TITLE
ci(sbom): CI-verifiable SPDX SBOM generation + validation (INFR-340)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,58 @@
+name: SBOM
+
+# Generates and validates a Software Bill of Materials (SPDX) for the source
+# tree on every PR and push, so the SBOM tooling is exercised by CI (not only
+# at release time). Shipping the SBOM attached to releases + provenance
+# attestation is wired separately in release.yml (see INFR-340).
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate & validate SBOM
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Generate SPDX SBOM (syft)
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        path: .
+        format: spdx-json
+        output-file: infernode.spdx.json
+        upload-artifact: false
+
+    - name: Validate SBOM
+      run: |
+        set -eu
+        f=infernode.spdx.json
+        test -s "$f" || { echo "SBOM not generated"; exit 1; }
+        ver=$(jq -r '.spdxVersion // empty' "$f")
+        n=$(jq -r '.packages | length' "$f")
+        echo "SBOM: ${ver:-<none>}, ${n} packages"
+        case "$ver" in
+          SPDX-*) ;;
+          *) echo "missing/invalid spdxVersion"; exit 1 ;;
+        esac
+        [ "$n" -ge 1 ] || { echo "SBOM has no packages — generation produced nothing"; exit 1; }
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      with:
+        name: sbom-spdx
+        path: infernode.spdx.json
+        if-no-files-found: error

--- a/doc/compliance/README.md
+++ b/doc/compliance/README.md
@@ -37,7 +37,7 @@ evidence has been reviewed.
 | ✅ **Met** | SP 800-207 Zero Trust | — (formally verified) |
 | ✅ **Met** | NIST PQC migration (hybrid) | — |
 | ✅ **Met** | FIDO2 / CTAP2 (authenticator) | — |
-| ✅ **Met** | SLSA Build L3 | L4 + SBOM (INFR-340) |
+| ✅ **Met** | SLSA Build L3 | SBOM now generated+validated in CI; release-attached SBOM + L4 (INFR-340) |
 | ◐ **Substantially met** | CNSA 2.0 | ML-KEM-1024 + ML-DSA-87 (INFR-329/330); LMS/XMSS (INFR-331) |
 | ◐ **Substantially met** | X.509 / mTLS | client-cert over TLS (INFR-344) |
 | ◐ **Partial** | SP 800-63B AAL3 | DK save-back + dual-key (EPIC 1) |

--- a/doc/compliance/SLSA.md
+++ b/doc/compliance/SLSA.md
@@ -35,20 +35,30 @@ isolated CI build that emits **non-forgeable provenance** and are **signed**. Bu
 
 | Item | Standard | Tracking |
 |------|----------|----------|
-| **SBOM** (SPDX or CycloneDX) per release | roadmap "SBOM (SPDX/CycloneDX)" | INFR-340 |
+| **SBOM** (SPDX) generated + validated in CI | roadmap "SBOM (SPDX/CycloneDX)" | ✅ `.github/workflows/sbom.yml` (syft → SPDX-JSON, validated, uploaded, on every PR/push) |
+| **SBOM attached to releases** + provenance attestation | roadmap "SBOM" / SLSA L4 | ☐ release.yml wiring — INFR-340 |
 | **in-toto** attestation beyond build-provenance | roadmap "in-toto" | INFR-340 |
 | **Hermetic + reproducible** build (SLSA L4) | SLSA L4 | INFR-340 |
 
 These are CI-config / documentation additions (no runtime code); any workflow change is
 flagged for review.
 
+**SBOM scope note (honest):** InferNode's core is first-party C and Limbo with no
+package-manager manifests, so the generated SPDX SBOM principally captures the
+third-party components that *do* carry external provenance (e.g. the Go modules under
+`tools/godis`, Android/Gradle deps) plus detected binaries — which is the set an SBOM
+exists to track for vulnerability management. The validation step fails CI if generation
+yields zero packages, so an empty/broken SBOM is caught.
+
 ## 4. Disposition
 
 **Met at SLSA Build L3.** The provenance + signing + checksum + pinning + scorecard evidence
-above substantiates the roadmap's "at SLSA 3" claim. L4 (hermetic/reproducible) and SBOM are
-the documented next push, tracked under INFR-340.
+above substantiates the roadmap's "at SLSA 3" claim. **SBOM generation is now exercised by
+CI on every PR/push** (`sbom.yml`); the remaining SR push is attaching the SBOM to release
+artifacts with an attestation (release.yml), plus hermetic/reproducible builds for L4 —
+tracked under INFR-340.
 
 ## 5. References
 
 - SLSA v1.0 (slsa.dev); OpenSSF Scorecard; Sigstore/cosign; SPDX / CycloneDX; in-toto.
-- `.github/workflows/release.yml`, `scorecard.yml`, `verify-dis-paths.yml`.
+- `.github/workflows/release.yml`, `sbom.yml`, `scorecard.yml`, `verify-dis-paths.yml`.

--- a/doc/compliance/SP800-53-171-mapping.md
+++ b/doc/compliance/SP800-53-171-mapping.md
@@ -120,9 +120,12 @@ The release pipeline (`.github/workflows/release.yml`) produces, for every artif
 - **SLSA build provenance attestations** (`actions/attest-build-provenance`, `:1280-1288`)
   for the tarball, DMG, and zip — the SLSA-3 provenance the roadmap claims.
 - **OpenSSF Scorecard** (`scorecard.yml`) continuous supply-chain posture scoring.
+- **SBOM (SPDX)** generated + validated on every PR/push (`.github/workflows/sbom.yml`,
+  syft) — see [`SLSA.md`](SLSA.md) §3.
 
-*Residual / next:* SBOM (SPDX/CycloneDX) generation and in-toto attestation are the
-documented push to SLSA L4 (roadmap "Supply chain & integrity"). Tracked under EPIC 4/SR.
+*Residual / next:* attaching the SBOM to release artifacts with an attestation, in-toto
+attestation, and hermetic/reproducible builds are the documented push to SLSA L4 (roadmap
+"Supply chain & integrity"). Tracked under INFR-340.
 
 ### 5.AU — Audit & Accountability (the gap)
 Today auditing is **per-subsystem**: `emitauditlog()` records namespace operations and the


### PR DESCRIPTION
## Summary

Teed up as a **CI-verifiable** change (per request): SBOM generation now runs on every PR and push, not just at release time — so CI exercises and validates it before merge.

### `.github/workflows/sbom.yml`
- Runs on `pull_request`, `push` to master, and `workflow_dispatch`.
- `syft` (anchore/sbom-action, pinned `e22c389` = v0.24.0, verified against the tag ref) generates an **SPDX-JSON** SBOM of the source tree.
- A `jq` **validation** step fails CI if the SBOM is missing, lacks a valid `spdxVersion`, or has **zero packages** — so an empty/broken SBOM is caught, not silently shipped.
- SBOM uploaded as a build artifact.
- Scoped `permissions: contents: read`; reuses the repo's existing pinned `checkout`/`upload-artifact` SHAs.

## Honest scope note
InferNode's core is first-party C/Limbo with no package manifests, so the SPDX SBOM principally captures the third-party components that carry external provenance (the Go modules under `tools/godis`, Android/Gradle deps) plus detected binaries — the set an SBOM exists to track for vuln management. Documented in `SLSA.md` §3.

## What this does NOT do (deliberately)
- **Attaching the SBOM to release artifacts + attestation** stays in `release.yml` territory, which only runs on a tag and can't be PR-verified — left as the remaining SLSA-L4 / SR step under **INFR-340**. This PR is the CI-verifiable half.

## Evidence updated
`SLSA.md` (SBOM row → generated+validated in CI; release-attach pending), `SP800-53-171-mapping.md` §5.SR, and the register scorecard.

## Test plan
The `sbom` job runs on this PR — generation + validation execute here, so a green check *is* the verification. No runtime code touched.

Refs: INFR-340 · epic INFR-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk

---
_Generated by [Claude Code](https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk)_