### PR TITLE
fix(auth): reject noncanonical message frames

### DIFF
--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -1677,7 +1677,7 @@ static int
 getmsg(int fd, char *buf, int n)
 {
 	char num[6];
-	int len, r;
+	int i, len, r, start;
 
 	release();
 	if((r = nreadn(fd, num, 5)) != 5){
@@ -1687,10 +1687,25 @@ getmsg(int fd, char *buf, int n)
 	}
 	num[5] = 0;
 
-	if(num[0] == '!')
-		len = strtoul(num+1, 0, 10);
-	else
-		len = strtoul(num, 0, 10);
+	/* Authentication framing is exactly "dddd\\n" for data and
+	 * "!ddd\\n" for errors.  strtoul accepted signs, whitespace, and a
+	 * missing newline, allowing non-canonical pre-auth frames to reach the
+	 * expensive handshake state machine. */
+	start = num[0] == '!' ? 1 : 0;
+	if(num[4] != '\n'){
+		getmsgerr(buf, n, 1);
+		acquire();
+		return -1;
+	}
+	len = 0;
+	for(i = start; i < 4; i++){
+		if(num[i] < '0' || num[i] > '9'){
+			getmsgerr(buf, n, 1);
+			acquire();
+			return -1;
+		}
+		len = len*10 + num[i]-'0';
+	}
 
 	r = -1;
 	if(len < 0 || len >= n || (r = nreadn(fd, buf, len)) != len){

--- a/tests/keyring_test.b
+++ b/tests/keyring_test.b
@@ -694,6 +694,37 @@ testDESCBC(t: ref T)
 	t.assert(rejected, "DES setup rejected");
 }
 
+# ── Authentication message framing ─────────────────────────────────────────
+
+getframed(raw: string): array of byte
+{
+	fds := array[2] of ref Sys->FD;
+	if(sys->pipe(fds) < 0)
+		return nil;
+	b := array of byte raw;
+	if(sys->write(fds[1], b, len b) != len b)
+		return nil;
+	fds[1] = nil;
+	return kr->getmsg(fds[0]);
+}
+
+testMessageFraming(t: ref T)
+{
+	msg := getframed("0001\n2");
+	t.assert(msg != nil && string msg == "2", "canonical data frame accepted");
+
+	msg = getframed("0001X2");
+	t.assert(msg == nil, "missing frame-header newline rejected");
+	msg = getframed("+001\n2");
+	t.assert(msg == nil, "signed frame length rejected");
+	msg = getframed("   1\n2");
+	t.assert(msg == nil, "whitespace-padded frame length rejected");
+	msg = getframed("0a01\n2");
+	t.assert(msg == nil, "nondigit frame length rejected");
+	msg = getframed("!01x\ne");
+	t.assert(msg == nil, "malformed error-frame length rejected");
+}
+
 init(nil: ref Draw->Context, args: list of string)
 {
 	sys = load Sys Sys->PATH;
@@ -744,6 +775,7 @@ init(nil: ref Draw->Context, args: list of string)
 	run("AES256", testAES256);
 	run("RC4", testRC4);
 	run("DESDisabled", testDESCBC);
+	run("MessageFraming", testMessageFraming);
 
 	# Asymmetric key tests
 	run("RSA", testRSA);


### PR DESCRIPTION
## Security finding
The native authentication frame parser used `strtoul` on a fixed five-byte header without validating every length digit or the required trailing newline.

A bounded live probe against the deployed V2 listener demonstrated that these noncanonical version frames were accepted and advanced into DH/KEM processing:
- `0001X2` (missing newline)
- `+001\n2` (signed length)
- `   1\n2` (whitespace-padded length)

Malformed state transitions did not bypass authentication and the service remained available. The issue nevertheless permits parser differentials and unnecessary unauthenticated cryptographic work.

## Fix
Parse authentication frame lengths digit by digit and require exactly:
- `dddd\n` for data
- `!ddd\n` for errors

Any other header fails before its payload reaches the authentication state machine.

## Empirical verification
- Direct `Keyring->getmsg` regression: canonical frame accepted; missing-newline, signed, whitespace-padded, nondigit, and malformed error frames rejected.
- Keyring suite: 29 passed, 1 pre-existing environment skip.
- Hybrid STS suite: 11 passed.
- Malformed handshake fuzz suite: passed all 9 cases.
- ARM64 C compilation completed with project hardening flags.
