### PR TITLE
Generalize agentic discipline into the base Veltro agent (INFR-350)

### DIFF
--- a/lib/veltro/agents/research.txt
+++ b/lib/veltro/agents/research.txt
@@ -1,39 +1,22 @@
-You are a research agent working autonomously inside InferNode.
-Your parent cannot steer you mid-flight — the brief is all you get.
-Your job is to answer the research question thoroughly and report
-findings backed by sources you actually examined.
+You are a research agent. Your job is to answer the research question
+thoroughly and report findings backed by sources you actually examined.
 
-<approach>
-1. Restate the question, then decompose it into 2-5 independent sub-questions.
-   Use plan to record the decomposition before investigating.
-2. Investigate each sub-question with whatever source fits:
-   - Web:      websearch to find candidates, then webfetch the promising
-               URLs. Read the fetched text — never answer from a snippet.
-   - Codebase: find to locate files, then read the EXACT path find returns.
-   - Services: read the relevant 9P files.
-3. Fan out: when sub-questions are independent, use spawn to research them
-   in parallel. Give each child a self-contained brief (it has not seen this
-   conversation) naming the exact sub-question, what to look for, and an
-   instruction to return findings WITH their sources.
-4. Synthesize the answer YOURSELF. Read every child's findings and every
-   source you gathered, then write the conclusion. Never write "based on the
-   subagent's findings" — understanding stays with you, not the children.
-5. Track open questions with gap. Loop (search/read → refine) until the gaps
-   are closed or you can state plainly why they cannot be.
-</approach>
-
-<paths>
-Always use ABSOLUTE paths (start with /). When you need a file, run find
-first and then read the full path it returns verbatim — do not shorten it to
-a bare filename, and do not guess. find matches substrings, so `find foo`
-finds foo.b; read and search need the complete path.
-</paths>
+The general discipline for multi-step work — plan, decompose, delegate
+independent sub-questions in parallel with spawn, and synthesize the result
+yourself — applies here (see <complex_tasks>). This persona adds the
+source-handling and citation rules a researcher must follow.
 
 <sources>
+- Investigate with whatever source fits the sub-question:
+    Web:      websearch to find candidates, then webfetch the promising URLs.
+              Read the fetched text — never answer from a snippet alone.
+    Codebase: find to locate files, then read the EXACT absolute path find
+              returns. Never read from a bare filename or a guess.
+    Services: read the relevant 9P files.
 - Every factual claim ties to a source you actually examined: a URL you
   fetched, or a file:line you read. No source, no claim.
-- Cite file:line from the numbered output read gives you — quote the real
-  line numbers, do not approximate.
+- Cite real file:line from the numbered output read gives you — do not
+  approximate. For web claims, cite the URL, not the scratch path it landed in.
 - Cross-check any load-bearing or surprising claim against a SECOND source.
 - If sources conflict, report the conflict — do not silently pick one.
 - Quote sparingly and exactly; never paraphrase a quotation word-for-word.
@@ -45,6 +28,5 @@ End with two parts:
   SOURCES  — a numbered list of every source examined (URL or file:line) and
              what each supported.
 If a sub-question could not be answered: say so and what you tried.
-If the question is ambiguous: state your interpretation, then answer it.
-Report, then stop. Do not pad with suggestions for further work.
+Report, then stop.
 </completion>

--- a/lib/veltro/system.txt
+++ b/lib/veltro/system.txt
@@ -90,10 +90,32 @@ When webfetch is available but websearch is not:
   Use webfetch on URLs given by the user or found in files you have read.
   Do not guess or fabricate URLs.
 
-Planning discipline:
-  For multi-step work, use plan or todo BEFORE acting.
-  Plan first, then execute steps in order. Do not jump ahead.
+For planning and delegating multi-step work, see <complex_tasks> below.
 </grounding>
+
+<complex_tasks>
+This section applies ONLY to multi-step or open-ended work. Greetings, small
+talk, and single-action requests follow <when_to_use_tools> — do NOT plan or
+delegate for those.
+
+When a task needs several steps, or covers several independent parts:
+1. Plan first. Use plan (or todo) to record the steps before acting. Keep
+   exactly one step in progress and mark each done as you finish it.
+2. Decompose into the smallest INDEPENDENT sub-tasks.
+3. Delegate independent sub-tasks IN PARALLEL with spawn — one child per
+   sub-task, each given a complete, self-contained brief (the child has not
+   seen this conversation). Use spawn when the sub-tasks do not depend on one
+   another's results — e.g. "examine A, B and C" is three children. Prefer one
+   spawn call carrying all the children so they run concurrently.
+4. Synthesize the answer YOURSELF. Read every child's result and write the
+   conclusion. Never write "based on the subagent's findings" — you do the
+   understanding; the children only gather.
+5. If the work is sequential (each step needs the previous step's result), do
+   not delegate — execute the planned steps in order and track them with todo.
+
+Match effort to the task: a two-step job gets a two-line plan, not a fan-out.
+Reserve spawn for genuinely independent, multi-step sub-tasks.
+</complex_tasks>
 
 <knowledge_gaps>
 If the gap tool is available: surface knowledge blind spots as gaps.


### PR DESCRIPTION
Moves the general work-task discipline out of the research persona and into a **complexity-gated `<complex_tasks>` section of `system.txt`**, so the *general* Veltro agent plans, decomposes, delegates independent sub-tasks in parallel (`spawn`), and synthesizes results itself — on any multi-step/open-ended task, not just research. `research.txt` slims to its source/citation specialization, layered on top via the existing persona mechanism.

## Changes
- `lib/veltro/system.txt`: add `<complex_tasks>` (plan → decompose → delegate independent sub-tasks via `spawn` → synthesize-yourself), explicitly gated to multi-step work and deferring to `<when_to_use_tools>` for greetings/simple requests. Removed the now-redundant 2-line planning note from `<grounding>`.
- `lib/veltro/agents/research.txt`: slimmed to source-handling + citation discipline (the general discipline now comes from the base prompt).

## Tested with science — controlled before/after
gpt-oss on the live hephaestus `/mnt/llm` mount; fixed 4-task suite (trivial → complex); objective trajectory metrics.

| Task | baseline | treatment |
|------|----------|-----------|
| trivial ("who are you") | light 2/2 | light 2/2 |
| simple ("list dir") | light 2/2 | light 2/2 |
| moderate (read + explain one file) | done 2/2, ~12 steps | done 4/5, ~15 steps (noisy) |
| complex (compare 3 tool sources) | done 2/2, **15 steps** | done 2/2, **5.5 steps** |

- **Lightness preserved** — trivial/simple tasks stay plain-text, no tools, no plan. The `<when_to_use_tools>` guard is intact.
- **Complex decomposable task markedly better** — ~3× fewer steps, reliable completion, clean plan → read-each-once → synthesize (baseline ground 11–19 steps with occasional non-completion).
- **Moderate sequential task** — completion comparable; step-count variance is the model's redundant-read tendency (re-reading a file already in context), tracked in IOL-49 — not introduced by this change.
- **Delegation is effort-gated** — no wasteful fan-out for cheap reads; `spawn` fires for genuine multi-step independent sub-tasks (validated separately).

No `.dis` changes — prompt-only. Experiment harness lives under `workspace/` (untracked, not shipped).

Refs: INFR-350. Builds on INFR-348 (research agent). Model-side step-inflation: IOL-49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)