### PR TITLE
feat(security): add internal configuration audit

### DIFF
--- a/lib/sh/security-check
+++ b/lib/sh/security-check
@@ -1,0 +1,168 @@
+#!/dis/sh.dis
+# security-check - audit an InferNode configuration from inside Inferno.
+#
+# Usage: sh /lib/sh/security-check [desktop|server|agent] [root]
+#
+# The optional root is for auditing an offline tree and for regression tests.
+# Runtime namespace checks are only meaningful with the default root (/).
+# Consumers should parse the final result record: nested Inferno shell scripts
+# do not reliably propagate an exit status to their caller.
+
+load std
+
+profile=$1
+root=$2
+if {~ $#profile 0} { profile=desktop }
+if {~ $#root 0} { root='' }
+if {! ~ $profile desktop server agent} {
+	echo 'usage: security-check [desktop|server|agent] [root]' >[1=2]
+	exit usage
+}
+
+failed=0
+warned=0
+
+fn pass {
+	echo 'PASS' $1 $2
+}
+
+fn warn {
+	warned=1
+	echo 'WARN' $1 $2
+}
+
+fn fail {
+	failed=1
+	echo 'FAIL' $1 $2
+}
+
+fn readscalar {
+	cat $1 >[2] /dev/null
+}
+
+echo 'security-check profile='^$profile 'root='^$root
+
+# Strict crypto policy. An explicitly disabled or missing policy is unsafe for
+# a network server; desktops may legitimately operate in classical mode.
+cnsafile=$root^/env/cnsamode
+cnsa=`{readscalar $cnsafile}
+if {~ $cnsa 1 y Y yes YES on ON true TRUE} {
+	pass CRYPTO-CNSA 'strict mode enabled'
+} {
+	if {~ $profile server agent} {
+		fail CRYPTO-CNSA 'strict mode is not enabled'
+	} {
+		warn CRYPTO-CNSA 'strict mode is not enabled'
+	}
+}
+
+# Remote LLM mounts must authenticate. Absence of the optional configuration
+# is informational: local llmsrv and dedicated profiles need not use it.
+llmcfg=$root^/lib/ndb/llm
+if {ftest -f $llmcfg} {
+	llmmode=`{sed -n 's/^mode=//p' $llmcfg >[2] /dev/null}
+	if {~ $llmmode remote} {
+		llmauth=`{sed -n 's/^auth=//p' $llmcfg >[2] /dev/null}
+		if {~ $llmauth keyring} {
+			pass LLM-AUTH 'remote mount requires keyring authentication'
+			llmkey=`{sed -n 's/^keyfile=//p' $llmcfg >[2] /dev/null}
+			if {~ $#llmkey 0} { llmkey=/lib/keyring/serve-llm }
+			if {ftest -f $root^$llmkey} {
+				pass LLM-KEY 'configured keyfile exists'
+			} {
+				fail LLM-KEY 'configured keyfile is missing'
+			}
+		} {
+			fail LLM-AUTH 'remote mount permits anonymous authentication'
+		}
+	} {
+		pass LLM-AUTH 'LLM service is not configured as a remote mount'
+	}
+} {
+	warn LLM-CONFIG 'no /lib/ndb/llm configuration found'
+}
+
+# Headless serve-profile reflects these host settings into /env. Check them
+# when present, without requiring desktop or agent runtimes to define them.
+serveauth=`{readscalar $root^/env/SERVE_LLM_AUTH}
+if {! ~ $#serveauth 0} {
+	if {~ $serveauth keyring} {
+		pass EXPORT-AUTH 'LLM export requires keyring authentication'
+	} {
+		fail EXPORT-AUTH 'LLM export authentication is not keyring'
+	}
+	servekey=`{readscalar $root^/env/SERVE_LLM_KEY}
+	if {~ $#servekey 0} {
+		fail EXPORT-KEY 'LLM export key path is unset'
+	} {
+		if {ftest -f $root^$servekey} {
+			pass EXPORT-KEY 'LLM export keyfile exists'
+		} {
+			fail EXPORT-KEY 'LLM export keyfile is missing'
+		}
+	}
+}
+
+# Authentication databases should not remain mounted in ordinary service or
+# agent namespaces. Factotum is an intentional desktop capability but is too
+# powerful for an agent namespace.
+if {~ $root ''} {
+	# A mntgen directory can exist without a server mounted on it. Inspect the
+	# namespace operations rather than treating the directory as authority.
+	if {ns | grep ' /mnt/keys' > /dev/null} {
+		fail KEYDB-EXPOSURE '/mnt/keys is mounted'
+	} {
+		pass KEYDB-EXPOSURE '/mnt/keys is not mounted'
+	}
+} {
+	if {ftest -e $root^/mnt/keys} {
+		fail KEYDB-EXPOSURE '/mnt/keys exists in offline tree'
+	} {
+		pass KEYDB-EXPOSURE '/mnt/keys is absent from offline tree'
+	}
+}
+
+if {~ $profile agent} {
+	for p in /cmd /n/local /mnt/factotum/ctl /mnt/keys /net {
+		if {ftest -e $root^$p} {
+			fail AGENT-AUTHORITY $p^' is visible'
+		} {
+			pass AGENT-AUTHORITY $p^' is absent'
+		}
+	}
+	if {ftest -d $root^/tool} {
+		if {~ $root ''} {
+			if {nsaudit -m /tool > /dev/null} {
+				pass AGENT-NSAUDIT 'capability policy accepted'
+			} {
+				fail AGENT-NSAUDIT 'capability policy violation'
+			}
+		} {
+			warn AGENT-NSAUDIT 'offline roots require a separate nsaudit run'
+		}
+	} {
+		warn AGENT-NSAUDIT '/tool capability manifest is not mounted'
+	}
+}
+
+# Auditing is recommended for servers and agents. It is not yet mandatory for
+# general desktop installations.
+if {ftest -e $root^/mnt/audit/ctl} {
+	pass AUDIT 'audit service is mounted'
+} {
+	if {~ $profile server agent} {
+		warn AUDIT 'audit service is not mounted'
+	} {
+		pass AUDIT 'audit service is optional for desktop profile'
+	}
+}
+
+if {! ~ $failed 0} {
+	echo 'security-check result=FAIL warnings='^$warned
+	exit 'unsafe InferNode configuration'
+}
+if {! ~ $warned 0} {
+	echo 'security-check result=WARN warnings=1'
+} {
+	echo 'security-check result=PASS warnings=0'
+}

