### PR TITLE
test(security): tolerate emu timeout status in host checks

### DIFF
--- a/tests/host/common.sh
+++ b/tests/host/common.sh
@@ -32,3 +32,10 @@ BINDIR="$ROOT/$EMUHOST/$OBJTYPE/bin"
 LIMBO="$BINDIR/limbo"
 
 export ROOT EMUHOST OBJTYPE EMU BINDIR LIMBO
+
+emu_timeout_ok() {
+    case "$1" in
+        0|124|137) return 0 ;;
+        *) return 1 ;;
+    esac
+}

--- a/tests/host/editor_capability_test.sh
+++ b/tests/host/editor_capability_test.sh
@@ -13,7 +13,7 @@ timeout 15 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 	'path=(/dis/veltro /dis/cmd /dis .); mkdir -p /tmp/veltro/editor/1; tools9p editor & sleep 2; echo open /appl/veltro/veltro.b > /tool/editor/run; sleep 2; echo HIDDEN; cat /tool/editor/run; echo open /lib/veltro/meta.txt > /tool/editor/run; sleep 2; echo VISIBLE; cat /tool/editor/run; cat /tmp/veltro/editor/ctl; echo 1 /lib/veltro/meta.txt 1 > /tmp/veltro/editor/index; echo save > /tool/editor/run; sleep 2; echo SAVE; cat /tool/editor/run; echo name /lib/veltro/new.txt > /tool/editor/run; sleep 2; echo NAME; cat /tool/editor/run' \
 	</dev/null >"$log" 2>&1
 rc=$?
-[[ $rc -eq 0 || $rc -eq 124 ]] || { cat "$log"; exit 1; }
+emu_timeout_ok "$rc" || { cat "$log"; exit 1; }
 
 grep -q 'path is outside the agent namespace: /appl/veltro/veltro.b' "$log" || { echo "FAIL: hidden path was accepted"; cat "$log"; exit 1; }
 grep -q 'open /lib/veltro/meta.txt' "$log" || { echo "FAIL: visible path was not forwarded"; cat "$log"; exit 1; }

--- a/tests/host/exec_confinement_test.sh
+++ b/tests/host/exec_confinement_test.sh
@@ -7,9 +7,12 @@ PROBE="$ROOT/dis/veltro/exec_confinement_probe.dis"
 log=$(mktemp)
 trap 'rm -f "$log" "$PROBE"' EXIT
 
-"$EMU" -r"$ROOT" /dis/sh.dis -c \
+timeout 30 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 	'limbo -I module -o dis/veltro/exec_confinement_probe.dis tests/exec_confinement_probe.b' \
-	</dev/null >"$log" 2>&1 || { cat "$log"; exit 1; }
+	</dev/null >"$log" 2>&1
+rc=$?
+emu_timeout_ok "$rc" || { cat "$log"; exit 1; }
+[[ -s "$PROBE" ]] || { cat "$log"; echo "ERROR: failed to build $PROBE"; exit 1; }
 
 timeout 15 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 	'path=(/dis/veltro /dis/cmd /dis .); tools9p exec & sleep 2; echo /dis/veltro/exec_confinement_probe.dis > /tool/exec/run; sleep 3; cat /tool/exec/run; echo DONE' \
@@ -17,7 +20,7 @@ timeout 15 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 rc=$?
 output=$(cat "$log")
 
-[[ $rc -eq 0 || $rc -eq 124 ]] || { echo "$output"; exit 1; }
+emu_timeout_ok "$rc" || { echo "$output"; exit 1; }
 grep -q DONE <<<"$output" || { echo "FAIL: exec probe did not complete"; echo "$output"; exit 1; }
 if grep -q 'PASS: exec process and device capabilities are confined' <<<"$output"; then
 	echo "PASS: exec uses only its private wait FD and process namespace"

--- a/tests/host/network_capability_test.sh
+++ b/tests/host/network_capability_test.sh
@@ -13,7 +13,7 @@ timeout 15 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 rc=$?
 output=$(cat "$log")
 
-[[ $rc -eq 0 || $rc -eq 124 ]] || { echo "$output"; exit 1; }
+emu_timeout_ok "$rc" || { echo "$output"; exit 1; }
 grep -q DONE <<<"$output" || { echo "FAIL: tools9p test did not complete"; echo "$output"; exit 1; }
 
 if grep -Eq 'cannot open.*/net|/net.*does not exist' <<<"$output"; then

--- a/tests/host/nsaudit_path_semantics_test.sh
+++ b/tests/host/nsaudit_path_semantics_test.sh
@@ -16,7 +16,7 @@ SH="/dis/sh.dis"
 run_nsaudit() {
 	timeout 30 "$EMU" -r"$ROOT" "$SH" -c \
 		"path=(/dis/veltro /dis/cmd /dis .); nsaudit -m $*" \
-		</dev/null 2>&1
+		</dev/null 2>&1 || true
 }
 
 out="$(run_nsaudit /tests/nsaudit-rules/durable-host-mutation /tmp/veltroevil/file)"

--- a/tests/host/write_capability_test.sh
+++ b/tests/host/write_capability_test.sh
@@ -10,10 +10,12 @@ trap 'rm -f "$CANARY" "$PROBE" "$ROOT/tmp/veltro/scratch/77/private"' EXIT
 
 [[ -x "$EMU" ]] || { echo "ERROR: emu not found at $EMU" >&2; exit 1; }
 
-"$EMU" -r"$ROOT" /dis/sh.dis -c \
+timeout 30 "$EMU" -r"$ROOT" /dis/sh.dis -c \
 	'limbo -I module -o dis/veltro/exec_ro_write_probe.dis tests/exec_ro_write_probe.b' \
-	</dev/null >/tmp/exec-ro-write-probe-build.log 2>&1 ||
-	{ cat /tmp/exec-ro-write-probe-build.log; exit 1; }
+	</dev/null >/tmp/exec-ro-write-probe-build.log 2>&1
+rc=$?
+emu_timeout_ok "$rc" || { cat /tmp/exec-ro-write-probe-build.log; exit 1; }
+[[ -s "$PROBE" ]] || { cat /tmp/exec-ro-write-probe-build.log; echo "ERROR: failed to build $PROBE"; exit 1; }
 
 runemu() {
 	local command="$1"
@@ -25,7 +27,7 @@ runemu() {
 	local rc=$?
 	OUTPUT=$(cat "$log")
 	rm -f "$log"
-	[[ $rc -eq 0 || $rc -eq 124 ]]
+	emu_timeout_ok "$rc"
 }
 
 echo original >"$CANARY"


### PR DESCRIPTION
## Summary
- Add a shared host-test helper for accepted emulator timeout statuses.
- Wrap compile-only emulator invocations in timeout and assert that the expected probe bytecode was produced.
- Let nsaudit path semantics assertions consume completed output even when the emulator is later killed by timeout.

## Hephaestus first-pass verification
Ran from clean side worktree `/tmp/infernode-security-pass` at `origin/master` (`aad8bfa83`) after `./build-linux-arm64.sh headless`:
- `./tests/host/write_capability_test.sh`
- `./tests/host/network_capability_test.sh`
- `./tests/host/tools9p_integration_test.sh`
- `./tests/host/nsaudit_profiles_test.sh`
- `./tests/host/nsaudit_rules_test.sh`
- `./tests/host/nsaudit_path_semantics_test.sh`
- `./tests/host/exec_confinement_test.sh`
- `./tests/host/editor_capability_test.sh`
- `./tests/host/stale_dis_test.sh`

All passed.