### PR TITLE
compliance: ship SBOM with releases + SP 800-53 per-control itemization (INFR-340)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1254,6 +1254,17 @@ jobs:
         path: artifacts
         merge-multiple: true
 
+    - name: Generate SBOM (SPDX)
+      # Named infernode-*-sbom.spdx.json so the checksum, cosign-signing and
+      # release-upload steps below cover it automatically (no extra wiring).
+      # Same pinned action proven CI-verifiable in sbom.yml.
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        path: .
+        format: spdx-json
+        output-file: artifacts/infernode-${{ steps.version.outputs.version }}-sbom.spdx.json
+        upload-artifact: false
+
     - name: Generate checksums
       run: |
         cd artifacts

--- a/doc/compliance/README.md
+++ b/doc/compliance/README.md
@@ -60,7 +60,7 @@ Common Criteria — all code- or assessor-gated.
 | **NIST SP 800-207** Zero Trust | [`SP800-207-zero-trust.md`](SP800-207-zero-trust.md) | 0 | **Met** (architectural posture; formally verified) |
 | **NIST SP 800-63B AAL3** | [`SP800-63B-AAL3.md`](SP800-63B-AAL3.md) | 1 | Partial — AAL3 verifier shipped & hardware-verified; EPIC 1 remainder open |
 | **NIST SP 800-92** tamper-evident audit log (AU) | [`SP800-92-audit-log-DESIGN.md`](SP800-92-audit-log-DESIGN.md) | 1 | **Design — awaiting owner approval** (new 9P service; highest-leverage control) |
-| **NIST SP 800-53 / 800-171** control mapping | [`SP800-53-171-mapping.md`](SP800-53-171-mapping.md) | 1 | Partial — first pass complete; 6 families strong; CMMC L2 subset identified |
+| **NIST SP 800-53 / 800-171** control mapping | [`SP800-53-171-mapping.md`](SP800-53-171-mapping.md) + [per-control AC/IA/SC/AU](SP800-53-controls.md) | 1 | Partial — family map + AC/IA/SC/AU itemized; 6 families strong; CMMC L2 subset identified |
 | **FIPS 140-3** readiness | [`FIPS-140-3-readiness.md`](FIPS-140-3-readiness.md) | 2 | Readiness/gap analysis — favorable architecture; 7 gaps (F1–F7) backlogged; not validated |
 | **NIST PQC migration** (hybrid) | [`NIST-PQC-migration.md`](NIST-PQC-migration.md) | 1 | **Met** — hybrid on TLS + native transport, adversarially tested |
 | **FIDO2 / CTAP2** | [`FIDO2-CTAP2.md`](FIDO2-CTAP2.md) | 0→1 | **Met** (authenticator; WebAuthn web-flow is a documented non-goal) |

--- a/doc/compliance/SLSA.md
+++ b/doc/compliance/SLSA.md
@@ -36,7 +36,8 @@ isolated CI build that emits **non-forgeable provenance** and are **signed**. Bu
 | Item | Standard | Tracking |
 |------|----------|----------|
 | **SBOM** (SPDX) generated + validated in CI | roadmap "SBOM (SPDX/CycloneDX)" | ✅ `.github/workflows/sbom.yml` (syft → SPDX-JSON, validated, uploaded, on every PR/push) |
-| **SBOM attached to releases** + provenance attestation | roadmap "SBOM" / SLSA L4 | ☐ release.yml wiring — INFR-340 |
+| **SBOM shipped with releases** (checksummed + cosign-signed) | roadmap "SBOM" | ✅ `release.yml` emits `infernode-<ver>-sbom.spdx.json`, covered by `SHA256SUMS.txt` + a `.sigstore` signature + published with the release |
+| **SBOM provenance attestation** (`attest-sbom`) | roadmap "in-toto" / attestation | ☐ optional next — INFR-340 |
 | **in-toto** attestation beyond build-provenance | roadmap "in-toto" | INFR-340 |
 | **Hermetic + reproducible** build (SLSA L4) | SLSA L4 | INFR-340 |
 
@@ -53,10 +54,10 @@ yields zero packages, so an empty/broken SBOM is caught.
 ## 4. Disposition
 
 **Met at SLSA Build L3.** The provenance + signing + checksum + pinning + scorecard evidence
