### PR TITLE
security: remove weak transport algorithms and close devfs races

### DIFF
--- a/emu/port/devfs-posix.c
+++ b/emu/port/devfs-posix.c
@@ -21,6 +21,7 @@
 #include	<unistd.h>
 #include	<pwd.h>
 #include	<grp.h>
+#include	<errno.h>
 
 typedef struct Fsinfo Fsinfo;
 struct Fsinfo
@@ -84,6 +85,34 @@ static	long	fsdirread(Chan*, uchar*, int, vlong);
 static	int	fsomode(int);
 static	void	fsremove(Chan*);
 static	vlong osdisksize(int);	/* defined by including file */
+
+static int
+fsattrfd(Chan *c, struct stat *expected)
+{
+	struct stat actual;
+	int fd, oerrno;
+
+#ifndef O_NOFOLLOW
+	errno = ENOTSUP;
+	return -1;
+#else
+	fd = open(FS(c)->name->s, O_RDONLY|O_NONBLOCK|O_NOFOLLOW);
+	if(fd < 0)
+		return -1;
+	if(fstat(fd, &actual) < 0){
+		oerrno = errno;
+		close(fd);
+		errno = oerrno;
+		return -1;
+	}
+	if(actual.st_dev != expected->st_dev || actual.st_ino != expected->st_ino){
+		close(fd);
+		errno = ESTALE;
+		return -1;
+	}
+	return fd;
+#endif
+}
 
 /*
  * make invalid symbolic links visible; less confusing, and at least you can then delete them.
@@ -540,7 +569,7 @@ fswstat(Chan *c, uchar *buf, int nb)
 	Cname *volatile ph;
 	struct stat st;
 	struct utimbuf utbuf;
-	int tsync;
+	int tsync, fd, rv, oerrno;
 
 	if(FS(c)->fd >= 0){
 		if(fstat(FS(c)->fd, &st) < 0)
@@ -585,7 +614,14 @@ fswstat(Chan *c, uchar *buf, int nb)
 			if(fchmod(FS(c)->fd, d->mode&0777) < 0)
 				oserror();
 		}else{
-			if(chmod(FS(c)->name->s, d->mode&0777) < 0)
+			fd = fsattrfd(c, &st);
+			if(fd < 0)
+				oserror();
+			rv = fchmod(fd, d->mode&0777);
+			oerrno = errno;
+			close(fd);
+			errno = oerrno;
+			if(rv < 0)
 				oserror();
 		}
 		FS(c)->mode &= ~0777;
@@ -626,7 +662,14 @@ fswstat(Chan *c, uchar *buf, int nb)
 				if(fchown(FS(c)->fd, st.st_uid, p->id) < 0)
 					oserror();
 			}else{
-				if(chown(FS(c)->name->s, st.st_uid, p->id) < 0)
+				fd = fsattrfd(c, &st);
+				if(fd < 0)
+					oserror();
+				rv = fchown(fd, st.st_uid, p->id);
+				oerrno = errno;
+				close(fd);
+				errno = oerrno;
+				if(rv < 0)
 					oserror();
 			}
 			FS(c)->gid = p->id;

--- a/emu/port/devssl.c
+++ b/emu/port/devssl.c
@@ -31,9 +31,6 @@ enum
 
 	/* encryption algorithms */
 	Noencryption=	0,
-	RC4=		3,
-	IDEACBC=	4,
-	IDEAECB=		5,
 	AESCBC=		6
 };
 
@@ -742,70 +739,6 @@ setsecret(OneWay *w, uchar *secret, int n)
 }
 
 static void
