### PR TITLE
ci(release): give macOS notarization room — job 30→60m, notarytool 15→30m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -843,7 +843,7 @@ jobs:
   macos-arm64:
     name: macOS ARM64
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -1045,7 +1045,7 @@ jobs:
           --apple-id "$APPLE_ID" \
           --team-id "$APPLE_TEAM_ID" \
           --password "$APPLE_APP_PASSWORD" \
-          --wait --timeout 15m
+          --wait --timeout 30m
 
         xcrun stapler staple "$DMG"
         echo "DMG: $(ls -lh $DMG)"


### PR DESCRIPTION
## Why

The `v0.3.0` release run cancelled the **macOS ARM64** job at its 30-minute `timeout-minutes` cap while `notarytool` was still waiting on Apple's notary service. The 30m budget had to cover the full SDL3 emulator build (~15m) **plus** the notarization wait, so a slow Apple queue blows the cap with no slack. (Two release runs cancelled this way tonight.)

## Change

- `macos-arm64` job `timeout-minutes`: **30 → 60** (matches the Linux GUI / Windows jobs that already carry 45m headroom)
- `notarytool --wait --timeout`: **15m → 30m** so a backed-up notary queue doesn't trip the tool's own cap before Apple responds

CI-only; no runtime change. Unblocks cutting **v0.3.0** (re-tag at the merge commit afterwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)