### PR TITLE
test(security): enforce llmsrv session capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,11 @@ jobs:
         ROOT=. bash tests/host/nsaudit_profiles_test.sh
         ROOT=. bash tests/host/nsaudit_path_semantics_test.sh
 
+    - name: Run llmsrv session capability checks
+      run: |
+        chmod +x tests/host/llmsrv_session_capability_test.sh
+        ROOT=. tests/host/llmsrv_session_capability_test.sh
+
     - name: Run test suite
       run: |
         # Create /tmp inside Inferno root for tmp_writable test

--- a/tests/host/llmsrv_session_capability_test.sh
+++ b/tests/host/llmsrv_session_capability_test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Exercise llmsrv session capability isolation without an LLM backend.
+set -eu
+
+. "$(dirname "$0")/common.sh"
+
+if [ ! -x "$EMU" ]; then
+	echo "SKIP: emulator not found at $EMU"
+	exit 77
+fi
+
+log="${TMPDIR:-/tmp}/llmsrv-session-capability.$$.log"
+pid=
+cleanup() {
+	if [ -n "$pid" ]; then
+		kill -9 "$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+	fi
+	rm -f "$log"
+}
+trap cleanup EXIT HUP INT TERM
+
+"$EMU" -c1 -r"$ROOT" /dis/sh.dis \
+	/tests/inferno/llmsrv_model_test.sh >"$log" 2>&1 &
+pid=$!
+
+i=0
+while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 20 ]; do
+	if grep -q '^PASS$' "$log" 2>/dev/null; then
+		cat "$log"
+		exit 0
+	fi
+	if grep -q '^sh: fail:' "$log" 2>/dev/null; then
+		break
+	fi
+	sleep 1
+	i=$((i + 1))
+done
+
+cat "$log"
+echo "FAIL: llmsrv session capability test did not pass" >&2
+exit 1

--- a/tests/inferno/llmsrv_model_test.sh
+++ b/tests/inferno/llmsrv_model_test.sh
@@ -17,6 +17,27 @@ if {~ $#id 0} {
 	raise 'skip:llmsrv did not start (/mnt/llm/new unreadable)'
 }
 
+# Session names are bearer capabilities, not enumerable numeric identifiers.
+# Keep this check backend-free so the isolation boundary can run in CI.
+badchars=`{echo -n $id | sed 's/[0-9a-f]//g'}
+nchars=`{echo -n $id | wc -c}
+if {! ~ $#badchars 0} {
+	raise 'fail:session token contains non-hex characters: '^$id
+}
+if {! ~ $nchars 32} {
+	raise 'fail:session token is not 128 bits: '^$id
+}
+root=`{ls /mnt/llm}
+if {! ~ $#root 2} {
+	raise 'fail:session token disclosed by root listing'
+}
+if {test -e /mnt/llm/0/model} {
+	raise 'fail:legacy numeric session path is walkable'
+}
+if {test -e /mnt/llm/00000000000000000000000000000000/model} {
+	raise 'fail:guessed session token is walkable'
+}
+
 # Server default model.
 m=`{cat /mnt/llm/$id/model}
 if {! ~ $"m claude-sonnet-4-5-20250929} {
@@ -42,6 +63,12 @@ echo haiku > /mnt/llm/$id/model
 m=`{cat /mnt/llm/$id/model}
 if {! ~ $"m claude-haiku-4-5-20251001} {
 	raise 'fail:haiku alias not resolved on write: '^$"m
+}
+
+# Revocation removes the capability immediately.
+echo close > /mnt/llm/$id/ctl
+if {test -e /mnt/llm/$id/model} {
+	raise 'fail:closed session token remains walkable'
 }
 
 echo PASS

--- a/tests/tooluse_test.b
+++ b/tests/tooluse_test.b
@@ -75,7 +75,7 @@ hasllm(): int
 
 # ---- Test: session creation ----------------------------------------
 
-# Test that createsession() returns a numeric session ID via /mnt/llm/new.
+# Test that createsession() returns a 128-bit capability via /mnt/llm/new.
 testSessionCreate(t: ref T)
 {
 	if(!hasllm()) {
@@ -86,17 +86,19 @@ testSessionCreate(t: ref T)
 	id := agentlib->createsession();
 	t.assertnotnil(id, "session id is non-empty");
 
-	# Session ID from llmsrv is a decimal integer
+	# Session names are 32 lowercase hexadecimal characters (INFR-321).
 	ok := 1;
+	if(len id != 32)
+		ok = 0;
 	for(i := 0; i < len id; i++) {
 		c := id[i];
-		if(c < '0' || c > '9') {
+		if(!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
 			ok = 0;
 			break;
 		}
 	}
-	t.assert(ok, "session id is numeric");
-	t.log(sys->sprint("session id: %s", id));
+	t.assert(ok, "session name is a 128-bit capability token");
+	t.log(sys->sprint("session token: %s", id));
 }
 
 # ---- Test: tool registration ---------------------------------------


### PR DESCRIPTION
## Summary
- assert llmsrv issues 128-bit lowercase-hex session capability tokens
- assert session tokens are not root-enumerable and numeric/guessed paths are rejected
- assert `ctl close` immediately revokes a session capability
- update the stale tool-use assertion that still expected numeric session IDs
- run the backend-free capability test in Linux CI

## Security model
Remote authenticated llmsrv mounts remain fully supported. A session token is an intentionally delegable bearer capability: an independent authenticated mount with the exact token can access the session, while mounts without it cannot enumerate or derive the token.

## Empirical verification
- live authenticated client: root exposed only `models` and `new`; `/new` returned a 32-character token
- independent authenticated mount: exact token read succeeded; prefix, suffix, uppercase, numeric, and all-zero guesses failed
- live unauthenticated mount failed before attach
- cross-mount `ctl close` revoked the token immediately
- local backend-free regression: PASS
- updated Limbo test compiled successfully
- `tools/verify-sh-exec.sh`: PASS
- `git diff --check`: PASS