### PR TITLE
ci(security): run namespace audit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,17 @@ jobs:
           exit 1
         fi
 
+    - name: Run namespace audit checks
+      run: |
+        echo "Running nsaudit security checks..."
+        chmod +x tests/host/nsaudit_rules_test.sh
+        chmod +x tests/host/nsaudit_profiles_test.sh
+        chmod +x tests/host/nsaudit_path_semantics_test.sh
+
+        ROOT=. bash tests/host/nsaudit_rules_test.sh
+        ROOT=. bash tests/host/nsaudit_profiles_test.sh
+        ROOT=. bash tests/host/nsaudit_path_semantics_test.sh
+
     - name: Run test suite
       run: |
         # Create /tmp inside Inferno root for tmp_writable test


### PR DESCRIPTION
## Summary
- run nsaudit rule, profile, and path-semantics host checks in Linux AMD64 CI
- make namespace audit checks gating after build/test compilation

## Security impact
The nsaudit tool and baseline profiles now run automatically in PR CI instead of relying on manual local execution.

## Validation
- tests/host/nsaudit_rules_test.sh
- tests/host/nsaudit_profiles_test.sh
- tests/host/nsaudit_path_semantics_test.sh