### PR TITLE
security: fuzz and harden production Dis parser

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -6,8 +6,11 @@
 
 # Dis bytecode parser fuzz target
 $CC $CFLAGS \
+    -I"$SRC/infernode/include" \
+    -I"$SRC/infernode/Linux/amd64/include" \
     -o "$OUT/fuzz_dis_parser" \
     "$SRC/infernode/.clusterfuzzlite/fuzz_dis_parser.c" \
+    "$SRC/infernode/libinterp/load.c" \
     $LIB_FUZZING_ENGINE
 
 # Seed corpus: existing .dis bytecode files from the runtime tree

--- a/.clusterfuzzlite/fuzz_dis_parser.c
+++ b/.clusterfuzzlite/fuzz_dis_parser.c
@@ -1,256 +1,352 @@
 /*
- * Fuzz harness for Dis bytecode parser.
+ * Runtime adapter for fuzzing the production Dis parser in libinterp/load.c.
  *
- * Exercises the operand encoding, instruction decoding, and type
- * descriptor parsing from libinterp/load.c using arbitrary byte
- * streams.  Self-contained: the parsing primitives are extracted
- * here so we don't need the full Inferno kernel to link.
+ * This supplies the allocator, heap, link, and kernel services parsemod needs
+ * while retaining the production parser and runtime data layouts unchanged.
  */
+#include "lib9.h"
+#include "isa.h"
+#include "interp.h"
+#include "raise.h"
+#include "kernel.h"
 
+#include <setjmp.h>
 #include <stdint.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
+#include <stdio.h>
 