-above substantiates the roadmap's "at SLSA 3" claim. **SBOM generation is now exercised by
-CI on every PR/push** (`sbom.yml`); the remaining SR push is attaching the SBOM to release
-artifacts with an attestation (release.yml), plus hermetic/reproducible builds for L4 —
-tracked under INFR-340.
+above substantiates the roadmap's "at SLSA 3" claim. **SBOM is generated + validated by CI on
+every PR/push** (`sbom.yml`) **and shipped with every release**, checksummed and cosign-signed
+(`release.yml`). Remaining SR/L4 push: an explicit `attest-sbom` provenance link and
+hermetic/reproducible builds — tracked under INFR-340.
 
 ## 5. References
 

--- a/doc/compliance/SP800-53-171-mapping.md
+++ b/doc/compliance/SP800-53-171-mapping.md
@@ -121,11 +121,12 @@ The release pipeline (`.github/workflows/release.yml`) produces, for every artif
   for the tarball, DMG, and zip — the SLSA-3 provenance the roadmap claims.
 - **OpenSSF Scorecard** (`scorecard.yml`) continuous supply-chain posture scoring.
 - **SBOM (SPDX)** generated + validated on every PR/push (`.github/workflows/sbom.yml`,
-  syft) — see [`SLSA.md`](SLSA.md) §3.
+  syft) **and shipped with every release** — checksummed + cosign-signed (`release.yml`).
+  See [`SLSA.md`](SLSA.md) §3.
 
-*Residual / next:* attaching the SBOM to release artifacts with an attestation, in-toto
-attestation, and hermetic/reproducible builds are the documented push to SLSA L4 (roadmap
-"Supply chain & integrity"). Tracked under INFR-340.
+*Residual / next:* an explicit `attest-sbom` provenance link, in-toto attestation, and
+hermetic/reproducible builds are the documented push to SLSA L4 (roadmap "Supply chain &
+integrity"). Tracked under INFR-340.
 
 ### 5.AU — Audit & Accountability (the gap)
 Today auditing is **per-subsystem**: `emitauditlog()` records namespace operations and the
@@ -141,6 +142,9 @@ underwrites AU-9 integrity-of-audit, SOC 2, and PCI-10 simultaneously). Honest s
 - **First pass complete:** every 800-53 family mapped with mechanism + evidence + honest
   type/status; six families (AC, IA, SC, SI, CM, SR) are technically strong and CA is strong
   on the technical side.
+- **Per-control itemization** for the four load-bearing families (AC / IA / SC / AU) is in
+  [`SP800-53-controls.md`](SP800-53-controls.md) — the control-level granularity an SSP /
+  CMMC L2 assessor works from.
 - **CMMC L2 framing:** scope the SSP around the six strong families; they are the
   hard-to-fake controls.
 - **Biggest single lever:** the AU hash-chained audit service (EPIC 2) — turns AU from

