### PR TITLE
test(security): cover nsaudit control descendants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,11 +144,13 @@ jobs:
         chmod +x tests/host/nsaudit_profiles_test.sh
         chmod +x tests/host/nsaudit_path_semantics_test.sh
         chmod +x tests/host/namespace_path_policy_test.sh
+        chmod +x tests/host/namespace_manifest_invariants_test.sh
 
         ROOT=. bash tests/host/nsaudit_rules_test.sh
         ROOT=. bash tests/host/nsaudit_profiles_test.sh
         ROOT=. bash tests/host/nsaudit_path_semantics_test.sh
         ROOT=. bash tests/host/namespace_path_policy_test.sh
+        ROOT=. bash tests/host/namespace_manifest_invariants_test.sh
 
     - name: Run llmsrv session capability checks
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,12 +145,14 @@ jobs:
         chmod +x tests/host/nsaudit_path_semantics_test.sh
         chmod +x tests/host/namespace_path_policy_test.sh
         chmod +x tests/host/namespace_manifest_invariants_test.sh
+        chmod +x tests/host/veltro_namespace_failclosed_test.sh
 
         ROOT=. bash tests/host/nsaudit_rules_test.sh
         ROOT=. bash tests/host/nsaudit_profiles_test.sh
         ROOT=. bash tests/host/nsaudit_path_semantics_test.sh
         ROOT=. bash tests/host/namespace_path_policy_test.sh
         ROOT=. bash tests/host/namespace_manifest_invariants_test.sh
+        ROOT=. bash tests/host/veltro_namespace_failclosed_test.sh
 
     - name: Run llmsrv session capability checks
       run: |

--- a/tests/nsaudit-rules/privileged-control-path/paths
+++ b/tests/nsaudit-rules/privileged-control-path/paths
@@ -1,1 +1,2 @@
 /mnt/toolctl
+/mnt/msg/ctl/session

--- a/tests/nsaudit-rules/privileged-tmpveltro-internal-path/paths
+++ b/tests/nsaudit-rules/privileged-tmpveltro-internal-path/paths
@@ -1,1 +1,2 @@
 /tmp/veltro/cow
+/tmp/veltro/cow/session

--- a/tests/nsaudit-rules/privileged-wallet-account-control-path/paths
+++ b/tests/nsaudit-rules/privileged-wallet-account-control-path/paths
@@ -1,1 +1,2 @@
 /n/wallet/alice/ctl
+/n/wallet/alice/ctl/session


### PR DESCRIPTION
## Summary
- add descendant trusted-control paths to nsaudit rule fixtures
- cover message ctl, wallet account ctl, and internal tmp state descendants
- run namespace manifest invariant and fail-closed checks in CI alongside nsaudit/path-policy checks

## Tests
- bash tests/host/nsaudit_rules_test.sh
- bash tests/host/nsaudit_path_semantics_test.sh
- bash tests/host/nsaudit_profiles_test.sh
- bash tests/host/namespace_manifest_invariants_test.sh
- bash tests/host/veltro_namespace_failclosed_test.sh