### PR TITLE
fix(security): deny raw app IPC path grants

### DIFF
--- a/appl/veltro/nsconstruct.b
+++ b/appl/veltro/nsconstruct.b
@@ -890,6 +890,8 @@ privilegedcontrolpath(path: string): int
 		return 1;
 	if(tmpveltrointernalpath(path))
 		return 1;
+	if(appipccontrolpath(path))
+		return 1;
 	if(uiagentcontrolpath(path))
 		return 1;
 	if(fixedservicecontrolpath(path))
@@ -919,6 +921,17 @@ tmpveltrointernalpath(path: string): int
 	return path == "/tmp/veltro/.ns" || prefix(path, "/tmp/veltro/.ns/") ||
 		path == "/tmp/veltro/cow" || prefix(path, "/tmp/veltro/cow/") ||
 		path == "/tmp/veltro/tasks" || prefix(path, "/tmp/veltro/tasks/");
+}
+
+appipccontrolpath(path: string): int
+{
+	# App IPC roots are controlled through their fixed-function tools. A raw
+	# path grant would let generic filesystem/shell tools drive the app protocol.
+	return path == "/tmp/veltro/browser" || prefix(path, "/tmp/veltro/browser/") ||
+		path == "/tmp/veltro/editor" || prefix(path, "/tmp/veltro/editor/") ||
+		path == "/tmp/veltro/shell" || prefix(path, "/tmp/veltro/shell/") ||
+		path == "/tmp/veltro/fractal" || prefix(path, "/tmp/veltro/fractal/") ||
+		path == "/tmp/veltro/man" || prefix(path, "/tmp/veltro/man/");
 }
 
 uiagentcontrolpath(path: string): int

--- a/tests/veltro_security_test.b
+++ b/tests/veltro_security_test.b
@@ -1536,6 +1536,11 @@ privilegedGrantPathsWorker(result: chan of string)
 		"/tmp/veltro/.ns",
 		"/tmp/veltro/cow",
 		"/tmp/veltro/tasks",
+		"/tmp/veltro/browser",
+		"/tmp/veltro/editor",
+		"/tmp/veltro/shell",
+		"/tmp/veltro/fractal",
+		"/tmp/veltro/man",
 	};
 
 	for(i := 0; i < len bad; i++) {


### PR DESCRIPTION
## Summary
- align nsconstruct runtime path validation with tools9p/nsaudit by rejecting raw app IPC roots under /tmp/veltro/{browser,editor,shell,fractal,man}
- extend the privileged grant regression set so these paths cannot be delegated as generic filesystem grants

## Security impact
App IPC roots are fixed-function tool authority, not generic path authority. Without this runtime check, a caller that reached nsconstruct directly could grant generic read/write/shell tooling access to app control protocols that nsaudit and tools9p already classify as privileged.

## Tests
- ./build-macos-headless.sh
- ./emu/MacOSX/o.emu -c1 -r/Users/pdfinn/github.com/infernode-os/infernode /dis/tests/veltro_security_test.dis
- ./tests/host/tools9p_integration_test.sh
- ./tests/host/nsaudit_rules_test.sh
- ./tests/host/nsaudit_profiles_test.sh
- git diff --check