--- a/man/8/security-check
+++ b/man/8/security-check
@@ -1,0 +1,58 @@
+.TH SECURITY-CHECK 8
+.SH NAME
+security-check \- audit an InferNode configuration from inside Inferno
+.SH SYNOPSIS
+.B sh /lib/sh/security-check
+[
+.B desktop
+|
+.B server
+|
+.B agent
+]
+.SH DESCRIPTION
+.I Security-check
+examines the effective Inferno namespace and security configuration.  It reports
+one record per check beginning with
+.BR PASS ,
+.BR WARN ,
+or
+.BR FAIL ,
+followed by a stable check identifier.
+.PP
+The server and agent profiles require CNSA strict mode.  All profiles reject an
+anonymous remote LLM configuration, missing configured key files, an anonymous
+LLM export mode, and a visible
+.BR /mnt/keys .
+The agent profile additionally rejects host command, host filesystem, factotum,
+key database, and raw network namespace exposure, and invokes
+.IR nsaudit (1)
+when a live
+.B /tool
+manifest is mounted.
+.PP
+The final line is suitable for machine parsing and is the authoritative result;
+Inferno shell wrappers do not reliably propagate the status of a nested script:
+.IP
+security-check result=PASS warnings=0
+.PP
+The command reports configuration; it does not modify it and does not print key
+or credential contents.
+.SH FILES
+.TF /lib/sh/security-check
+.TP
+.B /lib/sh/security-check
+Inferno shell implementation.
+.TP
+.B /lib/ndb/llm
+LLM backend and remote-mount authentication configuration.
+.TP
+.B /env/cnsamode
+CNSA strict-mode policy.
+.TP
+.B /env/SERVE_LLM_AUTH
+Headless LLM export authentication policy, when applicable.
+.SH SEE ALSO
+.IR nsaudit (1),
+.IR listen (1),
+.IR mount (1)

