### PR TITLE
fix(keyring): variable-width keyfile framing for PQ (CNSA) signer keys

### DIFF
--- a/libinterp/keyring.c
+++ b/libinterp/keyring.c
@@ -1722,6 +1722,73 @@ getmsg(int fd, char *buf, int n)
 	return len;
 }
 
+/*
+ * Keyfile framing (readauthinfo / writeauthinfo only).
+ *
+ * The on-disk signer keyfile carries whole keys: an ML-DSA-87 secret+public
+ * message is ~13KB and larger CNSA keys (SLH-DSA) bigger still, exceeding the
+ * fixed 4-digit ("dddd\n", <=9999) frame that getmsg/sendmsg use for the STS
+ * wire handshake.  A keyfile is a trusted local file, not adversarial pre-auth
+ * input, so it uses a variable-width decimal header "d+\n" bounded by Maxbuf.
+ * The strict wire frame is left unchanged (see #315).  The variable reader
+ * also still parses legacy 4-digit keyfiles, so old keyfiles keep working.
+ */
+static int
+sendkfmsg(int fd, void *buf, int n)
+{
+	char num[16];
+	int hn;
+
+	release();
+	hn = snprint(num, sizeof(num), "%d\n", n);
+	if(kwrite(fd, num, hn) != hn){
+		acquire();
+		return -1;
+	}
+	n = kwrite(fd, buf, n);
+	acquire();
+	return n;
+}
+
+static int
+getkfmsg(int fd, char *buf, int n)
+{
+	int i, len, r;
+	char c;
+
+	release();
+	len = 0;
+	for(i = 0;; i++){
+		if((r = nreadn(fd, &c, 1)) != 1){
+			getmsgerr(buf, n, r);
+			acquire();
+			return -1;
+		}
+		if(c == '\n')
+			break;
+		if(i >= 8 || c < '0' || c > '9'){	/* digits only, bounded */
+			getmsgerr(buf, n, 1);
+			acquire();
+			return -1;
+		}
+		len = len*10 + (c - '0');
+	}
+	if(i == 0){				/* empty header */
+		getmsgerr(buf, n, 1);
+		acquire();
+		return -1;
+	}
+	r = -1;
+	if(len < 0 || len >= n || (r = nreadn(fd, buf, len)) != len){
+		getmsgerr(buf, n, r);
+		acquire();
+		return -1;
+	}
+	buf[len] = 0;
+	acquire();
+	return len;
+}
+
 void
 Keyring_getmsg(void *fp)
 {
@@ -2284,27 +2351,27 @@ Keyring_writeauthinfo(void *fp)
 
 	/* signer's public key */
 	n = pktostr(spk, buf, Maxbuf);
-	if(sendmsg(fd, buf, n) <= 0)
+	if(sendkfmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* certificate for my public key */
 	n = certtostr(c, buf, Maxbuf);
-	if(sendmsg(fd, buf, n) <= 0)
+	if(sendkfmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* my secret/public key */
 	n = sktostr(mysk, buf, Maxbuf);
-	if(sendmsg(fd, buf, n) <= 0)
+	if(sendkfmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* diffie hellman base */
 	n = bigtobase64(alpha, buf, Maxbuf);
-	if(sendmsg(fd, buf, n) <= 0)
+	if(sendkfmsg(fd, buf, n) <= 0)
 		goto out;
 
 	/* diffie hellman modulus */
 	n = bigtobase64(p, buf, Maxbuf);
-	if(sendmsg(fd, buf, n) <= 0)
+	if(sendkfmsg(fd, buf, n) <= 0)
 		goto out;
 
 	*f->ret = 0;
@@ -2355,7 +2422,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* signer's public key */
-	n = getmsg(fd, buf, Maxbuf);
+	n = getkfmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 
@@ -2364,7 +2431,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* certificate for my public key */
-	n = getmsg(fd, buf, Maxbuf);
+	n = getkfmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	ai->cert = (Keyring_Certificate*)strtocert(buf);
@@ -2372,7 +2439,7 @@ Keyring_readauthinfo(void *fp)
 		goto out;
 
 	/* my secret/public key */
-	n = getmsg(fd, buf, Maxbuf);
+	n = getkfmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	mysk = strtosk(buf);
@@ -2385,14 +2452,14 @@ Keyring_readauthinfo(void *fp)
 	ai->mypk = (Keyring_PK*)mypk;
 
 	/* diffie hellman base */
-	n = getmsg(fd, buf, Maxbuf);
+	n = getkfmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	b = strtomp(buf, nil, 64, nil);
 	ai->alpha = newIPint(b);
 
 	/* diffie hellman modulus */
-	n = getmsg(fd, buf, Maxbuf);
+	n = getkfmsg(fd, buf, Maxbuf);
 	if(n < 0)
 		goto out;
 	b = strtomp(buf, nil, 64, nil);


### PR DESCRIPTION
## Summary

A CNSA-strict (ML-DSA-87) listener cannot read its own signer keyfile — `readauthinfo` fails with `"input or format error"`, so keyring+CNSA mounts never come up (the server falls back to dry / can't listen). Root cause is a **keyring message-frame overflow**, exposed (not caused) by #315.

## Root cause

The keyring frame is a fixed 4-digit header — `sendmsg` does `snprint(num, "%4.4d\n", n); kwrite(fd, num, 5)` — capping a single framed message at **9999 bytes**. An ML-DSA-87 signer keyfile's secret-key message (sk+pk base64) is ~**10 KB**, so the length needs 5 digits and the trailing `\n` is truncated by the 5-byte write.

- Pre-#315, `getmsg` used `strtoul` over the 5-byte read and tolerated the 5-digit frame, so oversized keyfiles round-tripped by luck.
- #315 ("reject noncanonical message frames") correctly requires `num[4] == '\n'` and now rejects the truncated frame → `readauthinfo` returns `"input or format error"`. `createsignerkey` writes the keyfile fine; `listen` can't read it back.

ML-DSA-87 is simply the first key large enough to cross 9999; `Maxbuf` (48 KB) was already sufficient, only the frame width was not.

## Fix

Widen **only the on-disk keyfile framing**, leaving the STS wire frame strict:

- The wire handshake never carries a >9999 message for ML-DSA-87 (cert ~6.2 KB, signer pk ~3.5 KB, ML-KEM-1024 pubkey 1.5 KB), so `getmsg`/`sendmsg` are untouched and #315's pre-auth anti-DoS is preserved.
- New `getkfmsg`/`sendkfmsg`, scoped to `readauthinfo`/`writeauthinfo`, frame a keyfile (a trusted local file) with a canonical **variable-width** header `d+\n` bounded by `Maxbuf`.
- The variable reader still parses **legacy 4-digit keyfiles**, so existing Ed25519/RSA keyfiles keep working — no re-keying required.

## Verification

- ML-DSA-87 signer keyfile now round-trips: secret-key message framed as `10012\n` (newline intact), all 5 messages consume the file exactly.
- A CNSA-strict listener (`--anon-lan` off, `CNSAMODE=1`) reads its regenerated keyfile and serves on `:5640`.
- Builds clean under `-Werror` on Linux **arm64** and **amd64**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
