### PR TITLE
docs: Limbo is the core's language, not an entry requirement — any language over 9P

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-InferNode is a mixed C, Limbo, and shell repository — application code is written in Limbo, never in other languages. Core runtime and kernel code lives in `libinterp/`, `emu/port/`, and `libsec/`. Limbo applications and libraries live under `appl/`, with notable areas in `appl/cmd/`, `appl/veltro/`, and `appl/xenith/`. Interface definitions belong in `module/*.m`. Tests are under `tests/`, with emulator tests named `*_test.b` and host-side shell tests in `tests/host/*_test.sh`. Supporting material lives in `docs/`, `formal-verification/`, and `tools/`.
+InferNode is a mixed C, Limbo, and shell repository — where "shell" means two dialects: host-side POSIX `sh` and Inferno's rc-style `sh` (see Coding Style below; they are not interchangeable). The Limbo rule is scoped to the **canonical core**: in-tree application code (`appl/`, `module/`) is written in Limbo. Connectors and ancillary services are deliberately not so constrained — **anything that speaks 9P integrates, in any language**. Serve 9P from Go, Python, Rust, C++, whatever you like; it gets mounted at a canonical path (`docs/NAMESPACE-LAYOUT.md`) and every InferNode program and agent uses it as files. You do not need to learn Limbo to contribute an integration. Core runtime and kernel code lives in `libinterp/`, `emu/port/`, and `libsec/`. Limbo applications and libraries live under `appl/`, with notable areas in `appl/cmd/`, `appl/veltro/`, and `appl/xenith/`. Interface definitions belong in `module/*.m`. Tests are under `tests/`, with emulator tests named `*_test.b` and host-side shell tests in `tests/host/*_test.sh`. Supporting material lives in `docs/`, `formal-verification/`, and `tools/`.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ Each tool is a Limbo module that serves a synthetic filesystem under `/tool/`.
 An AI agent (or any program) interacts with external services by reading and
 writing files — no new protocol to learn.
 
+**And no required language.** An integration is either a Limbo tool module
+in-tree, or an out-of-tree 9P server in whatever language you like — mature
+9P libraries exist for Go, Python, Rust, C, and others. If it serves 9P,
+InferNode mounts it at a canonical path and every program and agent uses it
+as files; the speech helpers (C++) and the LLM backends behind `llmsrv` are
+existing examples. Limbo is required only for the canonical in-tree core.
+Either way, start with the namespace sketch (["New Service / Tool
+Proposal"](docs/DESIGN-PRINCIPLES.md) issue template) — the file interface
+is the design regardless of implementation language.
+
 **Integrations we'd love to see:**
 
 | Category | Examples |

--- a/docs/DESIGN-PRINCIPLES.md
+++ b/docs/DESIGN-PRINCIPLES.md
@@ -50,9 +50,14 @@ add it as files.
 server, not a library, not an RPC endpoint, not a daemon with a
 bespoke socket protocol. Any program in any language — and any
 AI agent — can use it with `open`, `read`, `write`. No SDKs.
-No protocol buffers. Just files. (This is conceptually what MCP
-does for AI tools, except the protocol is forty years simpler
-and every existing tool already speaks it.)
+No protocol buffers. Just files. And the universality runs both
+ways: a service written in *any* language integrates by serving
+9P — Limbo is the language of the canonical in-tree core, not an
+entry requirement for connectors and ancillary services, which
+live outside the tree and meet the system at the mount point.
+(This is conceptually what MCP does for AI tools, except the
+protocol is forty years simpler and every existing tool already
+speaks it.)
 
 **The namespace is the schema.** The directory hierarchy carries
 the structure that other systems put into JSON objects, schemas,


### PR DESCRIPTION
## Summary

Two maintainer corrections to the contributor surface:

- **The Limbo rule was overstated.** "Application code is written in Limbo, never in other languages" read as a contribution gate. The real policy, now stated in AGENTS.md, DESIGN-PRINCIPLES ("the universality runs both ways"), and CONTRIBUTING's integrations section: Limbo governs the **canonical in-tree core** (`appl/`, `module/`); connectors and ancillary services integrate **in any language by serving 9P** — mounted at a canonical path, they're files to every program and agent. Existing proof in-tree: the C++ speech helpers, the external LLM backends behind `llmsrv`. Nobody needs to learn Limbo to contribute an integration; the namespace-sketch proposal flow applies either way, since the file interface is the design regardless of implementation language.
- **"Shell" disambiguated** in AGENTS.md's opening line: the repo carries two non-interchangeable dialects — host-side POSIX `sh` and Inferno's rc-style `sh` — with the style section and the shell table as the reference.

## Testing

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Eo29oZp7mPig1XekwRPsq