### PR TITLE
ci(security): align codeql-action pins to 4.36.3 (unbreak CodeQL, supersede #348)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # codeql-action/{init,analyze,upload-sarif} are one action; init and
+      # analyze MUST move together or CodeQL fails with a config-version
+      # mismatch. Bump every sub-path in a single PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
       with:
         languages: ${{ matrix.language }}
         # Security-focused queries plus quality checks
@@ -91,7 +91,7 @@ jobs:
         done
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
       with:
         category: "/language:${{ matrix.language }}"
 


### PR DESCRIPTION
## Problem

The `Security Analysis` / CodeQL check fails on Dependabot PR #348 with:

```
Loaded a configuration file for version '4.36.3', but running version '4.36.2'
CodeQL job status was configuration error.
```

`github/codeql-action/{init,analyze,upload-sarif}` are one action, and CodeQL requires **`init` and `analyze` to run the identical version** — `init` writes a DB config that `analyze` version-checks.

Dependabot has no `groups:` config, so it opens a separate PR per sub-path. #345 bumped `upload-sarif` 4.36.2 → 4.36.3 (merged); #348 bumps `init` alone. Merging `init` without `analyze` desyncs them and the config-version check fails. master stays green today only because `init` and `analyze` are *both* still 4.36.2.

## Fix

- Bump `init` and `analyze` in `security.yml` to `54f647b7` (4.36.3), matching the already-merged `upload-sarif`. All four `codeql-action` references now sit on one version.
- Add a Dependabot `group` so every `github/codeql-action*` sub-path bumps together in one PR — this can't split again.

Supersedes #348 (its lone `init` bump is included here, plus the `analyze` bump it was missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)