### PR TITLE
fix(profile): persist ~/.infernode overlays so YubiKey 2FA enrollment survives restart

### DIFF
--- a/doc/yubikey-2fa-operations.md
+++ b/doc/yubikey-2fa-operations.md
@@ -128,6 +128,53 @@ cd $ROOT
 ./emu/MacOSX/o.emu -c1 -pheap=1024m -pmain=1024m -pimage=1024m -r$PWD sh -l /lib/lucifer/boot.sh
 ```
 
+### Linux: use the standard build scripts
+
+The preferred way to build on Linux is the platform build script — **not** a
+hand-run `mk`. It rebuilds the host-native libraries and the emu together, so it
+also sidesteps the static-lib clobber described below:
+
+```sh
+sudo apt install libfido2-dev fido2-tools   # prereq (once) — see "Stub vs real" below
+
+./build-linux-amd64.sh            # SDL3 GUI (default) — graphical login window
+./build-linux-amd64.sh headless   # headless — console only, single-command use
+# (./build-linux-arm64.sh on aarch64, e.g. Jetson)
+
+ldd emu/Linux/o.emu | grep fido   # confirm: libfido2.so.1 ...
+```
+
+> **Stub vs real.** All three Linux mkfiles gate `-DHAVE_FIDO2` on
+> `pkg-config --exists libfido2`. With only the runtime `libfido2.so.1` and no
+> `-dev` package, `pkg-config` fails, the bridge compiles its stub, and
+> `/dev/2fa` reports `available=0`. Install `libfido2-dev` and rebuild.
+
+#### Fast iteration: relinking the emu alone
+
+When you are only touching emu C (`fido2bridge.c`, `devtfa.c`, …) you can skip
+the full script and relink just the emu:
+
+```sh
+export ROOT=$PWD SYSHOST=Linux OBJTYPE=amd64 SYSTARG=Linux
+export PATH=$ROOT/Linux/amd64/bin:$PATH
+cd $ROOT/emu/Linux && rm -f *.o *.emu emu.root.* emu.c errstr.h && mk
+```
+
+**If this fails with `undefined reference to __errno`:** an Android x86_64 NDK
+build has clobbered the shared host static libs in `Linux/amd64/lib/` with
+bionic objects (bionic spells `errno` as `__errno`; glibc as
+`__errno_location`), so the host link can't resolve `__errno`. The full build
+script avoids this by rebuilding those libs; to fix it for a targeted relink, do
+the same loop yourself, then relink:
+
+```sh
+for lib in lib9 libbio libmp libsec libmath libmemdraw libmemlayer libdraw; do
+    (cd $ROOT/$lib && rm -f *.o && mk install)
+done
+nm $ROOT/Linux/amd64/lib/lib9.a | grep 'U __errno'   # must be __errno_location
+cd $ROOT/emu/Linux && mk                              # relink
+```
+
 ---
 
 ## 2. Check status

--- a/lib/sh/profile
+++ b/lib/sh/profile
@@ -34,9 +34,11 @@ if {~ $emuhost MacOSX Linux Nt}{
 		# Windows: mount C:\ at /n/local. Profiles live at C:\Users\<name>,
 		# so /n/local/Users/$user matches macOS's /n/local/Users/$user.
 		trfs '#UC:/' /n/local >[2] /dev/null
+		ls /n/local >[2] /dev/null		# settle the EXPASYNC export/mount before first use (host-root trfs race)
 		ghome=/n/local/Users/^$user
 	}{
 		trfs '#U*' /n/local >[2] /dev/null
+		ls /n/local >[2] /dev/null		# settle the EXPASYNC export/mount before first use (host-root trfs race)
 		ghome=/n/local/^`{echo 'echo $HOME' | os sh}
 	}
 	home=$ghome
