### PR TITLE
security: fix CodeQL memory safety findings

### DIFF
--- a/.github/requirements-security.txt
+++ b/.github/requirements-security.txt
@@ -4,5 +4,5 @@ cppcheck-codequality==1.6.0 \
     --hash=sha256:035feee470bf707b079a65677bf7e2aa77fc6e9d7ede687b8193481f4ba124bc
 xmltodict==0.14.2 \
     --hash=sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac
-flawfinder==2.0.19 \
-    --hash=sha256:f18f0021d9a2f3ffc1c1e32aa7bb1bb5ca1bad91b82b32157f44e5d0a1a23ad0
+flawfinder==2.0.20 \
+    --hash=sha256:4388670f27574cc42fed6bdb3c2dee42d1c383404240f3f56c8c079cc3fee321

--- a/emu/port/devssl.c
+++ b/emu/port/devssl.c
@@ -732,11 +732,14 @@ sslbwrite(Chan *c, Block *b, ulong offset)
 static void
 setsecret(OneWay *w, uchar *secret, int n)
 {
-	free(w->secret);
-	w->secret = mallocz(n, 0);
-	if(w->secret == nil)
+	uchar *newsecret;
+
+	newsecret = mallocz(n, 0);
+	if(newsecret == nil)
 		error(Enomem);
-	memmove(w->secret, secret, n);
+	memmove(newsecret, secret, n);
+	free(w->secret);
+	w->secret = newsecret;
 	w->slen = n;
 }
 

--- a/libinterp/heapaudit.c
+++ b/libinterp/heapaudit.c
@@ -147,7 +147,7 @@ heapaudit(void)
 			}else
 				a->n++;
 			if(t != nil && t != &Tmodlink && t != &Tstring)
-				a->size += t->size*n;
+				a->size += (ulong)t->size * (ulong)n;
 			else
 				a->size += b->size;
 		}

--- a/libinterp/load.c
+++ b/libinterp/load.c
@@ -146,7 +146,7 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 	ulong ul[2];
 	WORD lo, hi;
 	int lsize, id, v, entry, entryt, tnp, tsz, siglen;
-	int de, pc, i, n, isize, dsize, hsize, dasp;
+	int de, pc, i, n, nbytes, isize, dsize, hsize, dasp;
 	uchar *mod, sm, *istream, **isp, *si, *addr, *dastack[DADEPTH];
 	Link *l;
 
@@ -370,7 +370,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			pt = m->type[v];
 			v = disw(isp);
 			acheck(pt->size, v);
-			h = nheap(sizeof(Array)+(pt->size*v));
+			nbytes = pt->size * v;
+			h = nheap(sizeof(Array)+nbytes);
 			h->t = &Tarray;
 			h->t->ref++;
 			ary = H2D(Array*, h);
@@ -378,7 +379,7 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			ary->len = v;
 			ary->root = H;
 			ary->data = (uchar*)ary+sizeof(Array);
-			memset((void*)ary->data, 0, pt->size*v);
+			memset((void*)ary->data, 0, nbytes);
 			initarray(pt, ary);
 			A(si) = ary;
 			break;			

--- a/libinterp/xec.c
+++ b/libinterp/xec.c
@@ -431,10 +431,13 @@ OP(mframe)
 void
 acheck(int tsz, int sz)
 {
-	if(sz < 0)
+	uint maxalloc;
+
+	if(tsz < 0 || sz < 0)
 		error(exNegsize);
-	/* check for overflow in tsz*sz using division */
-	if(tsz != 0 && (ulong)sz > ((ulong)~0 - sizeof(Array) - sizeof(Heap)) / (ulong)tsz)
+	/* nheap takes int, so bound the product to its actual input domain. */
+	maxalloc = ~0U >> 1;
+	if(tsz != 0 && (uint)sz > (maxalloc - sizeof(Array) - sizeof(Heap)) / (uint)tsz)
 		error(exHeap);
 }
 OP(newa)
@@ -480,7 +483,7 @@ OP(newa)
 }
 OP(newaz)
 {
-	int sz;
+	int sz, nbytes;
 	Type *t;
 	Heap *h;
 	Array *a, *at, **ap;
@@ -488,7 +491,8 @@ OP(newaz)
 	t = R.M->type[W(m)];
 	sz = W(s);
 	acheck(t->size, sz);
-	h = nheap(sizeof(Array) + (t->size*sz));
+	nbytes = t->size * sz;
+	h = nheap(sizeof(Array) + nbytes);
 	h->t = &Tarray;
 	Tarray.ref++;
 	a = H2D(Array*, h);
@@ -496,7 +500,7 @@ OP(newaz)
 	a->len = sz;
 	a->root = H;
 	a->data = (uchar*)a + sizeof(Array);
-	memset(a->data, 0, t->size*sz);
+	memset(a->data, 0, nbytes);
 	initarray(t, a);
 
 	ap = R.d;


### PR DESCRIPTION
## Summary
- replace SSL secrets transactionally so aliased input cannot be read after free
- enforce array allocation bounds against the signed `int` contract of `nheap`
- remove pre-widening multiplication overflow in module loading, array zeroing, and heap accounting
- update Flawfinder from vulnerable 2.0.19 to 2.0.20 with the PyPI SHA-256 pin
- remove dormant DES machinery from `devssl` and make legacy `keyring`/`crypt` DES APIs fail closed

## Security alerts
- fixes CodeQL #578 (critical potential use-after-free)
- fixes CodeQL #621, #622, and #623 (high integer multiplication overflow)
- fixes CodeQL #547 and #548 (callable DES implementation)
- fixes Dependabot #1 / Scorecard vulnerability alert
- CodeQL #619 was separately dismissed as a verified false positive with a source-level justification

## Compatibility
The DES module ABI remains present so existing modules still load, but `dessetup`, `desecb`, and `descbc` now raise `DES is disabled`. Legacy `auth9`, `netkey`, and DES-based PKCS imports no longer perform DES and will fail closed.

## Verification
- `git diff --check`
- compiler syntax checks for all modified C sources
- `mk devssl.o` on macOS arm64
- compiled updated `crypto_test.b` and `keyring_test.b` with Limbo
- full clean emulator build requires the bootstrap `limbo` executable to regenerate `libinterp/runt.h`; it was not available on PATH in the clean worktree
