### PR TITLE
test(security): cover control descendant delegation

### DIFF
--- a/tests/host/tools9p_integration_test.sh
+++ b/tests/host/tools9p_integration_test.sh
@@ -318,6 +318,17 @@ else
     fail "message ctl delegation-denial test failed"
 fi
 
+if emu_c "provision_control_descendants_denied" 14 \
+    "mkdir /mnt >[2] /dev/null; mkdir /mnt/msg >[2] /dev/null; mkdir /mnt/msg/ctl >[2] /dev/null; touch /mnt/msg/ctl/session; mkdir /n >[2] /dev/null; mkdir /n/wallet >[2] /dev/null; mkdir /n/wallet/new >[2] /dev/null; touch /n/wallet/new/session; tools9p -p /mnt/msg:rw -p /n/wallet:rw read task & sleep 3; echo '21 paths=/mnt/msg/ctl/session:rw,/n/wallet/new/session:rw' > /tool/provision; sleep 5; cat /mnt/toolctl.21/paths"; then
+    if echo "$OUTPUT" | grep -q "^/mnt/msg/ctl/session" || echo "$OUTPUT" | grep -q "^/n/wallet/new/session"; then
+        fail "broad parent grants must not mint trusted control descendants"
+    else
+        pass "child cannot derive trusted control descendants from broad parents"
+    fi
+else
+    fail "control descendant delegation-denial test failed"
+fi
+
 if emu_c "provision_wallet_controls_denied" 14 \
     "mkdir /n >[2] /dev/null; mkdir /n/wallet >[2] /dev/null; touch /n/wallet/ctl; touch /n/wallet/pending; touch /n/wallet/new; tools9p -p /n/wallet:rw read task & sleep 3; echo '17 paths=/n/wallet/ctl:rw,/n/wallet/pending:rw,/n/wallet/new:rw' > /tool/provision; sleep 5; cat /mnt/toolctl.17/paths"; then
     if echo "$OUTPUT" | grep -q "^/n/wallet/\\(ctl\\|pending\\|new\\)"; then
@@ -450,10 +461,10 @@ else
 fi
 
 if emu_c "bindpath_privileged_rejected" 12 \
-    "mkdir -p /mnt/ui/activity/0/presentation /mnt/msg; touch /mnt/msg/ctl; mkdir /n >[2] /dev/null; mkdir /n/wallet >[2] /dev/null; mkdir /n/wallet/alice >[2] /dev/null; touch /n/wallet/alice/ctl; mkdir -p /tmp/veltro/ftree /tmp/veltro/.ns /tmp/veltro/cow /tmp/veltro/tasks /tmp/veltro/browser /tmp/veltro/editor /tmp/veltro/shell /tmp/veltro/fractal /tmp/veltro/man; touch /tmp/veltro/ftree/ctl; tools9p read & sleep 2; echo 'bindpath /tmp' > /mnt/toolctl/ctl; echo 'bindpath /mnt/ui:rw' > /mnt/toolctl/ctl; echo 'bindpath /mnt/ui/activity/0/presentation:rw' > /mnt/toolctl/ctl; echo 'bindpath /mnt/msg/ctl' > /mnt/toolctl/ctl; echo 'bindpath /n/wallet/alice/ctl' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/ftree:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/.ns:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/cow:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/tasks:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/browser:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/editor:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/shell:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/fractal:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/man:rw' > /mnt/toolctl/ctl; echo AFTER; cat /tool/paths"; then
+    "mkdir -p /mnt/ui/activity/0/presentation /mnt/msg/ctl /n/wallet/alice/ctl /n/wallet/new /tmp/veltro/ftree /tmp/veltro/.ns /tmp/veltro/cow /tmp/veltro/tasks /tmp/veltro/browser /tmp/veltro/editor /tmp/veltro/shell /tmp/veltro/fractal /tmp/veltro/man; touch /mnt/msg/ctl/session; touch /n/wallet/alice/ctl/session; touch /n/wallet/new/session; touch /tmp/veltro/ftree/ctl; tools9p read & sleep 2; echo 'bindpath /tmp' > /mnt/toolctl/ctl; echo 'bindpath /mnt/ui:rw' > /mnt/toolctl/ctl; echo 'bindpath /mnt/ui/activity/0/presentation:rw' > /mnt/toolctl/ctl; echo 'bindpath /mnt/msg/ctl' > /mnt/toolctl/ctl; echo 'bindpath /mnt/msg/ctl/session' > /mnt/toolctl/ctl; echo 'bindpath /n/wallet/alice/ctl' > /mnt/toolctl/ctl; echo 'bindpath /n/wallet/alice/ctl/session' > /mnt/toolctl/ctl; echo 'bindpath /n/wallet/new/session' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/ftree:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/.ns:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/cow:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/tasks:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/browser:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/editor:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/shell:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/fractal:rw' > /mnt/toolctl/ctl; echo 'bindpath /tmp/veltro/man:rw' > /mnt/toolctl/ctl; echo AFTER; cat /tool/paths"; then
     if ! echo "$OUTPUT" | grep -q "^/tmp rw"; then
         fail "privileged bindpath probe did not establish a valid baseline (output: $OUTPUT)"