@@ -47,19 +49,24 @@ if {~ $emuhost MacOSX Linux Nt}{
 	# The emu root stays clean — no user data mixed with system files.
 	infhome=$ghome^/.infernode
 
-	# First-run: create overlay and seed defaults through Inferno's
-	# filesystem. This keeps trfs cache consistent so binds work.
-	if {! ftest -d $infhome/lib} {
-		mkdir -p $infhome/usr/inferno/secstore
-		mkdir -p $infhome/usr/inferno/tmp
-		mkdir -p $infhome/lib/ndb
-		mkdir -p $infhome/lib/lucifer/theme
-		mkdir -p $infhome/lib/veltro
-		mkdir -p $infhome/lib/veltro-agents
-		mkdir -p $infhome/lib/veltro-keys
-		mkdir -p $infhome/lib/keyring
-		mkdir -p $infhome/tmp
-		# Seed writable defaults from the emu root
+	# Ensure every overlay SOURCE dir exists BEFORE the binds below. This runs
+	# unconditionally (not gated on first-run): `bind -bc` of a missing source
+	# silently falls back to the emu-root dir, so a deleted (or never-created)
+	# ~/.infernode/usr/inferno/secstore would route secstore into the emu root /
+	# bundle instead of the user's home — and 2FA enrollment would not persist.
+	mkdir -p $infhome/usr/inferno/secstore
+	mkdir -p $infhome/usr/inferno/tmp
+	mkdir -p $infhome/lib/ndb
+	mkdir -p $infhome/lib/lucifer/theme
+	mkdir -p $infhome/lib/veltro
+	mkdir -p $infhome/lib/veltro-agents
+	mkdir -p $infhome/lib/veltro-keys
+	mkdir -p $infhome/lib/keyring
+	mkdir -p $infhome/tmp
+
+	# First-run only: seed writable defaults from the emu root (don't clobber
+	# a user's existing config on later boots).
+	if {! ftest -f $infhome/lib/ndb/llm} {
 		cp /lib/ndb/llm $infhome/lib/ndb/llm >[2] /dev/null
 		cp /lib/lucifer/theme/current $infhome/lib/lucifer/theme/current >[2] /dev/null
 		cp /lib/veltro/meta.txt $infhome/lib/veltro/meta.txt >[2] /dev/null


### PR DESCRIPTION
## Summary

While bringing up YubiKey/FIDO2 2FA on a Linux host, login kept falling back to password-only after a restart even though enrollment "succeeded". Root cause was in the cross-platform boot profile (`lib/sh/profile`), not the device layer (`/dev/2fa` works: `available=1`, hmac-secret derive confirmed).

Two distinct bugs made secstore (and the other `~/.infernode` overlays) land in the wrong place:

1. **trfs host-root race.** `trfs '#U*' /n/local` (POSIX) / `trfs '#UC:/' /n/local` (Windows) use an `EXPASYNC` export; the mount wasn't always wired before the profile wrote to `/n/local`, so writes leaked into the literal `<emu-root>/n/local`. Fix: settle the mount with an `ls /n/local` before first use — added to **both** the macOS/Linux and the Windows branch.

2. **Overlay-bind fallback (all platforms).** The overlay *source* dirs (`usr/inferno/secstore`, `tmp`, `lib/*`) were created only on first run, gated on `$infhome/lib` being absent. If a source dir was missing while `lib` still existed, `bind -bc` silently fell back to the emu-root dir — routing secstore into the emu root / bundle instead of `~/.infernode`, so 2FA enrollment never persisted. Fix: create the source dirs **unconditionally** before the binds; gate only the one-time default seeding.

## Cross-platform

Both fixes live in the shared `MacOSX/Linux/Nt` profile path:
- The bind-fallback fix is in the shared block → benefits **all three** platforms.
- The trfs settle is in both branches → macOS shares Linux's `#U*` path (validated here); the Windows settle is **by-parity and untested on Windows hardware** (mirrors the proven change; it's a harmless `ls`).

## Also included

- `docs(2fa)`: a Linux section in `doc/yubikey-2fa-operations.md` covering the standard build scripts (`./build-linux-amd64.sh [headless]`) and the Android-x86_64 static-lib clobber (`undefined reference to __errno`) recovery.

## Testing

- Diagnosed and verified on Linux: enrollment now persists to `~/.infernode/usr/inferno/secstore/`, and login requires the security key after restart (operator-confirmed).
- Clean-profile smoke test: no parse errors, no `n/local` leak, overlays land in `~/.infernode`.
- Not yet exercised on macOS or Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)