### PR TITLE
test(security): cover app IPC derived capability scoping

### DIFF
--- a/tests/host/tools9p_integration_test.sh
+++ b/tests/host/tools9p_integration_test.sh
@@ -512,6 +512,21 @@ else
     fail "fixed-service derived capability probe failed"
 fi
 
+if emu_c "app_ipc_tool_derived" 15 \
+    "mkdir -p /tmp/veltro/shell /tmp/veltro/fractal /tmp/veltro/man; echo shell-transcript > /tmp/veltro/shell/body; echo shell-input > /tmp/veltro/shell/input; echo 'type mandelbrot' > /tmp/veltro/fractal/state; echo 'fractal view' > /tmp/veltro/fractal/view; echo 'man state' > /tmp/veltro/man/state; echo 'manual page view' > /tmp/veltro/man/view; tools9p shell fractal man read & sleep 2; echo read > /tool/shell/ctl; cat /tool/shell/ctl; echo state > /tool/fractal/ctl; cat /tool/fractal/ctl; echo view > /tool/man/ctl; cat /tool/man/ctl; echo /tmp/veltro/shell/body > /tool/read/ctl; echo GENERIC; cat /tool/read/ctl"; then
+    if ! echo "$OUTPUT" | grep -q "shell-transcript" ||
+       ! echo "$OUTPUT" | grep -q "type mandelbrot" ||
+       ! echo "$OUTPUT" | grep -q "manual page view"; then
+        fail "fixed app tools lost their derived IPC capabilities (output: $OUTPUT)"
+    elif ! echo "$OUTPUT" | grep -q "error: cannot open /tmp/veltro/shell/body"; then
+        fail "generic read inherited an app IPC derived capability (output: $OUTPUT)"
+    else
+        pass "fixed app tools receive IPC paths while generic read remains isolated"
+    fi
+else
+    fail "app IPC derived capability probe failed"
+fi
+
 if emu_c "startup_direct_send_path_rejected" 12 \
     "mkdir /mnt >[2] /dev/null; mkdir /mnt/mail >[2] /dev/null; mkdir /mnt/mail/accounts >[2] /dev/null; mkdir /mnt/mail/accounts/alice >[2] /dev/null; touch /mnt/mail/accounts/alice/compose; tools9p -p /mnt/mail/accounts/alice/compose:rw read; cat /tool/paths >[2] /dev/null"; then
     if echo "$OUTPUT" | grep -q "privileged -p path not grantable" && ! echo "$OUTPUT" | grep -q "^/mnt/mail/accounts/alice/compose"; then


### PR DESCRIPTION
## Summary
- add a live tools9p regression for app IPC derived capabilities
- verify shell/fractal/man fixed tools can reach their own /tmp/veltro IPC trees
- verify generic read in the same tools9p server cannot reuse those derived IPC paths

## Security impact
This locks down the namespace capability invariant from the latest app IPC hardening: app IPC roots are fixed-function tool authority, not generic path authority. The test complements the raw -p/bindpath rejection checks by covering the positive derived-tool path and the negative cross-tool leakage path.

## Tests
- ./tests/host/tools9p_integration_test.sh
- git diff --check