-/* Dis bytecode constants (from include/isa.h) */
-enum {
-	XMAGIC	= 819248,
-	SMAGIC	= 923426,
+static jmp_buf parseerror;
+static int parsing;
+#ifdef STANDALONE_FUZZ_TARGET
+static int parsedmodule;
+#endif
 
-	AMP	= 0x00,
-	AFP	= 0x01,
-	AIMM	= 0x02,
-	AIND	= 0x04,
-	AMASK	= 0x07,
+char exNomem[] = "out of memory";
+int cflag;
+Type Tarray = { 1, nil, nil, sizeof(Array) };
 
-	ARM	= 0xC0,
-	AXIMM	= 0x40,
-	AXINF	= 0x80,
-	AXINM	= 0xC0,
-};
-
-#define SRC(x)		((x)<<3)
-#define DST(x)		((x)<<0)
-#define UXSRC(x)	((x)&(AMASK<<3))
-#define UXDST(x)	((x)&(AMASK<<0))
-
-typedef unsigned char uchar;
-typedef unsigned long ulong;
-
-static uchar *codeend;
-
-/*
- * Variable-length operand decoder (from libinterp/load.c).
- * This is the core parsing primitive for the Dis bytecode format.
- */
-static int
-operand(uchar **p)
+void*
+mallocz(ulong n, int clear)
 {
-	int c;
-	uchar *cp;
+	void *p;
 
-	cp = *p;
-	if(cp >= codeend)
-		return -1;
-	c = cp[0];
-	switch(c & 0xC0) {
-	case 0x00:
-		*p = cp+1;
-		return c;
-	case 0x40:
-		*p = cp+1;
-		return c|~0x7F;
-	case 0x80:
-		if(cp+2 > codeend)
-			return -1;
-		*p = cp+2;
-		if(c & 0x20)
-			c |= ~0x3F;
-		else
-			c &= 0x3F;
-		return (c<<8)|cp[1];
-	case 0xC0:
-		if(cp+4 > codeend)
-			return -1;
-		*p = cp+4;
-		if(c & 0x20)
-			c |= ~0x3F;
-		else
-			c &= 0x3F;
-		return (c<<24)|(cp[1]<<16)|(cp[2]<<8)|cp[3];
+	p = malloc(n);
+	if(p != nil && clear)
+		memset(p, 0, n);
+	return p;
+}
+
+void
+kwerrstr(char *fmt, ...)
+{
+	USED(fmt);
+}
+
+void
+error(char *message)
+{
+	USED(message);
+	if(parsing)
+		longjmp(parseerror, 1);
+	abort();
+}
+
+void
+errorf(char *fmt, ...)
+{
+	USED(fmt);
+	error("runtime error");
+}
+
+void
+freeheap(Heap *h, int swept)
+{
+	USED(h);
+	USED(swept);
+}
+
+Type*
+dtype(void (*destroyfn)(Heap*, int), int size, uchar *map, int mapsize)
+{
+	Type *t;
+
+	if(size < 0 || mapsize < 0)
+		return nil;
+	t = malloc(sizeof(Type)+mapsize);
+	if(t == nil)
+		return nil;
+	memset(t, 0, sizeof(Type)+mapsize);
+	t->ref = 1;
+	t->free = destroyfn;
+	t->size = size;
+	t->np = mapsize;
+	if(mapsize != 0)
+		memmove(t->map, map, mapsize);
+	return t;
+}
+
+void
+freetype(Type *t)
+{
+	if(t != nil && --t->ref == 0)
+		free(t);
+}
+
+void
+initmem(Type *t, void *data)
+{
+	uchar *map;
+	WORD **words;
+	int bit, i;
+
+	map = t->map;
+	words = data;
+	for(i = 0; i < t->np; i++){
+		for(bit = 0; bit < 8; bit++)
+			if(map[i] & (1 << (7-bit)))
+				words[bit] = H;
+		words += 8;
 	}
+}
+
+Heap*
+nheap(int n)
+{
+	Heap *h;
+
+	if(n < 0 || n > 128*1024*1024)
+		error("implausible heap allocation");
+	h = calloc(1, sizeof(Heap)+(size_t)n);
+	if(h == nil)
+		error(exNomem);
+	h->ref = 1;
+	return h;
+}
+
+Heap*
+heapz(Type *t)
+{
+	Heap *h;
+
+	h = nheap(t->size);
+	h->t = t;
+	t->ref++;
+	if(t->np != 0)
+		initmem(t, H2D(void*, h));
+	return h;
+}
+
+void
+initarray(Type *t, Array *a)
+{
+	uchar *p;
+	int i;
+
+	t->ref++;
+	if(t->np == 0)
+		return;
+	p = a->data;
+	for(i = 0; i < a->len; i++){
+		initmem(t, p);
+		p += t->size;
+	}
+}
+
+void
+destroy(void *data)
+{
+	Heap *h;
+	Array *a;
+	Type *t;
+	uchar *p;
+	WORD **words;
+	int bit, i, j;
+
+	if(data == H || data == nil)
+		return;
+	h = D2H(data);
+	if(--h->ref != 0)
+		return;
+	t = h->t;
+	if(t == &Tarray){
+		a = data;
+		if(a->root != H)
+			destroy(a->root);
+		else if(a->t->np != 0){
+			p = a->data;
+			for(i = 0; i < a->len; i++){
+				words = (WORD**)p;
+				for(j = 0; j < a->t->np; j++){
+					for(bit = 0; bit < 8; bit++)
+						if((a->t->map[j] & (1 << (7-bit))) && words[bit] != H)
+							destroy(words[bit]);
+					words += 8;
+				}
+				p += a->t->size;
+			}
+		}
+		freetype(a->t);
+		Tarray.ref--;
+	}else if(t != nil){
+		words = data;
+		for(i = 0; i < t->np; i++){
+			for(bit = 0; bit < 8; bit++)
+				if((t->map[i] & (1 << (7-bit))) && words[bit] != H)
+					destroy(words[bit]);
+			words += 8;
+		}
+		freetype(t);
+	}
+	free(h);
+}
+
+String*
+c2string(char *bytes, int len)
+{
+	Heap *h;
+	String *s;
+
+	if(len < 0)
+		return H;
+	h = nheap(sizeof(String)+(size_t)len+1);
+	s = H2D(String*, h);
+	s->len = len;
+	s->max = len+1;
+	memmove(s->Sascii, bytes, len);
+	((char*)&s->data)[len] = 0;
+	return s;
+}
+
+void
+acheck(int elementsize, int count)
+{
+	if(elementsize < 0 || count < 0 ||
+	   (elementsize != 0 && (uint)count >
+	    ((~0U >> 1)-sizeof(Array)-sizeof(Heap))/(uint)elementsize))
+		error("invalid array size");
+}
+
+void
+mlink(Module *m, Link *l, uchar *name, int sig, int pc, Type *frame)
+{
+	l->name = strdup((char*)name);
+	if(l->name == nil)
+		error(exNomem);
+	l->sig = sig;
+	l->frame = frame;
+	l->u.pc = m->prog+pc;
+}
+
+void
+destroylinks(Module *m)
+{
+	Link *l;
+
+	for(l = m->ext; l->name != nil; l++)
+		free(l->name);
+	free(m->ext);
+	m->ext = nil;
+}
+
+int
+verifysigner(uchar *signature, int siglen, uchar *data, ulong datalen)
+{
+	USED(signature);
+	USED(siglen);
+	USED(data);
+	USED(datalen);
+	return 1;
+}
+
+int
+mustbesigned(char *path, uchar *code, ulong length, Dir *dir)
+{
+	USED(path);
+	USED(code);
+	USED(length);
+	USED(dir);
 	return 0;
 }
 
-static ulong
-disw(uchar **p)
+int
+compile(Module *m, int size, Modlink *ml)
 {
-	ulong v;
-	uchar *c;
-
-	c = *p;
-	if(c+4 > codeend)
-		return 0;
-	v  = c[0] << 24;
-	v |= c[1] << 16;
-	v |= c[2] << 8;
-	v |= c[3];
-	*p = c + 4;
-	return v;
+	USED(m);
+	USED(size);
+	USED(ml);
+	return 1;
 }
 
-/*
- * Parse a Dis module header and instruction stream.
- * Mirrors the structure of parsemod() in libinterp/load.c
- * but without allocating kernel structures.
- */
-static int
-parse_dis(uchar *code, size_t length)
+Module*
+readmod(char *path, Module *m, int sync)
 {
-	uchar *istream, **isp;
-	int magic, isize, dsize, hsize, lsize, entry, entryt;
-	int i, op, add, siglen, n;
-
-	if(length < 4)
-		return -1;
-
-	istream = code;
-	isp = &istream;
-	codeend = code + length;
-
-	/* Magic number */
-	magic = operand(isp);
-	switch(magic) {
-	default:
-		return -1;
-	case SMAGIC:
-		siglen = operand(isp);
-		n = length - (*isp - code);
-		if(siglen < 0 || n < 0 || siglen > n)
-			return -1;
-		/* Skip signature */
-		*isp += siglen;
-		break;
-	case XMAGIC:
-		break;
-	}
-
-	/* Module header */
-	int rt = operand(isp);
-	int ss = operand(isp);
-	isize = operand(isp);
-	dsize = operand(isp);
-	hsize = operand(isp);
-	lsize = operand(isp);
-	entry = operand(isp);
-	entryt = operand(isp);
-
-	(void)rt;
-	(void)ss;
-	(void)entry;
-	(void)entryt;
-
-	if(isize < 0 || dsize < 0 || hsize < 0 || lsize < 0)
-		return -1;
-	if(isize > 1024*1024 || hsize > 1024*1024 || lsize > 1024*1024)
-		return -1;
-
-	/* Parse instruction stream */
-	for(i = 0; i < isize && istream < codeend; i++) {
-		if(istream + 2 > codeend)
-			return -1;
-		op = *istream++;
-		add = *istream++;
-
-		/* Middle operand */
-		switch(add & ARM) {
-		case AXIMM:
-		case AXINF:
-		case AXINM:
-			operand(isp);
-			break;
-		}
-
-		/* Source operand */
-		switch(UXSRC(add)) {
-		case SRC(AFP):
-		case SRC(AMP):
-		case SRC(AIMM):
-			operand(isp);
-			break;
-		case SRC(AIND|AFP):
-		case SRC(AIND|AMP):
-			operand(isp);
-			operand(isp);
-			break;
-		}
-
-		/* Destination operand */
-		switch(UXDST(add)) {
-		case DST(AFP):
-		case DST(AMP):
-		case DST(AIMM):
-			operand(isp);
-			break;
-		case DST(AIND|AFP):
-		case DST(AIND|AMP):
-			operand(isp);
-			operand(isp);
-			break;
-		}
-
-		(void)op;
-	}
-
-	/* Parse type descriptors */
-	for(i = 0; i < hsize && istream < codeend; i++) {
-		int id = operand(isp);
-		int tsz = operand(isp);
-		int tnp = operand(isp);
-		if(id < 0 || tsz < 0 || tnp < 0)
-			return -1;
-		if(tnp > 128*1024)
-			return -1;
-		/* Skip type bitmap */
-		if(istream + tnp > codeend)
-			return -1;
-		istream += tnp;
-	}
-
-	/* Parse link section */
-	for(i = 0; i < lsize && istream < codeend; i++) {
-		int pc = operand(isp);
-		int nargs = operand(isp);
-		int frame = operand(isp);
-		int nret = operand(isp);
-		(void)pc;
-		(void)nargs;
-		(void)frame;
-		(void)nret;
-
-		/* Skip function signature */
-		disw(isp);
-		/* Skip name (null-terminated string) */
-		while(istream < codeend && *istream != '\0')
-			istream++;
-		if(istream < codeend)
-			istream++;  /* skip null terminator */
-	}
-
-	return 0;
+	USED(path);
+	USED(m);
+	USED(sync);
+	return nil;
 }
 
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	/* Make a mutable copy since the parser advances pointers */
-	uchar *buf = malloc(size);
-	if(buf == NULL)
+	uchar *copy;
+	Module *m;
+	Dir dir;
+
+	if(size == 0 || size >= 8*1024*1024)
 		return 0;
-	memcpy(buf, data, size);
+	copy = malloc(size);
+	if(copy == nil)
+		return 0;
+	memmove(copy, data, size);
+	memset(&dir, 0, sizeof(dir));
 
-	parse_dis(buf, size);
-
-	free(buf);
+	parsing = 1;
+#ifdef STANDALONE_FUZZ_TARGET
+	parsedmodule = 0;
+#endif
+	if(setjmp(parseerror) == 0){
+		m = parsemod("/fuzz.dis", copy, size, &dir);
+		if(m != nil){
+#ifdef STANDALONE_FUZZ_TARGET
+			parsedmodule = 1;
+#endif
+			unload(m);
+		}
+	}
+	parsing = 0;
+	free(copy);
 	return 0;
 }
