### PR TITLE
test(security): cover exec support-tree containment

### DIFF
--- a/tests/host/write_capability_test.sh
+++ b/tests/host/write_capability_test.sh
@@ -6,7 +6,12 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$(dirname "$0")/common.sh"
 CANARY="$ROOT/lib/veltro/write-capability-canary"
 PROBE="$ROOT/dis/veltro/exec_ro_write_probe.dis"
-trap 'rm -f "$CANARY" "$PROBE" "$ROOT/tmp/veltro/scratch/77/private"' EXIT
+SUPPORT_CANARIES=(
+	"$ROOT/lib/veltro/exec-support-canary"
+	"$ROOT/lib/certs/exec-support-canary"
+	"$ROOT/dis/veltro/exec-support-canary"
+)
+trap 'rm -f "$CANARY" "$PROBE" "$ROOT/tmp/veltro/scratch/77/private" "${SUPPORT_CANARIES[@]}"' EXIT
 
 [[ -x "$EMU" ]] || { echo "ERROR: emu not found at $EMU" >&2; exit 1; }
 
@@ -47,6 +52,15 @@ echo original >"$CANARY"
 runemu "tools9p -p /lib/veltro:ro exec & sleep 2; echo '/dis/veltro/exec_ro_write_probe.dis /lib/veltro/write-capability-canary' > /tool/exec/run; sleep 3; cat /tool/exec/run; echo HOST; cat /lib/veltro/write-capability-canary"
 grep -q '^original$' <<<"$OUTPUT" || { echo "FAIL: exec mutated an ro path grant"; echo "$OUTPUT"; exit 1; }
 echo "PASS: exec cannot write through an ro path grant"
+
+for target in /lib/veltro/exec-support-canary /lib/certs/exec-support-canary /dis/veltro/exec-support-canary; do
+	host="$ROOT${target}"
+	rm -f "$host"
+	runemu "tools9p exec & sleep 2; echo '/dis/veltro/exec_ro_write_probe.dis $target' > /tool/exec/run; sleep 3; cat /tool/exec/run; echo DONE"
+	grep -q '^DONE$' <<<"$OUTPUT" || { echo "FAIL: exec support-tree probe did not complete for $target"; echo "$OUTPUT"; exit 1; }
+	[[ ! -e "$host" ]] || { echo "FAIL: exec persisted write to support tree $target"; echo "$OUTPUT"; exit 1; }
+done
+echo "PASS: exec support-tree writes are ephemeral or denied"
 
 runemu "tools9p -a 77 write & sleep 2; echo /tmp/veltro/shared-root denied > /tool/write/run; sleep 2; cat /tool/write/run; echo /tmp/veltro/scratch/private allowed > /tool/write/run; sleep 2; cat /tool/write/run; echo SCRATCH; cat /tmp/veltro/scratch/77/private"
 grep -q "not covered by an rw path grant" <<<"$OUTPUT" || { echo "FAIL: shared workspace root write was not denied"; exit 1; }


### PR DESCRIPTION
## Summary
- extend the write capability host test to probe exec writes against baseline support trees
- assert exec cannot durably mutate /lib/veltro, /lib/certs, or /dis/veltro from its restricted namespace

## Testing
- tests/host/write_capability_test.sh
- tests/host/exec_confinement_test.sh
- tests/host/network_capability_test.sh
- tests/host/tools9p_integration_test.sh
- git diff --check