-initIDEAkey(OneWay *w)
-{
-
-	free(w->state);
-	w->state = malloc(sizeof(IDEAstate));
-	if(w->state == nil)
-		error(Enomem);
-	if(w->slen >= 24)
-		setupIDEAstate(w->state, w->secret, w->secret+16);
-	else if(w->slen >= 16)
-		setupIDEAstate(w->state, w->secret, 0);
-	else
-		error("secret too short");
-}
-
-static void
-initRC4key(OneWay *w)
-{
-	free(w->state);
-	w->state = malloc(sizeof(RC4state));
-	if (!w->state)
-		error(Enomem);
-	setupRC4state(w->state, w->secret, w->slen);
-}
-
-/*
- *  40 bit RC4 is the same as n-bit RC4.  However,
- *  we ignore all but the first 40 bits of the key.
- */
-static void
-initRC4key_40(OneWay *w)
-{
-	int slen = w->slen;
-
-	if(slen > 5)
-		slen = 5;
-
-	free(w->state);
-	w->state = malloc(sizeof(RC4state));
-	if (!w->state)
-		error(Enomem);
-	setupRC4state(w->state, w->secret, slen);
-}
-
-/*
- *  128 bit RC4 is the same as n-bit RC4.  However,
- *  we ignore all but the first 128 bits of the key.
- */
-static void
-initRC4key_128(OneWay *w)
-{
-	int slen = w->slen;
-
-	if(slen > 16)
-		slen = 16;
-
-	free(w->state);
-	w->state = malloc(sizeof(RC4state));
-	if (!w->state)
-		error(Enomem);
-	setupRC4state(w->state, w->secret, slen);
-}
-
-static void
 initAES128key(OneWay *w)
 {
 	free(w->state);
@@ -846,10 +779,6 @@ struct Hashalg
 Hashalg hashtab[] =
 {
 	{ "sha256", SHA256dlen, sha256, },
-	{ "sha1", SHA1dlen, sha1, },
-	{ "sha", SHA1dlen, sha1, },
-	{ "md5", MD5dlen, md5, },
-	{ "md4", MD4dlen, md4, },
 	{ 0 }
 };
 
@@ -883,10 +812,6 @@ Encalg encrypttab[] =
 {
 	{ "aes_256_cbc", 16, AESCBC, initAES256key, },
 	{ "aes_128_cbc", 16, AESCBC, initAES128key, },
-	{ "ideacbc", 8, IDEACBC, initIDEAkey, },
-	{ "ideaecb", 8, IDEAECB, initIDEAkey, },
-	/* Deprecated weak ciphers removed: rc4_256, rc4_128, rc4_40, rc4,
-	   des_56_cbc, des_56_ecb, des_40_cbc, des_40_ecb, descbc, desecb */
 	{ 0 }
 };
 
@@ -1117,31 +1042,7 @@ out:
 static Block*
 encryptb(Dstate *s, Block *b, int offset)
 {
-	uchar *p, *ep, *p2, *ip, *eip;
-	IDEAstate *is;
-
 	switch(s->encryptalg){
-	case IDEAECB:
-		is = s->out.state;
-		ep = b->rp + BLEN(b);
-		for(p = b->rp + offset; p < ep; p += 8)
-			idea_cipher(is->edkey, p, 0);
-		break;
-	case IDEACBC:
-		is = s->out.state;
-		ep = b->rp + BLEN(b);
-		for(p = b->rp + offset; p < ep; p += 8){
-			p2 = p;
-			ip = is->ivec;
-			for(eip = ip+8; ip < eip; )
-				*p2++ ^= *ip++;
-			idea_cipher(is->edkey, p, 0);
-			memmove(is->ivec, p, 8);
-		}
-		break;
-	case RC4:
-		rc4(s->out.state, b->rp + offset, BLEN(b) - offset);
-		break;
 	case AESCBC:
 		aesCBCencrypt(b->rp + offset, BLEN(b) - offset, s->out.state);
 		break;
@@ -1153,9 +1054,6 @@ static Block*
 decryptb(Dstate *s, Block *inb)
 {
 	Block *b, **l;
-	uchar *p, *ep, *tp, *ip, *eip;
-	IDEAstate *is;
-	uchar tmp[8];
 	int i;
 
 	l = &inb;
@@ -1173,29 +1071,6 @@ decryptb(Dstate *s, Block *inb)
 
 		/* decrypt */
 		switch(s->encryptalg){
-		case IDEAECB:
-			is = s->in.state;
-			ep = b->rp + BLEN(b);
-			for(p = b->rp; p < ep; p += 8)
-				idea_cipher(is->edkey, p, 1);
-			break;
-		case IDEACBC:
-			is = s->in.state;
-			ep = b->rp + BLEN(b);
-			for(p = b->rp; p < ep;){
-				memmove(tmp, p, 8);
-				idea_cipher(is->edkey, p, 1);
-				tp = tmp;
-				ip = is->ivec;
-				for(eip = ip+8; ip < eip; ){
-					*p++ ^= *ip;
-					*ip++ = *tp++;
-				}
-			}
-			break;
-		case RC4:
-			rc4(s->in.state, b->rp, BLEN(b));
-			break;
 		case AESCBC:
 			aesCBCdecrypt(b->rp, BLEN(b), s->in.state);
 			break;

--- a/emu/port/devssl.c
+++ b/emu/port/devssl.c
@@ -31,8 +31,6 @@ enum
 
 	/* encryption algorithms */
 	Noencryption=	0,
-	DESCBC=		1,
-	DESECB=		2,
 	RC4=		3,
 	IDEACBC=	4,
 	IDEAECB=		5,
@@ -760,52 +758,6 @@ initIDEAkey(OneWay *w)
 }
 
 static void
-initDESkey(OneWay *w)
-{
-
-	free(w->state);
-	w->state = malloc(sizeof(DESstate));
-	if (!w->state)
-		error(Enomem);
-	if(w->slen >= 16)
-		setupDESstate(w->state, w->secret, w->secret+8);
-	else if(w->slen >= 8)
-		setupDESstate(w->state, w->secret, 0);
-	else
-		error("secret too short");
-}
-
-/*
- *  40 bit DES is the same as 56 bit DES.  However,
- *  16 bits of the key are masked to zero.
- */
-static void
-initDESkey_40(OneWay *w)
-{
-	uchar key[8];
-
-
-	if(w->slen >= 8) {
-		memmove(key, w->secret, 8);
-		key[0] &= 0x0f;
-		key[2] &= 0x0f;
-		key[4] &= 0x0f;
-		key[6] &= 0x0f;
-	}
-
-	free(w->state);
-	w->state = malloc(sizeof(DESstate));
-	if (!w->state)
-		error(Enomem);
-	if(w->slen >= 16)
-		setupDESstate(w->state, key, w->secret+8);
-	else if(w->slen >= 8)
-		setupDESstate(w->state, key, 0);
-	else
-		error("secret too short");
-}
-
-static void
 initRC4key(OneWay *w)
 {
 	free(w->state);
@@ -1166,28 +1118,9 @@ static Block*
 encryptb(Dstate *s, Block *b, int offset)
 {
 	uchar *p, *ep, *p2, *ip, *eip;
-	DESstate *ds;
 	IDEAstate *is;
 
 	switch(s->encryptalg){
-	case DESECB:
-		ds = s->out.state;
-		ep = b->rp + BLEN(b);
-		for(p = b->rp + offset; p < ep; p += 8)
-			block_cipher(ds->expanded, p, 0);
-		break;
-	case DESCBC:
-		ds = s->out.state;
-		ep = b->rp + BLEN(b);
-		for(p = b->rp + offset; p < ep; p += 8){
-			p2 = p;
-			ip = ds->ivec;
-			for(eip = ip+8; ip < eip; )
-				*p2++ ^= *ip++;
-			block_cipher(ds->expanded, p, 0);
-			memmove(ds->ivec, p, 8);
-		}
-		break;
 	case IDEAECB:
 		is = s->out.state;
 		ep = b->rp + BLEN(b);
@@ -1221,7 +1154,6 @@ decryptb(Dstate *s, Block *inb)
 {
 	Block *b, **l;
 	uchar *p, *ep, *tp, *ip, *eip;
-	DESstate *ds;
 	IDEAstate *is;
 	uchar tmp[8];
 	int i;
@@ -1241,26 +1173,6 @@ decryptb(Dstate *s, Block *inb)
 
 		/* decrypt */
 		switch(s->encryptalg){
-		case DESECB:
-			ds = s->in.state;
-			ep = b->rp + BLEN(b);
-			for(p = b->rp; p < ep; p += 8)
-				block_cipher(ds->expanded, p, 1);
-			break;
-		case DESCBC:
-			ds = s->in.state;
-			ep = b->rp + BLEN(b);
-			for(p = b->rp; p < ep;){
-				memmove(tmp, p, 8);
-				block_cipher(ds->expanded, p, 1);
-				tp = tmp;
-				ip = ds->ivec;
-				for(eip = ip+8; ip < eip; ){
-					*p++ ^= *ip;
-					*ip++ = *tp++;
-				}
-			}
-			break;
 		case IDEAECB:
 			is = s->in.state;
 			ep = b->rp + BLEN(b);

--- a/libinterp/crypt.c
+++ b/libinterp/crypt.c
@@ -443,100 +443,22 @@ cryptmodinit(void)
 void
 Crypt_dessetup(void *fp)
 {
-	F_Crypt_dessetup *f;
-	Heap *h;
-	XDESstate *ds;
-	uchar *ivec;
-	void *v;
-
-	f = fp;
-	v = *f->ret;
-	*f->ret = H;
-	destroy(v);
-
-	if(f->key == H)
-		error(exNilref);
-	if(f->key->len < 8)
-		error(exBadKey);
-	if(f->ivec != H){
-		if(f->ivec->len < 8)
-			error(exBadIvec);
-		ivec = f->ivec->data;
-	}else
-		ivec = nil;
-
-	h = heap(TDESstate);
-	ds = H2D(XDESstate*, h);
-	setupDESstate(&ds->state, f->key->data, ivec);
-
-	*f->ret = (Crypt_DESstate*)ds;
+	USED(fp);
+	error("DES is disabled");
 }
 
 void
 Crypt_desecb(void *fp)
 {
-	F_Crypt_desecb *f;
-	XDESstate *ds;
-	int i;
-	uchar *p;
-
-	f = fp;
-
-	if(f->buf == H)
-		return;
-	if(f->n < 0 || f->n > f->buf->len)
-		error(exBounds);
-	if(f->n & 7)
-		error(exBadBsize);
-
-	ds = checktype(f->state, TDESstate, exBadState, 0);
-	p = f->buf->data;
-
-	for(i = 8; i <= f->n; i += 8, p += 8)
-		block_cipher(ds->state.expanded, p, f->direction);
+	USED(fp);
+	error("DES is disabled");
 }
 
 void
 Crypt_descbc(void *fp)
 {
-	F_Crypt_descbc *f;
-	XDESstate *ds;
-	uchar *p, *ep, *ip, *p2, *eip;
-	uchar tmp[8];
-
-	f = fp;
-
-	if(f->buf == H)
-		return;
-	if(f->n < 0 || f->n > f->buf->len)
-		error(exBounds);
-	if(f->n & 7)
-		error(exBadBsize);
-
-	ds = checktype(f->state, TDESstate, exBadState, 0);
-	p = f->buf->data;
-
-	if(f->direction == 0){
-		for(ep = p + f->n; p < ep; p += 8){
-			p2 = p;
-			ip = ds->state.ivec;
-			for(eip = ip+8; ip < eip; )
-				*p2++ ^= *ip++;
-			block_cipher(ds->state.expanded, p, 0);
-			memmove(ds->state.ivec, p, 8);
-		}
-	} else {
-		for(ep = p + f->n; p < ep; ){
-			memmove(tmp, p, 8);
-			block_cipher(ds->state.expanded, p, 1);
-			p2 = tmp;
-			ip = ds->state.ivec;
-			for(eip = ip+8; ip < eip; ){
-				*p++ ^= *ip;
-				*ip++ = *p2++;
-			}
-		}
-	}
+	USED(fp);
+	error("DES is disabled");
 }
 
 void

--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -2622,98 +2622,22 @@ Keyring_putbytearray(void *fp)
 void
 Keyring_dessetup(void *fp)
 {
-	F_Keyring_dessetup *f;
-	Heap *h;
-	XDESstate *ds;
-	uchar *ivec;
-	void *r;
-
-	f = fp;
-	r = *f->ret;
-	*f->ret = H;
-	destroy(r);
-
-	if(f->key == H || f->key->len < 8)
-		error(exBadKey);
-	if(f->ivec != H){
-		if(f->ivec->len < 8)
-			error(exBadIvec);
-		ivec = f->ivec->data;
-	}else
-		ivec = nil;
-
-	h = heap(TDESstate);
-	ds = H2D(XDESstate*, h);
-	setupDESstate(&ds->state, f->key->data, ivec);
-
-	*f->ret = (Keyring_DESstate*)ds;
+	USED(fp);
+	error("DES is disabled");
 }
 
 void
 Keyring_desecb(void *fp)
 {
-	F_Keyring_desecb *f;
-	XDESstate *ds;
-	int i;
-	uchar *p;
-
-	f = fp;
-
-	if(f->buf == H)
-		return;
-	if(f->n < 0 || f->n > f->buf->len)
-		error(exBounds);
-	if(f->n & 7)
-		error(exBadBsize);
-
-	ds = checktype(f->state, TDESstate, exBadState, 0);
-	p = f->buf->data;
-
-	for(i = 8; i <= f->n; i += 8, p += 8)
-		block_cipher(ds->state.expanded, p, f->direction);
+	USED(fp);
+	error("DES is disabled");
 }
 
 void
 Keyring_descbc(void *fp)
 {
-	F_Keyring_descbc *f;
-	XDESstate *ds;
-	uchar *p, *ep, *ip, *p2, *eip;
-	uchar tmp[8];
-
-	f = fp;
-
-	if(f->buf == H)
-		return;
-	if(f->n < 0 || f->n > f->buf->len)
-		error(exBounds);
-	if(f->n & 7)
-		error(exBadBsize);
-
-	ds = checktype(f->state, TDESstate, exBadState, 0);
-	p = f->buf->data;
-
-	if(f->direction == 0){
-		for(ep = p + f->n; p < ep; p += 8){
-			p2 = p;
-			ip = ds->state.ivec;
-			for(eip = ip+8; ip < eip; )
-				*p2++ ^= *ip++;
-			block_cipher(ds->state.expanded, p, 0);
-			memmove(ds->state.ivec, p, 8);
-		}
-	} else {
-		for(ep = p + f->n; p < ep; ){
-			memmove(tmp, p, 8);
-			block_cipher(ds->state.expanded, p, 1);
-			p2 = tmp;
-			ip = ds->state.ivec;
-			for(eip = ip+8; ip < eip; ){
-				*p++ ^= *ip;
-				*ip++ = *p2++;
-			}
-		}
-	}
+	USED(fp);
+	error("DES is disabled");
 }
 
 void

--- a/tests/cipher_matrix_test.b
+++ b/tests/cipher_matrix_test.b
@@ -9,8 +9,8 @@ implement CipherMatrixTest;
 # a real auth->server / auth->client handshake and a data round-trip, and
 # asserting the payload survives byte-for-byte.
 #
-#   ciphers: aes_256_cbc, aes_128_cbc, ideacbc, ideaecb
-#   MACs:    sha256, sha1, md5, md4
+#   ciphers: aes_256_cbc, aes_128_cbc
+#   MACs:    sha256
 #   plus:    none (auth succeeds, no ssl pushed)
 #
 # Runs over a pipe (no TCP ports needed); each case has a timeout safety net.
@@ -179,13 +179,6 @@ roundtrip(t: ref T, label: string, serverAlgs: list of string, clientAlg: string
 # ---- cipher sweep (sha256 MAC) ----
 testAes256(t: ref T)  { roundtrip(t, "aes_256_cbc/sha256", "aes_256_cbc"::"sha256"::nil, "aes_256_cbc sha256"); }
 testAes128(t: ref T)  { roundtrip(t, "aes_128_cbc/sha256", "aes_128_cbc"::"sha256"::nil, "aes_128_cbc sha256"); }
-testIdeaCbc(t: ref T) { roundtrip(t, "ideacbc/sha256", "ideacbc"::"sha256"::nil, "ideacbc sha256"); }
-testIdeaEcb(t: ref T) { roundtrip(t, "ideaecb/sha256", "ideaecb"::"sha256"::nil, "ideaecb sha256"); }
-
-# ---- MAC sweep (aes_256_cbc cipher) ----
-testSha1(t: ref T) { roundtrip(t, "aes_256_cbc/sha1", "aes_256_cbc"::"sha1"::nil, "aes_256_cbc sha1"); }
-testMd5(t: ref T)  { roundtrip(t, "aes_256_cbc/md5", "aes_256_cbc"::"md5"::nil, "aes_256_cbc md5"); }
-testMd4(t: ref T)  { roundtrip(t, "aes_256_cbc/md4", "aes_256_cbc"::"md4"::nil, "aes_256_cbc md4"); }
 
 # ---- unencrypted path ----
 testNone(t: ref T) { roundtrip(t, "none", nil, "none"); }
@@ -223,11 +216,6 @@ init(nil: ref Draw->Context, args: list of string)
 
 	run("Aes256Sha256", testAes256);
 	run("Aes128Sha256", testAes128);
-	run("IdeaCbcSha256", testIdeaCbc);
-	run("IdeaEcbSha256", testIdeaEcb);
-	run("Aes256Sha1", testSha1);
-	run("Aes256Md5", testMd5);
-	run("Aes256Md4", testMd4);
 	run("NoEncryption", testNone);
 
 	if(testing->summary(passed, failed, skipped) > 0)

--- a/tests/crypto_test.b
+++ b/tests/crypto_test.b
@@ -409,26 +409,22 @@ testRC4Disabled(t: ref T)
 #
 testDESDisabled(t: ref T)
 {
-	t.log("Testing that DES is disabled...");
-
-	# DES setup should still work at the low level (keyring)
-	# but SSL3 should reject it at the protocol level
-
 	key := array[8] of byte;
 	for(i := 0; i < 8; i++)
 		key[i] = byte i;
 
-	state := kr->dessetup(key, nil);
-
-	if(state != nil) {
-		t.log("DES is available at keyring level (expected)");
-		t.log("SSL3 protocol-level rejection tested separately");
-	} else {
-		t.log("DES setup returned nil - may be completely removed");
+	rejected := 0;
+	{
+		state := kr->dessetup(key, nil);
+		if(state != nil)
+			t.error("DES setup unexpectedly succeeded");
+	} exception {
+	"DES is disabled" =>
+		rejected = 1;
+	"*" =>
+		t.error("DES setup failed with an unexpected exception");
 	}
-
-	# This test passes because we've verified the code change.
-	t.assert(1, "DES disabled verification (code review confirmed)");
+	t.assert(rejected, "DES setup rejected");
 }
 
 #

--- a/tests/keyring_test.b
+++ b/tests/keyring_test.b
@@ -679,29 +679,19 @@ testDESCBC(t: ref T)
 	key := array[8] of byte;
 	for(i := 0; i < len key; i++)
 		key[i] = byte (i + 1);
-	iv := array[8] of byte;
 
-	estate := kr->dessetup(key, iv);
-	if(estate == nil) {
-		t.fatal("dessetup failed");
-		return;
+	rejected := 0;
+	{
+		state := kr->dessetup(key, nil);
+		if(state != nil)
+			t.error("DES setup unexpectedly succeeded");
+	} exception {
+	"DES is disabled" =>
+		rejected = 1;
+	"*" =>
+		t.error("DES setup failed with an unexpected exception");
 	}
-
-	# DES-CBC needs blocks of 8
-	plain := array[16] of byte;
-	for(i = 0; i < len plain; i++)
-		plain[i] = byte (i * 5);
-	cipher := array[16] of byte;
-	cipher[:] = plain;
-	kr->descbc(estate, cipher, len cipher, Keyring->Encrypt);
-
-	t.assert(!byteseq(cipher, plain), "DES-CBC ciphertext differs");
-
-	# Decrypt
-	iv2 := array[8] of byte;
-	dstate := kr->dessetup(key, iv2);
-	kr->descbc(dstate, cipher, len cipher, Keyring->Decrypt);
-	t.assert(byteseq(cipher, plain), "DES-CBC roundtrip");
+	t.assert(rejected, "DES setup rejected");
 }
 
 init(nil: ref Draw->Context, args: list of string)
@@ -753,7 +743,7 @@ init(nil: ref Draw->Context, args: list of string)
 	run("AESCBC", testAESCBC);
 	run("AES256", testAES256);
 	run("RC4", testRC4);
-	run("DESCBC", testDESCBC);
+	run("DESDisabled", testDESCBC);
 
 	# Asymmetric key tests
 	run("RSA", testRSA);

--- a/tests/ssl_transport_test.b
+++ b/tests/ssl_transport_test.b
@@ -104,22 +104,30 @@ testAlgorithmAdvertised(t: ref T)
 	# Check for aes_128_cbc and aes_256_cbc
 	found128 := 0;
 	found256 := 0;
+	foundweak := 0;
 	for(el := encalgs; el != nil; el = tl el) {
 		if(hd el == "aes_128_cbc")
 			found128 = 1;
 		if(hd el == "aes_256_cbc")
 			found256 = 1;
+		if(hd el == "ideacbc" || hd el == "ideaecb" || hd el == "rc4")
+			foundweak = 1;
 	}
 	t.assert(found128, "aes_128_cbc in encalgs");
 	t.assert(found256, "aes_256_cbc in encalgs");
+	t.assert(!foundweak, "weak ciphers absent from encalgs");
 
 	# Check for sha256
 	foundsha := 0;
+	foundweakhash := 0;
 	for(hl := hashalgs; hl != nil; hl = tl hl) {
 		if(hd hl == "sha256")
 			foundsha = 1;
+		if(hd hl == "sha1" || hd hl == "sha" || hd hl == "md5" || hd hl == "md4")
+			foundweakhash = 1;
 	}
 	t.assert(foundsha, "sha256 in hashalgs");
+	t.assert(!foundweakhash, "weak hashes absent from hashalgs");
 }
 
 # Set up two SSL connections over a pipe, configure algorithm, return (side_a, side_b)


### PR DESCRIPTION
## Summary
- carry forward the DES fail-closed change that landed after PR #300 was merged
- restrict `devssl` negotiation to AES-128/AES-256 with SHA-256
- remove dormant DES, IDEA, and RC4 transport execution paths
- reject DES through the legacy `keyring` and `crypt` module ABI
- replace path-based `chmod`/`chown` fallbacks with verified no-follow descriptors
- update transport and crypto tests to assert weak algorithm rejection

## Compatibility
- node transport no longer accepts IDEA, RC4, SHA-1, MD5, or MD4
- `auth9`, `netkey`, and DES-based PKCS imports fail closed at DES setup
- unopened host files must be obtainable through a no-follow descriptor for chmod/chown; otherwise wstat fails rather than using a racy pathname operation

## Flawfinder triage
- reviewed all 36 open error-level findings
- dismissed 34 verified false positives with source-level comments
- fixed the two genuine path race findings in `devfs-posix.c`
- Flawfinder 2.0.20 reports no level-5 findings and no longer reports the path-based chmod/chown calls

## Verification
- compiled `devssl.o` and `devfs.o` on macOS arm64
- compiler syntax checks for modified builtin crypto sources
- compiled `crypto_test.b`, `keyring_test.b`, `cipher_matrix_test.b`, and `ssl_transport_test.b`
- `git diff --check`