+
+#ifdef STANDALONE_FUZZ_TARGET
+int
+main(int argc, char **argv)
+{
+	FILE *fp;
+	uchar *data;
+	long size;
+	int i;
+	int failed;
+
+	failed = 0;
+	for(i = 1; i < argc; i++){
+		fp = fopen(argv[i], "rb");
+		if(fp == nil)
+			continue;
+		fseek(fp, 0, SEEK_END);
+		size = ftell(fp);
+		fseek(fp, 0, SEEK_SET);
+		data = malloc(size > 0 ? (size_t)size : 1);
+		if(size > 0 && fread(data, 1, size, fp) == (size_t)size){
+			LLVMFuzzerTestOneInput(data, size);
+			if(!parsedmodule){
+				fprintf(stderr, "rejected valid module: %s\n", argv[i]);
+				failed = 1;
+			}
+		}
+		free(data);
+		fclose(fp);
+	}
+	return failed;
+}
+#endif

--- a/libinterp/load.c
+++ b/libinterp/load.c
@@ -142,6 +142,7 @@ static ulong
 disw(ParseState *ps, uchar **p)
 {
 	ulong v;
+	u32int bits;
 	uchar *c;
 
 	c = *p;
@@ -149,11 +150,15 @@ disw(ParseState *ps, uchar **p)
 		ps->error = 1;
 		return 0;
 	}