-    elif echo "$OUTPUT" | grep -q "^/mnt/ui" || echo "$OUTPUT" | grep -q "^/mnt/msg/ctl" || echo "$OUTPUT" | grep -q "^/n/wallet/alice/ctl" || echo "$OUTPUT" | grep -q "^/tmp/veltro/ftree" || echo "$OUTPUT" | grep -q "^/tmp/veltro/.ns" || echo "$OUTPUT" | grep -q "^/tmp/veltro/cow" || echo "$OUTPUT" | grep -q "^/tmp/veltro/tasks" || echo "$OUTPUT" | grep -q "^/tmp/veltro/browser" || echo "$OUTPUT" | grep -q "^/tmp/veltro/editor" || echo "$OUTPUT" | grep -q "^/tmp/veltro/shell" || echo "$OUTPUT" | grep -q "^/tmp/veltro/fractal" || echo "$OUTPUT" | grep -q "^/tmp/veltro/man"; then
+    elif echo "$OUTPUT" | grep -q "^/mnt/ui" || echo "$OUTPUT" | grep -q "^/mnt/msg/ctl" || echo "$OUTPUT" | grep -q "^/n/wallet/alice/ctl" || echo "$OUTPUT" | grep -q "^/n/wallet/new/session" || echo "$OUTPUT" | grep -q "^/tmp/veltro/ftree" || echo "$OUTPUT" | grep -q "^/tmp/veltro/.ns" || echo "$OUTPUT" | grep -q "^/tmp/veltro/cow" || echo "$OUTPUT" | grep -q "^/tmp/veltro/tasks" || echo "$OUTPUT" | grep -q "^/tmp/veltro/browser" || echo "$OUTPUT" | grep -q "^/tmp/veltro/editor" || echo "$OUTPUT" | grep -q "^/tmp/veltro/shell" || echo "$OUTPUT" | grep -q "^/tmp/veltro/fractal" || echo "$OUTPUT" | grep -q "^/tmp/veltro/man"; then
         fail "bindpath accepted privileged control path (output: $OUTPUT)"
     else
         pass "bindpath rejects privileged control paths"


### PR DESCRIPTION
## Summary
- add a child provisioning regression for trusted control descendants under broad parent grants
- expand the privileged bindpath probe to include descendant controls such as /mnt/msg/ctl/session and /n/wallet/new/session
- no runtime behavior changes; this locks in the policy from #426 at the tools9p delegation surface

## Tests
- bash tests/host/tools9p_integration_test.sh
- bash tests/host/namespace_path_policy_test.sh
- ./emu/MacOSX/o.emu -c1 -r$PWD /dis/tests/veltro_security_test.dis