### PR TITLE
test(security): add adversarial tools9p namespace probes

### DIFF
--- a/tests/host/tools9p_integration_test.sh
+++ b/tests/host/tools9p_integration_test.sh
@@ -58,7 +58,7 @@ emu_c() {
         </dev/null >"$log" 2>&1
     local rc=$?
     OUTPUT=$(cat "$log")
-    if [[ "$rc" -eq 0 ]] || [[ "$rc" -eq 124 ]]; then
+    if emu_timeout_ok "$rc"; then
         info "[$name] ok: $OUTPUT"
         return 0
     else
@@ -342,6 +342,45 @@ if emu_c "provision_readonly_baseline" 14 \
     fi
 else
     fail "read-only child baseline test failed"
+fi
+
+echo ""
+echo "── adversarial namespace inputs ──"
+
+if emu_c "tool_ctl_hidden_live" 15 \
+    "tools9p read task & sleep 3; echo /tool/ctl > /tool/read/run; sleep 2; echo TOOLCTL; cat /tool/read/run; echo /mnt/toolctl/ctl > /tool/read/run; sleep 2; echo MNTCTL; cat /tool/read/run"; then
+    ctl_denials=$(echo "$OUTPUT" | grep -Ec 'cannot open|does not exist|file does not exist' || true)
+    if [[ "$ctl_denials" -ge 2 ]]; then
+        pass "restricted tool invocation cannot read /tool/ctl or trusted /mnt/toolctl"
+    else
+        fail "restricted tool invocation may see a tool control path (output: $OUTPUT)"
+    fi
+else
+    fail "live tool-control hiding probe failed"
+fi
+
+if emu_c "provision_invalid_paths" 14 \
+    "tools9p -p /tmp:rw read task & sleep 3; echo '14 paths=/:rw,/tmp/../lib:rw,/tmp//evil:rw,/tmp/./evil:rw,relative/path:rw' > /tool/provision; sleep 5; cat /mnt/toolctl.14/paths"; then
+    if echo "$OUTPUT" | grep -qE '^/|relative/path'; then
+        fail "child provisioning accepted traversal or non-absolute path (output: $OUTPUT)"
+    else
+        pass "child provisioning rejects traversal, empty-component, root, and relative paths"
+    fi
+else
+    fail "invalid child path provisioning probe failed"
+fi
+
+if emu_c "provision_sibling_prefix" 14 \
+    "tools9p -p /tmp/veltro:rw read task & sleep 3; echo '15 paths=/tmp/veltroevil:rw,/tmp/veltro/ok:rw' > /tool/provision; sleep 5; cat /mnt/toolctl.15/paths"; then
+    if echo "$OUTPUT" | grep -q '^/tmp/veltroevil'; then
+        fail "child provisioning treated sibling prefix as covered by parent grant"
+    elif echo "$OUTPUT" | grep -q '^/tmp/veltro/ok rw'; then
+        pass "child provisioning is component-aware for sibling prefixes"
+    else
+        fail "child provisioning did not preserve covered descendant path (output: $OUTPUT)"
+    fi
+else
+    fail "sibling-prefix child path provisioning probe failed"
 fi
 
 # ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add live tools9p probes that verify restricted tool invocations cannot read `/tool/ctl` or the trusted `/mnt/toolctl` alias.
- Add adversarial child provisioning checks for root, traversal, empty-component, relative, and sibling-prefix paths.
- Reuse the shared emulator timeout-status helper in the tools9p integration harness.

## Verification
Local:
- `./tests/host/tools9p_integration_test.sh` — 21 passed, 0 failed, 0 skipped

Hephaestus:
- Copied the patched test into clean side worktree `/tmp/infernode-security-pass`
- `./tests/host/tools9p_integration_test.sh` — 21 passed, 0 failed, 0 skipped

## Security result
No namespace bypass found in this second pass; this PR preserves the hostile cases as regression coverage.