-	v  = (ulong)c[0] << 24;
-	v |= (ulong)c[1] << 16;
-	v |= (ulong)c[2] << 8;
-	v |= c[3];
+	bits  = (u32int)c[0] << 24;
+	bits |= (u32int)c[1] << 16;
+	bits |= (u32int)c[2] << 8;
+	bits |= c[3];
 	*p = c + 4;
+	if(bits & (1U<<31))
+		v = (ulong)((vlong)bits-(1LL<<32));
+	else
+		v = bits;
 	return v;
 }
 

--- a/libinterp/load.c
+++ b/libinterp/load.c
@@ -23,9 +23,81 @@ havebytes(ParseState *ps, uchar *p, ulong n)
 }
 
 static int
+aligned(uchar *p, ulong n)
+{
+	return n == 0 || (uintptr)p%n == 0;
+}
+
+static int
+pointerslot(Type *t, ulong offset)
+{
+	ulong word, map;
+
+	if(t == nil || t->size <= 0 || offset%sizeof(WORD) != 0)
+		return 0;
+	offset %= t->size;
+	word = offset/sizeof(WORD);
+	map = word/8;
+	return map < (ulong)t->np && (t->map[map] & (1 << (7-(word%8)))) != 0;
+}
+
+static int
+haspointers(Type *t, uchar *base, uchar *p, ulong n)
+{
+	ulong first, last, offset;
+
+	if(t == nil || t->np == 0 || n == 0)
+		return 0;
+	first = p-base;
+	last = first+n;
+	offset = first-(first%sizeof(WORD));
+	for(; offset < last; offset += sizeof(WORD))
+		if(pointerslot(t, offset))
+			return 1;
+	return 0;
+}
+
+static int
+ismanagedpointer(Type *t, uchar *base, uchar *p)
+{
+	return p >= base && pointerslot(t, p-base);
+}
+
+static int
+validtypemap(int size, uchar *map, int mapsize)
+{
+	ulong maxwords, word;
+	int bit, i;
+
+	maxwords = (ulong)size/sizeof(WORD);
+	if(mapsize != 0 && size%sizeof(WORD) != 0)
+		return 0;
+	if((ulong)mapsize > (maxwords+7)/8)
+		return 0;
+	for(i = 0; i < mapsize; i++)
+		for(bit = 0; bit < 8; bit++){
+			word = (ulong)i*8+bit;
+			if((map[i] & (1 << (7-bit))) != 0 && word >= maxwords)
+				return 0;
+		}
+	return 1;
+}
+
+static int
+validarraysize(int elementsize, int count)
+{
+	uint maxalloc;
+
+	maxalloc = 128*1024*1024;
+	return elementsize >= 0 && count >= 0 &&
+		(elementsize == 0 || (uint)count <= (maxalloc-sizeof(Array))/(uint)elementsize);
+}
+
+static int
 operand(ParseState *ps, uchar **p)
 {
 	int c;
+	u32int v;
 	uchar *cp;
 
 	cp = *p;
@@ -47,22 +119,21 @@ operand(ParseState *ps, uchar **p)
 			return -1;
 		}
 		*p = cp+2;
