### PR TITLE
feat(crypto): P-384 ECDH Keyring builtins + Limbo test [G1-TLS phase 2a]

### DIFF
--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -3808,6 +3808,59 @@ Keyring_p384_ecdsa_verify(void *fp)
 	*f->ret = p384_ecdsa_verify(f->sig->data, &pt, f->hash->data, f->hash->len);
 }
 
+void
+Keyring_p384_keygen(void *fp)
+{
+	F_Keyring_p384_keygen *f;
+	uchar priv[48], pubbuf[97];
+	ECpoint384 pub;
+
+	f = fp;
+	destroy(f->ret->t0);
+	destroy(f->ret->t1);
+	f->ret->t0 = H;
+	f->ret->t1 = H;
+
+	if(p384_keygen(priv, &pub) != 0)
+		error(exBadKey);
+
+	pubbuf[0] = 0x04;	/* SEC1 uncompressed point */
+	memmove(pubbuf + 1, pub.x, 48);
+	memmove(pubbuf + 49, pub.y, 48);
+	f->ret->t0 = mem2array(priv, 48);
+	f->ret->t1 = mem2array(pubbuf, 97);
+	secureZero(priv, 48);
+}
+
+void
+Keyring_p384_ecdh(void *fp)
+{
+	F_Keyring_p384_ecdh *f;
+	ECpoint384 peer;
+	uchar shared[48];
+	void *r;
+
+	f = fp;
+	r = *f->ret;
+	*f->ret = H;
+	destroy(r);
+
+	if(f->priv == H || f->priv->len != 48)
+		error(exBadKey);
+	if(f->pub == H || f->pub->len != 97 || f->pub->data[0] != 0x04)
+		error(exBadPK);
+
+	memmove(peer.x, f->pub->data + 1, 48);
+	memmove(peer.y, f->pub->data + 49, 48);
+
+	/* p384_ecdh validates the peer point (on-curve, non-identity) */
+	if(p384_ecdh(shared, f->priv->data, &peer) != 0)
+		error(exBadPK);
+
+	*f->ret = mem2array(shared, 48);
+	secureZero(shared, 48);
+}
+
 /*
  *  secp256k1 ECDSA (Ethereum/Bitcoin)
  *  Uses raw byte arrays: priv[32], pub[65], sig[65]

--- a/libinterp/keyring.h
+++ b/libinterp/keyring.h
@@ -77,7 +77,9 @@ Runtab Keyringmodtab[]={
 	"p256_keygen",0xffffffffcae8d70e,Keyring_p256_keygen,64,0,{0},
 	"p256_make_point",0x6fa90725,Keyring_p256_make_point,72,2,{0x0,0x80,},
 	"p256_point_bytes",0x131763e3,Keyring_p256_point_bytes,72,2,{0x0,0x80,},
+	"p384_ecdh",0xffffffffb21f0c63,Keyring_p384_ecdh,80,2,{0x0,0xc0,},
 	"p384_ecdsa_verify",0x62e080aa,Keyring_p384_ecdsa_verify,88,2,{0x0,0xe0,},
+	"p384_keygen",0xffffffffe94519d8,Keyring_p384_keygen,64,0,{0},
 	"pktoattr",0xfffffffffb4e61ba,Keyring_pktoattr,72,2,{0x0,0x80,},
 	"pktostr",0xfffffffffb4e61ba,Keyring_pktostr,72,2,{0x0,0x80,},
 	"putbytearray",0x7cfef557,Keyring_putbytearray,88,2,{0x0,0xc0,},
@@ -128,4 +130,4 @@ Runtab Keyringmodtab[]={
 	"IPint.xor",0xffffffffa47c1b24,IPint_xor,80,2,{0x0,0xc0,},
 	0
 };
-#define Keyringmodlen	126
+#define Keyringmodlen	128

--- a/libinterp/keyringif.h
+++ b/libinterp/keyringif.h
@@ -1518,6 +1518,16 @@ struct F_Keyring_p256_point_bytes
 	uchar	temps[24];
 	Keyring_ECpoint*	pub;
 };
+void Keyring_p384_ecdh(void*);
+typedef struct F_Keyring_p384_ecdh F_Keyring_p384_ecdh;
+struct F_Keyring_p384_ecdh
+{
+	WORD	regs[NREG-1];
+	Array**	ret;
+	uchar	temps[24];
+	Array*	priv;
+	Array*	pub;
+};
 void Keyring_p384_ecdsa_verify(void*);
 typedef struct F_Keyring_p384_ecdsa_verify F_Keyring_p384_ecdsa_verify;
 struct F_Keyring_p384_ecdsa_verify
@@ -1528,6 +1538,14 @@ struct F_Keyring_p384_ecdsa_verify
 	Array*	pubkey;
 	Array*	hash;
 	Array*	sig;
+};
+void Keyring_p384_keygen(void*);
+typedef struct F_Keyring_p384_keygen F_Keyring_p384_keygen;
+struct F_Keyring_p384_keygen
+{
+	WORD	regs[NREG-1];
+	struct{ Array* t0; Array* t1; }*	ret;
+	uchar	temps[24];
 };
 void Keyring_pktoattr(void*);
 typedef struct F_Keyring_pktoattr F_Keyring_pktoattr;

--- a/module/keyring.m
+++ b/module/keyring.m
@@ -275,8 +275,11 @@ Keyring: module
 	p256_make_point:   fn(pubkey: array of byte): ref ECpoint;
 	p256_point_bytes:  fn(pub: ref ECpoint): array of byte;
 
-	# P-384 ECDSA verify (raw byte arrays, no ADT)
+	# P-384 ECDSA verify + ECDH (raw byte arrays, no ADT).
+	# pub is SEC1 uncompressed: 0x04 || x || y (97 bytes).
 	p384_ecdsa_verify: fn(pubkey: array of byte, hash: array of byte, sig: array of byte): int;
+	p384_keygen: fn(): (array of byte, array of byte);	# => (priv[48], pub[97]=04||x||y)
+	p384_ecdh:   fn(priv: array of byte, pub: array of byte): array of byte;	# => shared[48]
 
 	# secp256k1 ECDSA (Ethereum/Bitcoin)
 	secp256k1_keygen:  fn(): (array of byte, array of byte);	# => (priv[32], pub[65])

--- a/tests/keyring_test.b
+++ b/tests/keyring_test.b
@@ -564,6 +564,60 @@ testP256ECDH(t: ref T)
 	t.assert(byteseq(shared1, shared2), "P-256 ECDH shared secrets match");
 }
 
+# ── P-384 ECDH (CNSA-approved curve; for the SecP384r1MLKEM1024 TLS hybrid) ──
+
+p384hexv(c: int): int
+{
+	if(c >= '0' && c <= '9')
+		return c - '0';
+	if(c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if(c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return 0;
+}
+
+p384fromhex(s: string): array of byte
+{
+	a := array[len s / 2] of byte;
+	for(i := 0; i < len a; i++)
+		a[i] = byte((p384hexv(s[2*i]) << 4) | p384hexv(s[2*i+1]));
+	return a;
+}
+
+testP384ECDH(t: ref T)
+{
+	# round-trip: ecdh(a, B.pub) == ecdh(b, A.pub)
+	(sk1, pk1) := kr->p384_keygen();
+	(sk2, pk2) := kr->p384_keygen();
+	if(sk1 == nil || sk2 == nil) {
+		t.skip("p384_keygen not supported");
+		return;
+	}
+	t.assert(len sk1 == 48, "P-384 private key is 48 bytes");
+	t.assert(len pk1 == 97 && int pk1[0] == 16r04, "P-384 public key is 97-byte SEC1 uncompressed");
+
+	shared1 := kr->p384_ecdh(sk1, pk2);
+	shared2 := kr->p384_ecdh(sk2, pk1);
+	if(shared1 == nil || shared2 == nil) {
+		t.fatal("p384_ecdh returned nil");
+		return;
+	}
+	t.assert(len shared1 == 48, "P-384 shared secret is 48 bytes");
+	t.assert(byteseq(shared1, shared2), "P-384 ECDH shared secrets match");
+
+	# known-answer, cross-validated against OpenSSL: ecdh(d, Q) == Z
+	d  := p384fromhex("37baf696b92be4f4ff790f36617b716b718572daa46841040554962f36f9222800cc27002487f7d3df62a9519c4e7970");
+	qb := p384fromhex("041b447b404cd7baf8a96453ef52de61229256ccf504d454c19f23556bd7f15d7ba16c5451f10c68bd2ce5ab8a06685a31f75b8518f44b14f55d151230d4f1074d5059767500b8216f1ca31ec3e90d2c024a04d56e730d127439995fc14b23d956");
+	z  := p384fromhex("341483532711a09d2256c7cca37067c162ef819e4811a6dc2da9197bc057fef9fe7320ff99687e6ab0f7590a5c364ace");
+	got := kr->p384_ecdh(d, qb);
+	if(got == nil) {
+		t.fatal("p384_ecdh known-answer returned nil");
+		return;
+	}
+	t.assert(byteseq(got, z), "P-384 ECDH matches OpenSSL known-answer");
+}
+
 # ── P-256 ECDSA ─────────────────────────────────────────────────────────────
 
 testP256ECDSA(t: ref T)
@@ -709,6 +763,7 @@ init(nil: ref Draw->Context, args: list of string)
 	# Key exchange tests
 	run("X25519", testX25519);
 	run("P256ECDH", testP256ECDH);
+	run("P384ECDH", testP384ECDH);
 	run("P256ECDSA", testP256ECDSA);
 
 	if(testing->summary(passed, failed, skipped) > 0)


### PR DESCRIPTION
Builds on #277 (P-384 ECDH primitive, now merged). Exposes it to Limbo and brings it under CI.

## What's added
- **Keyring builtins** `p384_keygen` / `p384_ecdh` (keyring.m + keyring.c), mirroring the ML-KEM byte-array tuple style. Public keys are SEC1 uncompressed `0x04||x||y` (97 bytes) — consistent with the existing `p384_ecdsa_verify` builtin and with TLS. C builtin validates length/format; `p384_ecdh` validates the peer point (on-curve, non-identity).
- **Limbo test** (`tests/keyring_test.b` → `P384ECDH`): keygen round-trip + the same OpenSSL-cross-validated known-answer, now exercised **end-to-end through the builtin** (Limbo→C→libsec). Suite: 28 passed.

This also closes the gap I flagged in #277 — the phase-1 standalone C harness wasn't CI-run; this brings P-384 ECDH into the CI Limbo suite.

Next (phase 2b, separate PR): wire `SecP384r1MLKEM1024` (0x11ED) into `tls.b` under CNSA mode using these builtins + `mlkem1024_*`. Commits unsigned (tooling can't touch the key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)