### PR TITLE
ci(release): build libtk for the macOS jobs (Tk reintegration)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -985,6 +985,13 @@ jobs:
           echo "Building $dir..."
           (cd $dir && "$ROOT/MacOSX/arm64/bin/mk" install) || true
         done
+        # libtk (Tk reintegration): the emu now links libtk.a, so build it
+        # after the draw libraries it depends on. The loop above is best-effort
+        # (|| true); libtk must succeed or the emu link fails with
+        # "no such file or directory: libtk.a".
+        echo "Building libtk..."
+        (cd libtk && "$ROOT/MacOSX/arm64/bin/mk" install) || { echo "libtk build failed"; exit 1; }
+        test -f MacOSX/arm64/lib/libtk.a || { echo "libtk.a not produced"; exit 1; }
 
     - name: Build SDL3 GUI emulator
       run: |
@@ -1242,6 +1249,13 @@ jobs:
           echo "Building $dir..."
           (cd $dir && "$ROOT/MacOSX/arm64/bin/mk" install) || true
         done
+        # libtk (Tk reintegration): the emu now links libtk.a, so build it
+        # after the draw libraries it depends on. The loop above is best-effort
+        # (|| true); libtk must succeed or the emu link fails with
+        # "no such file or directory: libtk.a".
+        echo "Building libtk..."
+        (cd libtk && "$ROOT/MacOSX/arm64/bin/mk" install) || { echo "libtk build failed"; exit 1; }
+        test -f MacOSX/arm64/lib/libtk.a || { echo "libtk.a not produced"; exit 1; }
 
     - name: Build headless emulator
       run: |


### PR DESCRIPTION
## Why

The Tk reintegration landed on master, so the emu now links `libtk.a`. The macOS release jobs build libraries from a hand-maintained list that never included `libtk`, so **both the GUI and headless macOS builds failed** at the emu link step in the v0.3.5 release run:

```
clang: error: no such file or directory: '.../MacOSX/arm64/lib/libtk.a'
```

CI passed because `ci.yml` builds via `build-macos-sdl3.sh` (full lib set); `release.yml` hand-rolls its list and had drifted. **Linux** already builds libtk (`build-linux-*.sh`) and **Windows** compiles `tk.c` into its interp build, so this is macOS-only.

## Change

Build `libtk` after the draw libraries it depends on, in **both** the `macos-arm64` and `macos-arm64-headless` jobs, with a hard failure if `libtk.a` isn't produced (the surrounding loop is best-effort `|| true`).

CI-only; no runtime change. Unblocks the v0.3.5 release build (tag will be re-pointed to the merge commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)