+		v = ((u32int)(c&0x3F)<<8)|cp[1];
 		if(c & 0x20)
-			c |= ~0x3F;
-		else
-			c &= 0x3F;
-		return (c<<8)|cp[1];
+			return (int)((vlong)v-(1LL<<14));
+		return (int)v;
 	case 0xC0:
 		if(!havebytes(ps, cp, 4)){
 			ps->error = 1;
 			return -1;
 		}
 		*p = cp+4;
+		v = ((u32int)(c&0x3F)<<24)|((u32int)cp[1]<<16)|
+			((u32int)cp[2]<<8)|cp[3];
 		if(c & 0x20)
-			c |= ~0x3F;
-		else
-			c &= 0x3F;
-		return (c<<24)|(cp[1]<<16)|(cp[2]<<8)|cp[3];
+			return (int)((vlong)v-(1LL<<30));
+		return (int)v;
 	}
 	return 0;
 }
@@ -78,9 +149,9 @@ disw(ParseState *ps, uchar **p)
 		ps->error = 1;
 		return 0;
 	}
-	v  = c[0] << 24;
-	v |= c[1] << 16;
-	v |= c[2] << 8;
+	v  = (ulong)c[0] << 24;
+	v |= (ulong)c[1] << 16;
+	v |= (ulong)c[2] << 8;
 	v |= c[3];
 	*p = c + 4;
 	return v;
