### PR TITLE
test(security): cover fd namespace hiding

### DIFF
--- a/tests/exec_confinement_probe.b
+++ b/tests/exec_confinement_probe.b
@@ -35,5 +35,11 @@ init(nil: ref Draw->Context, nil: list of string)
 		sys->print("FAIL: restricted /prog entry count %d\n", seen);
 		return;
 	}
+
+	fd = sys->open("/fd", Sys->OREAD);
+	if(fd != nil) {
+		sys->print("FAIL: /fd is visible in restricted exec namespace\n");
+		return;
+	}
 	sys->print("PASS: exec process and device capabilities are confined\n");
 }

--- a/tests/host/tools9p_integration_test.sh
+++ b/tests/host/tools9p_integration_test.sh
@@ -359,6 +359,17 @@ else
     fail "live tool-control hiding probe failed"
 fi
 
+if emu_c "fd_hidden_live" 15 \
+    "tools9p read & sleep 3; echo /fd > /tool/read/run; sleep 2; cat /tool/read/run"; then
+    if echo "$OUTPUT" | grep -Eq 'cannot open|does not exist|file does not exist'; then
+        pass "restricted tool invocation cannot enumerate /fd"
+    else
+        fail "restricted tool invocation may see /fd (output: $OUTPUT)"
+    fi
+else
+    fail "live /fd hiding probe failed"
+fi
+
 if emu_c "provision_invalid_paths" 14 \
     "tools9p -p /tmp:rw read task & sleep 3; echo '14 paths=/:rw,/tmp/../lib:rw,/tmp//evil:rw,/tmp/./evil:rw,relative/path:rw' > /tool/provision; sleep 5; cat /mnt/toolctl.14/paths"; then
     if echo "$OUTPUT" | grep -qE '^/|relative/path'; then


### PR DESCRIPTION
## Summary
- add /fd visibility assertion to the exec confinement probe
- add live tools9p integration coverage that read invocations cannot enumerate /fd

## Tests
- tests/host/exec_confinement_test.sh
- tests/host/tools9p_integration_test.sh
- tests/host/network_capability_test.sh
- tests/host/write_capability_test.sh
- tests/host/namespace_manifest_invariants_test.sh