--- a/doc/compliance/SP800-53-controls.md
+++ b/doc/compliance/SP800-53-controls.md
@@ -1,0 +1,83 @@
+# Compliance Evidence — SP 800-53 Rev 5 Per-Control Itemization (AC / IA / SC / AU)
+
+**Standard:** NIST SP 800-53 Rev 5 (selected controls); maps to SP 800-171 / CMMC L2.
+**Parent:** [`SP800-53-171-mapping.md`](SP800-53-171-mapping.md) (family-level). This file
+drills the four technically load-bearing families to individual controls — the granularity
+an SSP / CMMC L2 assessor works from.
+**Tracking:** EPIC 4 / [INFR-340]; program epic [INFR-328].
+**Artifact date:** 2026-06-22.
+**Status convention:** Met · Substantially met · Partial · Planned · Operator (organizational).
+Every "Met/Substantially" row points at code/test or an evidence artifact.
+
+> Honesty notes carried forward: **SC-13** is *partial* because the algorithms are approved
+> but the module is not yet FIPS-validated (Tier 2 — [`FIPS-140-3-readiness.md`](FIPS-140-3-readiness.md)).
+> **AU** is largely *planned/partial* pending the audit-log service
+> ([`SP800-92-audit-log-DESIGN.md`](SP800-92-audit-log-DESIGN.md)).
+
+---
+
+## AC — Access Control
+
+| Control | Requirement (abridged) | Mechanism / evidence | Status |
+|---------|------------------------|----------------------|--------|
+| **AC-2** Account Management | Manage accounts/lifecycle | Factotum credential agent + secstore accounts; lifecycle is partly operator process | Partial |
+| **AC-3** Access Enforcement | Enforce approved authorizations | **Per-process namespace = capability**: an unbound name cannot be expressed; enforcement is structural, not a checkpoint. [`SP800-207-zero-trust.md`](SP800-207-zero-trust.md) §2; `appl/veltro/nsconstruct.b` | **Met** |
+| **AC-4** Information Flow Enforcement | Control information flows between domains | Namespace boundaries mediate flow today; cross-domain *guarded* transfer is the CDS guard (roadmap EPIC 5, planned) | Partial |
+| **AC-5** Separation of Duties | Separate duties via access | Capability sets per agent; distinct factotum identities | Partial |
+| **AC-6** Least Privilege | Grant least privilege | **Capability attenuation** (child caps ≤ parent, structural); default-deny bind-replace; `NODEVS` device gate. [`SP800-207-zero-trust.md`](SP800-207-zero-trust.md) §2; `tests/veltro_security_test.b` | **Met** |
+| **AC-6(9)** Audit of Privileged Functions | Log privileged use | Ties to AU — `emitauditlog()` today; full coverage needs the audit-log service | Partial |
+| **AC-25** Reference Monitor | Tamper-proof, small, verifiable mediator | 9P/Styx is the single mediation chokepoint; namespace isolation **formally verified** (TLA+ 3.17B states, SPIN, CBMC on real C). `formal-verification/` | **Met** (assurance-backed) |
+
+## IA — Identification & Authentication
+
+| Control | Requirement | Mechanism / evidence | Status |
+|---------|-------------|----------------------|--------|
+| **IA-2** Identify/Authenticate Org Users | Uniquely auth users | Factotum + secstore login; native STS mutual auth between nodes | **Met** |
+| **IA-2(1)** MFA to Privileged Accounts | Multifactor | **FIDO2 hardware key + UV (PIN)** gating secstore unlock — AAL3. [`SP800-63B-AAL3.md`](SP800-63B-AAL3.md) | **Met** |
+| **IA-2(8)** Replay-Resistant Auth | Resist replay | Challenge-response (`hmac-secret`); STS handshake with transcript binding | **Met** |
+| **IA-5** Authenticator Management | Manage authenticators | DK-wrapped secstore slots; recovery slot; never-brick enroll. Dual-key-by-default + DK save-back open (EPIC 1). [`SP800-63B-AAL3.md`](SP800-63B-AAL3.md) §4 | Substantially met |
+| **IA-5(2)** PKI-Based Auth | Validate certs incl. revocation | X.509 path validation + **CRL** (`appl/lib/crypt/x509.b:1896,1941`); PQ-capable certs | **Met** |
+| **IA-7** Crypto Module Authentication | Use validated crypto for auth | Approved algorithms in use; module **not** FIPS-validated (see SC-13) | Partial |
+| **IA-8** Identify/Authenticate Non-Org Users | — | Factotum protocols; largely deployment-specific | Partial |
+
+## SC — System & Communications Protection
+
+| Control | Requirement | Mechanism / evidence | Status |
+|---------|-------------|----------------------|--------|
+| **SC-7** Boundary Protection | Monitor/control at boundaries | Namespace boundaries + 9P as the one mediated interface; `NODEVS` device gate | **Met** |
+| **SC-8** Transmission Confidentiality & Integrity | Protect data in transit | TLS 1.2/1.3 (AES-256-GCM); native STS line encryption. [`X509-mTLS.md`](X509-mTLS.md) | **Met** (server-auth; client-cert mTLS open — INFR-344) |
+| **SC-8(1)** Cryptographic Protection | Crypto in transit | AEAD ciphers; hybrid PQC key exchange | **Met** |
+| **SC-12** Crypto Key Establishment & Management | Establish/manage keys | **Hybrid X25519+ML-KEM** (TLS) and DH+ML-KEM (native). [`NIST-PQC-migration.md`](NIST-PQC-migration.md) | **Met** |
+| **SC-13** Cryptographic Protection (approved/validated) | FIPS-validated crypto | Approved algorithms present (AES-256, SHA-384/512, FIPS 203/204/205 PQC) — but the module is **not FIPS-140-validated** yet. [`CNSA-2.0.md`](CNSA-2.0.md); [`FIPS-140-3-readiness.md`](FIPS-140-3-readiness.md) | Partial (algorithms ✅; validated module ☐) |
+| **SC-23** Session Authenticity | Protect session authenticity | TLS/STS session keys; transcript binding rejects active MITM (`tests/pqauth_test.b` *TamperedEkRejected*) | **Met** |
+| **SC-28** Protection of Information at Rest | Encrypt data at rest | **AES-256-GCM** secstore vault, DK-wrapped, factor-gated. [`SP800-63B-AAL3.md`](SP800-63B-AAL3.md) §1; `doc/yubikey-2fa-operations.md` §9 | **Met** |
+| **SC-39** Process Isolation | Isolate processes | Per-process namespaces; Dis VM memory/type safety | **Met** |
+
+## AU — Audit & Accountability
+
+| Control | Requirement | Mechanism / evidence | Status |
+|---------|-------------|----------------------|--------|
+| **AU-2** Event Logging | Log defined events | Per-subsystem today (`emitauditlog()`, subagent trajectory logs); central event set pending the audit service | Partial |
+| **AU-3** Content of Audit Records | Sufficient record content | Defined by the audit-log record format (seq/time/source/event). [`SP800-92-audit-log-DESIGN.md`](SP800-92-audit-log-DESIGN.md) §4 | Planned |
+| **AU-9** Protection of Audit Information | Protect logs from tampering | **Designed**: hash-chained append-only 9P service, externally anchorable. [`SP800-92-audit-log-DESIGN.md`](SP800-92-audit-log-DESIGN.md) | Planned (design ready; INFR-343) |
+| **AU-12** Audit Record Generation | Generate records across components | Subsystem wiring to the audit service (login/factotum/CDS/veltro) | Planned |
+
+---
+
+## Disposition
+
+- **Strong, evidenced today:** AC-3, AC-6, AC-25, IA-2/2(1)/2(8)/5(2), SC-7, SC-8(1), SC-12,
+  SC-23, SC-28, SC-39 — these are the hard-to-fake controls a generic OS cannot evidence as
+  cleanly (namespace = capability; formally verified isolation; hybrid-PQC transport;
+  AAL3 hardware auth; AES-256 at rest).
+- **Honest partials:** SC-13 (validated module — Tier 2 FIPS work), IA-5 (dual-key/DK
+  save-back — EPIC 1), SC-8 (client-cert mTLS — INFR-344), AC-4 (CDS guard — EPIC 5).
+- **Planned cluster:** the AU family resolves together once the audit-log service lands
+  (the single highest-leverage control — carries AU-2/3/9/12 + SOC 2 + PCI-10).
+- **CMMC L2 framing:** an assessor can stand up the SSP on the "Met" rows immediately and
+  schedule the partials/planned against the named tickets.
+
+## References
+
+- NIST SP 800-53 Rev 5; SP 800-171 Rev 2; CMMC 2.0 L2.
+- Sibling artifacts in this directory (cited inline).