@@ -158,7 +229,7 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 {
 	Heap *h;
 	Inst *ip;
-	Type *pt;
+	Type *pt, *datatype;
 	String *s;
 	Module *m;
 	Array *ary;
@@ -166,8 +237,9 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 	WORD lo, hi;
 	int lsize, id, v, entry, entryt, tnp, tsz, siglen;
 	int de, pc, i, n, nbytes, isize, dsize, hsize, dasp;
-	uchar *mod, sm, *istream, **isp, *si, *addr, *addrend;
-	uchar *dastack[DADEPTH], *endstack[DADEPTH];
+	uchar *mod, sm, *istream, **isp, *si, *addr, *addrend, *database;
+	uchar *dastack[DADEPTH], *endstack[DADEPTH], *basestack[DADEPTH];
+	Type *typestack[DADEPTH];
 	Link *l;
 	ParseState ps;
 
@@ -310,7 +382,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 		}
 		tsz = operand(&ps, isp);
 		tnp = operand(&ps, isp);
-		if(ps.error || tsz < 0 || tsz > 128*1024*1024 || tnp < 0 || tnp > 128*1024 || !havebytes(&ps, istream, tnp)){
+		if(ps.error || tsz < 0 || tsz > 128*1024*1024 || tnp < 0 || tnp > 128*1024 ||
+		   !havebytes(&ps, istream, tnp) || !validtypemap(tsz, istream, tnp)){
 			kwerrstr("implausible Dis file");
 			goto bad;
 		}
@@ -324,6 +397,10 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 	}
 
 	if(dsize != 0) {
+		if(hsize == 0 || m->type == nil){
+			kwerrstr("missing desc for mp");
+			goto bad;
+		}
 		pt = m->type[0];
 		if(pt == 0 || pt->size != dsize) {
 			kwerrstr("bad desc for mp");
@@ -334,6 +411,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 	}
 	addr = m->origmp;
 	addrend = addr == H ? H : addr+dsize;
+	database = addr;
+	datatype = dsize == 0 ? nil : m->type[0];
 	dasp = 0;
 	for(;;) {
 		if(istream >= ps.end) {
@@ -357,7 +436,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			kwerrstr("bad data item");
 			goto bad;
 		case DEFS:
-			if(!havebytes(&ps, istream, n) || (ulong)(addrend-si) < sizeof(String*)){
+			if(!havebytes(&ps, istream, n) || (ulong)(addrend-si) < sizeof(String*) ||
+			   !aligned(si, sizeof(String*)) || !ismanagedpointer(datatype, database, si) || *(String**)si != H){
 				kwerrstr("bad string data range");
 				goto bad;
 			}
@@ -366,7 +446,7 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			*(String**)si = s;
 			break;
 		case DEFB:
-			if(!havebytes(&ps, istream, n) || n > addrend-si){
+			if(!havebytes(&ps, istream, n) || n > addrend-si || haspointers(datatype, database, si, n)){
 				kwerrstr("bad byte data range");
 				goto bad;
 			}
@@ -374,7 +454,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 				*si++ = *istream++;
 			break;
 		case DEFW:
-			if(n > (addrend-si)/sizeof(WORD) || !havebytes(&ps, istream, (ulong)n*4)){
+			if(n > (addrend-si)/sizeof(WORD) || !havebytes(&ps, istream, (ulong)n*4) ||
+			   !aligned(si, sizeof(WORD)) || haspointers(datatype, database, si, (ulong)n*sizeof(WORD))){
 				kwerrstr("bad word data range");
 				goto bad;
 			}
@@ -384,26 +465,21 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			break;
 		case DEFL:
-			if(n > (addrend-si)/sizeof(LONG) || !havebytes(&ps, istream, (ulong)n*8)){
+			if(n > (addrend-si)/sizeof(LONG) || !havebytes(&ps, istream, (ulong)n*8) ||
+			   !aligned(si, sizeof(LONG)) || haspointers(datatype, database, si, (ulong)n*sizeof(LONG))){
 				kwerrstr("bad long data range");
 				goto bad;
 			}
 			for(i = 0; i < n; i++) {
 				hi = disw(&ps, isp);
 				lo = disw(&ps, isp);
-				/*
-				 * Mask the low word to 32 bits with u32int. ulong is 64-bit on
-				 * LP64 hosts, so (ulong)lo does not narrow lo, and disw() returns
-				 * the word sign-extended (its c[0]<<24 is a signed-int shift); a
-				 * low word with bit 31 set would otherwise leak 1s into the high
-				 * half of the assembled LONG.
-				 */
-				*(LONG*)si = (LONG)hi << 32 | (LONG)(u32int)lo;
+				*(ULONG*)si = ((ULONG)(u32int)hi << 32) | (u32int)lo;
 				si += sizeof(LONG);
 			}
 			break;
 		case DEFF:
-			if(n > (addrend-si)/sizeof(REAL) || !havebytes(&ps, istream, (ulong)n*8)){
+			if(n > (addrend-si)/sizeof(REAL) || !havebytes(&ps, istream, (ulong)n*8) ||
+			   !aligned(si, sizeof(REAL)) || haspointers(datatype, database, si, (ulong)n*sizeof(REAL))){
 				kwerrstr("bad real data range");
 				goto bad;
 			}
@@ -415,7 +491,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			break;
 		case DEFA:			/* Array */
-			if((ulong)(addrend-si) < sizeof(Array*) || !havebytes(&ps, istream, 8)){
+			if((ulong)(addrend-si) < sizeof(Array*) || !havebytes(&ps, istream, 8) ||
+			   !aligned(si, sizeof(Array*)) || !ismanagedpointer(datatype, database, si) || A(si) != H){
 				kwerrstr("bad array data range");
 				goto bad;
 			}
@@ -426,11 +503,10 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			pt = m->type[v];
 			v = disw(&ps, isp);
-			if(ps.error){
-				kwerrstr("truncated array data");
+			if(ps.error || !validarraysize(pt->size, v)){
+				kwerrstr("bad array size");
 				goto bad;
 			}
-			acheck(pt->size, v);
 			nbytes = pt->size * v;
 			h = nheap(sizeof(Array)+nbytes);
 			h->t = &Tarray;
@@ -445,7 +521,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			A(si) = ary;
 			break;			
 		case DIND:			/* Set index */
-			if((ulong)(addrend-si) < sizeof(Array*)){
+			if((ulong)(addrend-si) < sizeof(Array*) || !aligned(si, sizeof(Array*)) ||
+			   !ismanagedpointer(datatype, database, si)){
 				kwerrstr("bad array index data range");
 				goto bad;
 			}
@@ -461,8 +538,12 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			dastack[dasp++] = addr;
 			endstack[dasp-1] = addrend;
+			basestack[dasp-1] = database;
+			typestack[dasp-1] = datatype;
 			addr = ary->data+v*ary->t->size;
 			addrend = ary->data+ary->len*ary->t->size;
+			database = ary->data;
+			datatype = ary->t;
 			break;
 		case DAPOP:
 			if(dasp == 0) {
@@ -471,6 +552,8 @@ parsemod(char *path, uchar *code, ulong length, Dir *dir)
 			}
 			addr = dastack[--dasp];
 			addrend = endstack[dasp];
+			database = basestack[dasp];
+			datatype = typestack[dasp];
 			break;
 		}
 	}

--- a/tests/host/dis_parser_bounds_test.sh
+++ b/tests/host/dis_parser_bounds_test.sh
@@ -35,6 +35,38 @@ header = b"".join(operand(v) for v in (819248, 0, 0, 0, 0, 1, 0, -1, -1))
 (out / "type-map-truncated.dis").write_bytes(
     header + operand(0) + operand(0) + operand(1)
 )
+
+# Module data requires type descriptor zero.
+(out / "missing-data-type.dis").write_bytes(
+    b"".join(operand(v) for v in (819248, 0, 0, 0, 8, 0, 0, -1, -1))
+)
+
+data_header = b"".join(operand(v) for v in (819248, 0, 0, 0, 8, 1, 0, -1, -1))
+
+# A type bitmap must not mark pointer words beyond the object allocation.
+(out / "type-map-oob.dis").write_bytes(
+    data_header + operand(0) + operand(8) + operand(1) + b"\x40"
+)
+
+pointer_type = data_header + operand(0) + operand(8) + operand(1) + b"\x80"
+
+# Scalar initializers must not replace managed pointers with attacker data.
+(out / "scalar-pointer.dis").write_bytes(
+    pointer_type + b"\x21" + operand(0) + b"\x70\xc0\x14\x68"
+)
+
+# Reinitializing a managed pointer used to leak the first allocation.
+(out / "duplicate-pointer.dis").write_bytes(
+    pointer_type + b"\x31" + operand(0) + b"a" + b"\x31" + operand(0) + b"b"
+)
+
+scalar_header = b"".join(operand(v) for v in (819248, 0, 0, 0, 16, 1, 0, -1, -1))
+scalar_type = scalar_header + operand(0) + operand(16) + operand(0)
+
+# Typed stores at attacker-selected offsets must be naturally aligned.
+(out / "unaligned-word.dis").write_bytes(
+    scalar_type + b"\x21" + operand(1) + b"\x00\x00\x00\x01"
+)
 PY
 
 run_bad() {
@@ -55,6 +87,11 @@ run_bad() {
 
 run_bad type-id-oob.dis "heap id range"
 run_bad type-map-truncated.dis "implausible Dis file"
+run_bad missing-data-type.dis "missing desc for mp"
+run_bad type-map-oob.dis "implausible Dis file"
+run_bad scalar-pointer.dis "bad word data range"
+run_bad duplicate-pointer.dis "bad string data range"
+run_bad unaligned-word.dis "bad word data range"
 
 for size in 0 1 2 4 8 16 32 64 128 256 512 1024 2048 4096; do
 	cp "$ROOT/dis/sh.dis" "$PROBEDIR/truncated.dis"


### PR DESCRIPTION
## Summary
- replace the copied/simplified Dis fuzzer with the production libinterp/load.c parser
- add a runtime adapter using the real Module, Type, Heap, Array, and String layouts
- validate type bitmaps and data initializers against managed-pointer metadata
- reject missing module-data descriptors, unaligned typed stores, duplicate pointer initialization, and oversized arrays
- remove signed-shift undefined behavior from operand and data decoding
- extend host regressions for the newly proven malformed modules

## Proven findings
The production-parser sanitizer harness demonstrated:
- heap overflow from a type bitmap marking pointers beyond the declared type size
- attacker-controlled invalid pointer followed during module cleanup after scalar data overwrote a managed-pointer slot
- null dereference when dsize is nonzero and hsize is zero
- unaligned typed accesses from attacker-controlled data offsets
- signed-shift undefined behavior in normal operand and 64-bit data decoding
- memory leak from duplicate pointer initialization and from oversized-array exceptions bypassing parser cleanup

## Empirical validation
- native ARM64 libinterp build
- 50 real Dis modules parsed and unloaded with ASan/UBSan
- 2,000 deterministic real-module mutations with ASan/UBSan
- Linux ClusterFuzz build with libFuzzer, ASan, UBSan, and LeakSanitizer
- final bounded Linux run: approximately 509,000 executions, no crash/UB/leak artifact
