### PR TITLE
test(security): catch manifest path descendants

### DIFF
--- a/tests/host/namespace_manifest_invariants_test.sh
+++ b/tests/host/namespace_manifest_invariants_test.sh
@@ -61,12 +61,20 @@ assert_absent_paths() {
 		"/mnt/llm"
 	)
 	local found=""
-	local p
-	for p in "${bad[@]}"; do
-		if grep -q "^path=${p}\\([ 	]\\|$\\)" <<<"$output"; then
-			found="$found $p"
-		fi
-	done
+	local line entry p
+	while IFS= read -r line; do
+		case "$line" in
+		path=*)
+			entry="${line#path=}"
+			entry="${entry%%[ 	]*}"
+			for p in "${bad[@]}"; do
+				if [[ "$entry" == "$p" || "$entry" == "$p/"* ]]; then
+					found="$found $entry"
+				fi
+			done
+			;;
+		esac
+	done <<<"$output"
 	if [[ -n "$found" ]]; then
 		fail "$label manifest exposes dangerous paths:$found"
 	else


### PR DESCRIPTION
## Summary
- make namespace manifest invariant checks reject descendants of dangerous roots
- parse emitted manifest path fields instead of matching exact root strings only

## Tests
- bash tests/host/namespace_manifest_invariants_test.sh
- bash tests/host/namespace_path_policy_test.sh
- ./emu/MacOSX/o.emu -c1 -r$PWD /dis/tests/veltro_security_test.dis