### PR DESCRIPTION
## Summary

The two remaining lean compliance items from epic **INFR-328**.

### 1. Ship a signed SBOM with releases (`release.yml`) — INFR-340
Adds one SBOM step to the release job using the **same pinned `anchore/sbom-action`** proven CI-verifiable in PR #261. The SBOM is written as `infernode-<version>-sbom.spdx.json`, so the existing checksum, cosign-signing, and release-upload steps cover it **automatically** — no extra wiring. Every release now publishes a checksummed, Sigstore-signed SPDX SBOM.

> Honesty: this path runs only on a release tag, so PR CI doesn't exercise it. The generation command itself is the one already verified green on PR #261; this is the same invocation in the release context. Flagged for your awareness rather than claimed as PR-tested.

### 2. SP 800-53 per-control itemization (`SP800-53-controls.md`) — docs only
Drills the four load-bearing families from family-level to **individual controls** — the SSP / CMMC L2 granularity an assessor works from:
- **AC** 2/3/4/5/6/6(9)/25, **IA** 2/2(1)/2(8)/5/5(2)/7/8, **SC** 7/8/8(1)/12/13/23/28/39, **AU** 2/3/9/12
- Each with mechanism, evidence pointer, honest status.
- Carries the nuances forward: **SC-13 partial** (algorithms approved, module not FIPS-validated), **AU planned** pending the audit-log service, **SC-8** client-cert mTLS open (INFR-344).
- Linked from the family mapping and the register index.

## Test plan
- `sbom.yml` (added previously) still runs on this PR and validates SBOM generation — green there is the proof the generator works.
- `release.yml` change is release-tag-only (see note above).
- Itemization is documentation; no build/test impact.

Refs: INFR-340 · epic INFR-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk

---
_Generated by [Claude Code](https://claude.ai/code/session_012X21KLXd5DppjKdhaQyzVk)_