--- a/tests/host/security_check_test.sh
+++ b/tests/host/security_check_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Regression tests for the in-Inferno security-check script.
+
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+
+[[ -x "$EMU" ]] || { echo "SKIP: emu not found at $EMU"; exit 77; }
+
+FIX="$ROOT/tmp/security-check-fixture"
+rm -rf "$FIX"
+mkdir -p "$FIX/env" "$FIX/lib/ndb" "$FIX/lib/keyring" "$FIX/mnt/audit"
+printf '1\n' > "$FIX/env/cnsamode"
+printf 'mode=remote\nauth=keyring\nkeyfile=/lib/keyring/serve-llm\n' > "$FIX/lib/ndb/llm"
+printf 'test-public-key-placeholder\n' > "$FIX/lib/keyring/serve-llm"
+touch "$FIX/mnt/audit/ctl"
+
+run_check() {
+    local profile="${1:-server}"
+    timeout 20 "$EMU" -c1 -r"$ROOT" /dis/sh.dis -c \
+        "sh /lib/sh/security-check $profile /tmp/security-check-fixture" \
+        </dev/null 2>&1 || true
+}
+
+out="$(run_check)"
+grep -q 'security-check result=PASS' <<<"$out" || {
+    echo "FAIL: safe fixture was not accepted"
+    echo "$out"
+    rm -rf "$FIX"
+    exit 1
+}
+
+printf 'mode=remote\nauth=none\n' > "$FIX/lib/ndb/llm"
+out="$(run_check)"
+grep -q 'FAIL LLM-AUTH remote mount permits anonymous authentication' <<<"$out" || {
+    echo "FAIL: anonymous remote mount was not rejected"
+    echo "$out"
+    rm -rf "$FIX"
+    exit 1
+}
+grep -q 'security-check result=FAIL' <<<"$out" || {
+    echo "FAIL: unsafe fixture did not produce failing summary"
+    echo "$out"
+    rm -rf "$FIX"
+    exit 1
+}
+
+# A headless export must never select the anonymous listener branch.
+printf 'mode=local\n' > "$FIX/lib/ndb/llm"
+printf 'anon\n' > "$FIX/env/SERVE_LLM_AUTH"
+out="$(run_check)"
+grep -q 'FAIL EXPORT-AUTH LLM export authentication is not keyring' <<<"$out" || {
+    echo "FAIL: anonymous LLM export was not rejected"
+    echo "$out"
+    rm -rf "$FIX"
+    exit 1
+}
+
+# An agent namespace must not expose host command authority.
+rm -f "$FIX/env/SERVE_LLM_AUTH"
+touch "$FIX/cmd"
+out="$(run_check agent)"
+grep -q 'FAIL AGENT-AUTHORITY /cmd is visible' <<<"$out" || {
+    echo "FAIL: agent-visible /cmd was not rejected"
+    echo "$out"
+    rm -rf "$FIX"
+    exit 1
+}
+
+rm -rf "$FIX"
+echo 'PASS: security-check accepts safe configuration and rejects anonymous mounts, exports, and agent host authority'


### PR DESCRIPTION
## Summary
- add an internal `security-check` Inferno shell audit with desktop, server, and agent profiles
- reject anonymous remote LLM mounts/exports, missing keys, mounted key databases, and dangerous agent authority
- integrate `nsaudit` for live agent capability checks and document stable machine-readable results
- add fixture coverage for hardened and unsafe configurations

## Testing
- `./tests/host/security_check_test.sh`
- live namespace smoke: `sh /lib/sh/security-check desktop` (expected WARN with CNSA unset)

## Security notes
The script reports configuration and never modifies it or prints credential contents. The final `security-check result=...` record is authoritative because nested Inferno shell scripts do not reliably propagate exit status.