### PR TITLE
emu(Linux): extend FIDO2 (#F /dev/2fa) to headless builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         echo "Version: $(cat include/version.h)"
 
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential
+      run: sudo apt-get update && sudo apt-get install -y build-essential libfido2-dev libudev-dev
 
     - name: Bootstrap build (mk, libraries, limbo, emulator)
       run: |
@@ -85,6 +85,12 @@ jobs:
         test -x emu/Linux/o.emu || { echo "Emulator not built"; exit 1; }
         file emu/Linux/o.emu
         test -x Linux/amd64/bin/limbo || { echo "Limbo compiler not built"; exit 1; }
+
+    - name: Verify libfido2 linkage (/dev/2fa)
+      run: |
+        # libfido2-dev is installed, so the headless emu must link libfido2 or
+        # the #F device would ship as a stub. Same guard as the GUI jobs.
+        ldd emu/Linux/o.emu | grep -i libfido2 || { echo "Emulator not linked against libfido2 — /dev/2fa would be a stub"; exit 1; }
 
     - name: Compile test suite
       run: |
@@ -582,7 +588,7 @@ jobs:
         echo "Version: $(cat include/version.h)"
 
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential
+      run: sudo apt-get update && sudo apt-get install -y build-essential libfido2-dev libudev-dev
 
     - name: Bootstrap build (mk, libraries, limbo, emulator)
       run: |
@@ -594,6 +600,12 @@ jobs:
         test -x emu/Linux/o.emu || { echo "Emulator not built"; exit 1; }
         file emu/Linux/o.emu
         test -x Linux/arm64/bin/limbo || { echo "Limbo compiler not built"; exit 1; }
+
+    - name: Verify libfido2 linkage (/dev/2fa)
+      run: |
+        # libfido2-dev is installed, so the headless emu must link libfido2 or
+        # the #F device would ship as a stub. Same guard as the GUI jobs.
+        ldd emu/Linux/o.emu | grep -i libfido2 || { echo "Emulator not linked against libfido2 — /dev/2fa would be a stub"; exit 1; }
 
     - name: Compile test suite
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         echo "Version: $(cat include/version.h)"
 
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential
+      run: sudo apt-get update && sudo apt-get install -y build-essential libfido2-dev libudev-dev patchelf
 
     - name: Build (headless)
       run: |
@@ -151,6 +151,25 @@ jobs:
         cp emu/Linux/o.emu "$STAGE/emu/Linux/"
         cp Linux/amd64/bin/limbo Linux/amd64/bin/mk "$STAGE/Linux/amd64/bin/"
         strip "$STAGE/emu/Linux/o.emu" "$STAGE/Linux/amd64/bin/limbo" "$STAGE/Linux/amd64/bin/mk"
+
+        # Bundle libfido2 (+ its non-system dep libcbor) next to the headless
+        # emu so /dev/2fa works without the user installing libfido2-dev —
+        # mirrors the GUI job. libudev/libcrypto are near-universal and stay as
+        # system deps; libcbor is bundled. The headless binary has no RUNPATH by
+        # default, so set $ORIGIN here (and on libfido2, so it finds libcbor).
+        patchelf --set-rpath '$ORIGIN' "$STAGE/emu/Linux/o.emu" || true
+        FIDO2_LIB=$(ldd emu/Linux/o.emu | grep -i libfido2 | awk '{print $3}')
+        if [ -n "$FIDO2_LIB" ] && [ -f "$FIDO2_LIB" ]; then
+          cp -L "$FIDO2_LIB" "$STAGE/emu/Linux/$(basename "$FIDO2_LIB")"
+          patchelf --set-rpath '$ORIGIN' "$STAGE/emu/Linux/$(basename "$FIDO2_LIB")" || true
+          CBOR_LIB=$(ldd "$FIDO2_LIB" | grep -i libcbor | awk '{print $3}')
+          if [ -n "$CBOR_LIB" ] && [ -f "$CBOR_LIB" ]; then
+            cp -L "$CBOR_LIB" "$STAGE/emu/Linux/$(basename "$CBOR_LIB")"
+          fi
+          echo "Bundled FIDO2 runtime: $(ls "$STAGE"/emu/Linux/libfido2* "$STAGE"/emu/Linux/libcbor* 2>/dev/null)"
+        else
+          echo "WARNING: libfido2 not linked — /dev/2fa will be a stub in this artifact" >&2
+        fi
 
         # Shared runtime tree
         for d in dis lib fonts module services locale usr mnt; do
@@ -480,7 +499,7 @@ jobs:
         echo "Version: $(cat include/version.h)"
 
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential
+      run: sudo apt-get update && sudo apt-get install -y build-essential libfido2-dev libudev-dev patchelf
 
     - name: Build (headless)
       run: |
@@ -590,6 +609,25 @@ jobs:
         # Platform binaries
         cp emu/Linux/o.emu "$STAGE/emu/Linux/"
         cp Linux/arm64/bin/limbo Linux/arm64/bin/mk "$STAGE/Linux/arm64/bin/"
+
+        # Bundle libfido2 (+ its non-system dep libcbor) next to the headless
+        # emu so /dev/2fa works without the user installing libfido2-dev —
+        # mirrors the GUI job. libudev/libcrypto are near-universal and stay as
+        # system deps; libcbor is bundled. The headless binary has no RUNPATH by
+        # default, so set $ORIGIN here (and on libfido2, so it finds libcbor).
+        patchelf --set-rpath '$ORIGIN' "$STAGE/emu/Linux/o.emu" || true
+        FIDO2_LIB=$(ldd emu/Linux/o.emu | grep -i libfido2 | awk '{print $3}')
+        if [ -n "$FIDO2_LIB" ] && [ -f "$FIDO2_LIB" ]; then
+          cp -L "$FIDO2_LIB" "$STAGE/emu/Linux/$(basename "$FIDO2_LIB")"
+          patchelf --set-rpath '$ORIGIN' "$STAGE/emu/Linux/$(basename "$FIDO2_LIB")" || true
+          CBOR_LIB=$(ldd "$FIDO2_LIB" | grep -i libcbor | awk '{print $3}')
+          if [ -n "$CBOR_LIB" ] && [ -f "$CBOR_LIB" ]; then
+            cp -L "$CBOR_LIB" "$STAGE/emu/Linux/$(basename "$CBOR_LIB")"
+          fi
+          echo "Bundled FIDO2 runtime: $(ls "$STAGE"/emu/Linux/libfido2* "$STAGE"/emu/Linux/libcbor* 2>/dev/null)"
+        else
+          echo "WARNING: libfido2 not linked — /dev/2fa will be a stub in this artifact" >&2
+        fi
 
         # Shared runtime tree
         for d in dis lib fonts module services locale usr mnt; do

--- a/emu/Linux/mkfile-g
+++ b/emu/Linux/mkfile-g
@@ -16,6 +16,13 @@ INSTALLDIR=$ROOT/$SYSTARG/$OBJTYPE/bin	#path of directory where kernel is instal
 <| $SHELLNAME ../port/mkdevlist  $CONF	#sets $IP, $DEVS, $PORT, $LIBS
 <mkfile-$OBJTYPE	# sets $ARCHFILES
 
+# libfido2 for /dev/2fa (YubiKey/FIDO2). This is the build the headless release
+# and `build-linux-*.sh headless` use, so it gets the same conditional FIDO2
+# wiring as the sdl3 backend: -DHAVE_FIDO2 + link libfido2 only when present
+# (apt install libfido2-dev), else fido2bridge.c compiles its stub path.
+FIDO2_CFLAGS=`if pkg-config --exists libfido2 2>/dev/null; then echo -DHAVE_FIDO2; pkg-config --cflags libfido2; fi`
+FIDO2_LIBS=`if pkg-config --exists libfido2 2>/dev/null; then pkg-config --libs libfido2; fi`
+
 OBJ=\
 	asm-$OBJTYPE.$O\
 	$ARCHFILES\
@@ -39,7 +46,7 @@ CFLAGS=\
 	-I$ROOT/$SYSTARG/$OBJTYPE/include\
 	-I$ROOT/include\
 	-I$ROOT/libinterp\
-	$CTHREADFLAGS $CFLAGS $EMUOPTIONS\
+	$CTHREADFLAGS $CFLAGS $EMUOPTIONS $FIDO2_CFLAGS\
 
 KERNDATE=`{$NDATE}
 
@@ -52,7 +59,7 @@ default:V:	$O.$CONF
 
 $O.$CONF:	$OBJ $CONF.c $CONF.root.h # $LIBNAMES
 	$CC $CFLAGS '-DKERNDATE='$KERNDATE $CONF.c
-	$LD $LDFLAGS -o $target $OBJ $CONF.$O $LIBFILES $SYSLIBS
+	$LD $LDFLAGS -o $target $OBJ $CONF.$O $LIBFILES $SYSLIBS $FIDO2_LIBS
 
 install:V: $O.$CONF
 	cp $O.$CONF $INSTALLDIR/$CONF

--- a/emu/Linux/mkfile-gui-headless
+++ b/emu/Linux/mkfile-gui-headless
@@ -4,5 +4,14 @@
 GUISRC=\
 	stubs-headless.$O\
 
-GUIFLAGS=
-GUILIBS=
+# libfido2 for /dev/2fa (YubiKey/FIDO2). Same conditional pattern as the sdl3
+# backend: only -DHAVE_FIDO2 + link libfido2 when it is present (apt install
+# libfido2-dev), so a headless host without it still builds — the #F device
+# reports available=0 instead of failing to find <fido.h>. There is no display
+# here, but the 2fa device is display-independent and headless installs are a
+# supported target, so it ships with FIDO2 too.
+FIDO2_CFLAGS=`if pkg-config --exists libfido2 2>/dev/null; then echo -DHAVE_FIDO2; pkg-config --cflags libfido2; fi`
+FIDO2_LIBS=`if pkg-config --exists libfido2 2>/dev/null; then pkg-config --libs libfido2; fi`
+
+GUIFLAGS=$FIDO2_CFLAGS
+GUILIBS=$FIDO2_LIBS


### PR DESCRIPTION
## Summary

#305 brought YubiKey/FIDO2 (`#F` / `/dev/2fa`) to Linux but scoped it to the **SDL3 GUI** build (`emu/Linux/mkfile-gui-sdl3`). The **headless** build path — `emu/Linux/mkfile-g` and `mkfile-gui-headless`, used by `build-linux-*.sh headless` and the headless CI/release jobs — still compiled `fido2bridge.c` as a stub, so `/dev/2fa` was dead on headless and container installs. This closes that gap so the headless artifacts ship FIDO2 too, using the exact conventions #305 established.

## Changes

- **`emu/Linux/mkfile-g`, `emu/Linux/mkfile-gui-headless`**: add the conditional FIDO2 wiring — `-DHAVE_FIDO2` + link libfido2 via pkg-config when present, stub path otherwise — identical in shape to the sdl3 backend.
- **`.github/workflows/ci.yml`**: install `libfido2-dev libudev-dev` in the two headless Linux jobs (AMD64, ARM64) and add the same "emulator must link libfido2" guard the GUI jobs already carry.
- **`.github/workflows/release.yml`**: bundle `libfido2` + `libcbor` next to the headless emu with rpath `$ORIGIN` on both the binary and libfido2 (DT_RUNPATH is not transitive, so libfido2 needs its own `$ORIGIN` to resolve the bundled libcbor). `libudev`/`libcrypto` stay as system deps — exactly the GUI job's split.

No source/runtime code changes; `fido2bridge.c` and `devtfa.c` are unchanged. Purely build/CI/release wiring for the headless target.

## Testing

Verified on Linux AMD64:
- Headless emu builds with `-DHAVE_FIDO2` and links libfido2 (`fido2bridge.o` + `devtfa.o` in the link line; `o.emu` → `libfido2.so.1`) via `mkfile-g`.
- JIT boot smoke test passes (16 tools loaded, no crashes).
- `#F` binds and `/dev/providers` returns live libfido2 status (`available=0` in a keyless container).
- Release bundling reproduced locally: with the host `libfido2`/`libcbor` removed, the staged binary resolves both from the bundle via rpath `$ORIGIN`.

Hardware enroll/derive (touch + PIN) still requires a human with a YubiKey, same as every other platform; and the release-artifact bundling should be confirmed by a release dry-run since the release pipeline can't be exercised from a PR.

- [x] Tested on: Linux AMD64 (headless build, boot smoke, device probe, bundling sim)
- [ ] Hardware FIDO2 enroll/derive (needs a YubiKey)
- [ ] Release dry-run to confirm headless tarball bundling

## Checklist

- [x] Code follows the existing style of the file(s) modified (mirrors #305)
- [x] No `.dis` build artifacts committed
- [x] No secrets, API keys, or credentials included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Zh24xGi532AuaemCJDR1e)_