### PR TITLE
docs: extract the Inferno shell reference to its own page

### DIFF
--- a/.claude/skills/limbo-dev/SKILL.md
+++ b/.claude/skills/limbo-dev/SKILL.md
@@ -87,5 +87,4 @@ checklist honestly.
 
 `-c1` enables JIT, `-c0` forces the interpreter (useful for isolating JIT
 bugs). Inferno's shell is rc-style: no `&&`/`||`, `for i in $x { ... }` —
-see the shell section of
-[docs/LIMBO-FOR-GO-PROGRAMMERS.md](../../../docs/LIMBO-FOR-GO-PROGRAMMERS.md).
+see [docs/INFERNO-SHELL.md](../../../docs/INFERNO-SHELL.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Use the platform scripts instead of inventing local build flows.
 
 ## Coding Style & Naming Conventions
 
-Match the surrounding code closely. Limbo (`.b`) is close to Go in structure but should follow existing Inferno idioms, naming, and control-flow style. C uses Plan 9 / Inferno conventions and tabs, not generic modern C house styles. *Host-side* shell scripts (`tests/host/`, `tools/`, `build-*.sh`) stay POSIX `sh` compatible; scripts that run *inside Inferno* (`tests/inferno/`, `lib/sh/`, boot scripts) are rc-style — no `&&`/`||` — see the shell table in [docs/LIMBO-FOR-GO-PROGRAMMERS.md](docs/LIMBO-FOR-GO-PROGRAMMERS.md). Name new emulator tests `*_test.b`, host tests `*_test.sh`, and keep module interfaces in `module/` aligned with their implementation names.
+Match the surrounding code closely. Limbo (`.b`) is close to Go in structure but should follow existing Inferno idioms, naming, and control-flow style. C uses Plan 9 / Inferno conventions and tabs, not generic modern C house styles. *Host-side* shell scripts (`tests/host/`, `tools/`, `build-*.sh`) stay POSIX `sh` compatible; scripts that run *inside Inferno* (`tests/inferno/`, `lib/sh/`, boot scripts) are rc-style — no `&&`/`||` — see [docs/INFERNO-SHELL.md](docs/INFERNO-SHELL.md). Name new emulator tests `*_test.b`, host tests `*_test.sh`, and keep module interfaces in `module/` aligned with their implementation names.
 
 Use Inferno `mk`, not GNU make, for subtree builds. In `mkfile`s, do not chain commands with `&&`; use separate rules or `;`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ The Inferno® shell is rc-style, not POSIX sh:
 - `for` loops: `for i in $list { commands }` not `for i in $list; do ... done`
 - Different quoting rules
 
+Full dialect reference: [docs/INFERNO-SHELL.md](docs/INFERNO-SHELL.md).
+
 ## Testing System
 
 InferNode uses a custom testing framework (`module/testing.m`) for Limbo unit tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,10 @@ InferNode's shell (`sh`) is rc-style, **not** POSIX:
 - `for` loops: `for i in $list { commands }`
 - Different quoting rules than bash/zsh
 
-This matters when writing scripts that run inside the emulator.
+This matters when writing scripts that run inside the emulator. The
+full dialect reference — the POSIX→Inferno translation table, the
+runtime gotchas that have shipped as real bugs, and the script
+conventions — is [docs/INFERNO-SHELL.md](docs/INFERNO-SHELL.md).
 
 ## Community
 

--- a/docs/DESIGN-PRINCIPLES.md
+++ b/docs/DESIGN-PRINCIPLES.md
@@ -512,7 +512,7 @@ any code is written:
 | A global "busy"/"in-use" flag any client can wedge | Per-fid session state, torn down at clunk; exclusivity is `DMEXCL`. (See "The fid is the session" in the ninep-server skill.) |
 | UI policy (chords, bindings, gestures) inside a device driver | Drivers deliver events; policy lives in the window system. |
 | An effectful file an agent can reach, guarded by a flag | Proposal/commit split; put the commit in a namespace the agent doesn't have. |
-| `&&`, `\|\|`, POSIX loops in Inferno-side scripts | Inferno `sh` is rc-style; see [LIMBO-FOR-GO-PROGRAMMERS.md](LIMBO-FOR-GO-PROGRAMMERS.md#the-shell). |
+| `&&`, `\|\|`, POSIX loops in Inferno-side scripts | Inferno `sh` is rc-style; see [INFERNO-SHELL.md](INFERNO-SHELL.md). |
 | GNU make / `limbo -o` by hand | `mk` and `tools/compile-limbo.sh`; the module's `PATH` constant decides the target. |
 
 None of these is an absolute prohibition — JSON is right at

--- a/docs/DOCUMENTATION-INDEX.md
+++ b/docs/DOCUMENTATION-INDEX.md
@@ -8,6 +8,7 @@
 |----------|-------------|
 | [DESIGN-PRINCIPLES.md](DESIGN-PRINCIPLES.md) | **The design philosophy** — namespace-as-capability, file interfaces, text protocols, mechanism over policy; read before designing anything |
 | [LIMBO-FOR-GO-PROGRAMMERS.md](LIMBO-FOR-GO-PROGRAMMERS.md) | Limbo mapped from Go, plus the gotchas that bite |
+| [INFERNO-SHELL.md](INFERNO-SHELL.md) | The rc-style shell dialect — POSIX→Inferno translation table, runtime gotchas, script conventions |
 | [NAMESPACE-LAYOUT.md](NAMESPACE-LAYOUT.md) | `/mnt` vs `/n` placement convention and why it is security work |
 | [compliance/](compliance/README.md) | Standards evidence register (CNSA 2.0, zero trust, SP 800-92 audit, SLSA, FIPS 140-3 readiness, AI governance) |
 

--- a/docs/INFERNO-SHELL.md
+++ b/docs/INFERNO-SHELL.md
@@ -1,0 +1,64 @@
+# The Inferno Shell
+
+InferNode carries two shell dialects that are not interchangeable:
+host-side scripts (`tests/host/`, `tools/`, `build-*.sh`) are POSIX
+`sh`, and everything that runs *inside* Inferno (`tests/inferno/`,
+`lib/sh/`, boot scripts, anything with a `#!/dis/sh.dis` shebang) is
+Inferno `sh` — an rc-style shell descended from Plan 9's rc, not a
+POSIX shell. This page is the reference for the second dialect.
+POSIX habits here are the most common review comment we make.
+
+The full paper is in-tree at `doc/sh.ms`; `man/1/sh` is the
+reference manual.
+
+
+## POSIX → Inferno translation
+
+| POSIX habit | Inferno sh |
+|---|---|
+| `a && b` | `a ; b` (no `&&`, no `\|\|`) |
+| `for i in x y; do ...; done` | `for i in x y { ... }` |
+| `if [ -d /x ]; then` | `if {ftest -d /x} { ... }` |
+| `. script.sh` | `run script.sh` |
+| `VAR=v cmd` | `VAR=v; cmd` |
+| exit status tests | `raise 'fail:reason'` / `raise 'skip:reason'` |
+| `"$var/path"` (empty var → `/path`) | `$var^/path` **raises** `null list in concatenation` when `$var` is empty — guard with `if {! ~ $#var 0}` before any `^` on command-substitution output |
+| `cmd > $f` failing quietly in an `if` | a failed redirection **raises past `if {...}`**, aborting the script — to assert "writing $f fails", let the command open it: `cp /dev/null $f` |
+
+The last two rows are semantic, not stylistic — rc-legal scripts
+that raise at runtime, and both have shipped as real bugs: an
+unguarded null-list concatenation in a boot probe aborts the entire
+boot for every user, and the redirection rule is why the tutorial's
+contract test asserts write-denial with `cp` (see
+[TUTORIAL-9P-SERVICE.md](TUTORIAL-9P-SERVICE.md), step 5). The
+advisory style gate cannot catch these — it checks style, not
+semantics; semantics are this page's job.
+
+
+## Script conventions
+
+- Scripts begin `#!/dis/sh.dis` and usually `load std`.
+- Quoting is single-quote based, with `''` to embed a quote.
+  Variables are *lists*; `$"var` flattens one to a single string,
+  `$#var` is its length, `` `{cmd} `` captures command output as a
+  list.
+- A backgrounded 9P server (`svc &`) keeps the emulator alive until
+  killed — remember that in test scripts (the poll-for-sentinel
+  pattern in the `limbo-test` skill exists because of it).
+- Scripts under `tests/inferno/` must be committed executable (mode
+  100755) — `sh->system()` execs the path, and a 644 script fails as
+  "file does not exist". CI enforces this (`tools/verify-sh-exec.sh`).
+- `raise 'skip:reason'` marks a test SKIP to the runner;
+  `raise 'fail:reason'` marks it FAIL.
+- The shell can drive Tk directly (`load tk`, `man/1/sh-tk`) —
+  available for harness work, currently unused by any test.
+
+
+## Further reading
+
+- `doc/sh.ms` — the original paper, in-tree.
+- `man/1/sh` — the reference; `man/1/sh-tk` for the Tk builtins.
+- [LIMBO-FOR-GO-PROGRAMMERS.md](LIMBO-FOR-GO-PROGRAMMERS.md) — the
+  language this shell composes with.
+- The `limbo-test` skill — where each kind of script lives and how
+  the runners treat them.

--- a/docs/LIMBO-FOR-GO-PROGRAMMERS.md
+++ b/docs/LIMBO-FOR-GO-PROGRAMMERS.md
@@ -118,33 +118,13 @@ hook does this after pulls).
 
 ## The shell
 
-You will also write Inferno `sh`. It is rc-style, not POSIX, and
-POSIX habits are the most common review comment we make:
-
-| POSIX habit | Inferno sh |
-|---|---|
-| `a && b` | `a ; b` (no `&&`, no `\|\|`) |
-| `for i in x y; do ...; done` | `for i in x y { ... }` |
-| `if [ -d /x ]; then` | `if {ftest -d /x} { ... }` |
-| `. script.sh` | `run script.sh` |
-| `VAR=v cmd` | `VAR=v; cmd` |
-| exit status tests | `raise 'fail:reason'` / `raise 'skip:reason'` |
-| `"$var/path"` (empty var → `/path`) | `$var^/path` **raises** `null list in concatenation` when `$var` is empty — guard with `if {! ~ $#var 0}` before any `^` on command-substitution output |
-| `cmd > $f` failing quietly in an `if` | a failed redirection **raises past `if {...}`**, aborting the script — to assert "writing $f fails", let the command open it: `cp /dev/null $f` |
-
-Scripts begin `#!/dis/sh.dis` and usually `load std`. Quoting is
-single-quote based, with `''` to embed a quote. A backgrounded
-9P server (`svc &`) keeps the emulator alive until killed —
-remember that in test scripts. `doc/sh.ms` is the full paper;
-`man/1/sh` the reference.
-
-The last two table rows are semantic, not stylistic — rc-legal
-scripts that raise at runtime. Both have shipped: an unguarded
-null-list concatenation in a boot probe aborts the entire boot for
-every user, and the redirection rule is why the tutorial's contract
-test asserts write-denial with `cp` (see
-[TUTORIAL-9P-SERVICE.md](TUTORIAL-9P-SERVICE.md), step 5). The
-style gate cannot catch these — it checks style, not semantics.
+You will also write Inferno `sh`. It is rc-style, not POSIX — no
+`&&`/`||`, `for i in x y { ... }`, different quoting — and POSIX
+habits in it are the most common review comment we make. The
+dialect has its own reference:
+[INFERNO-SHELL.md](INFERNO-SHELL.md) — the POSIX→Inferno
+translation table, the two runtime gotchas that have shipped as
+real bugs, and the script conventions.
 
 
 ## Where tests go

--- a/tools/style-gate.sh
+++ b/tools/style-gate.sh
@@ -8,8 +8,8 @@
 #
 # Scope: this gate checks STYLE, not semantics. An rc-legal script can
 # still raise at runtime (null-list concatenation, failed redirections
-# escaping if-blocks) — those live in the shell table of
-# docs/LIMBO-FOR-GO-PROGRAMMERS.md, which is documentation's job.
+# escaping if-blocks) — those live in
+# docs/INFERNO-SHELL.md, which is documentation's job.
 #
 # Checks:
 #   1. POSIX-isms (&& / ||) in Inferno-side shell scripts. Inferno sh
@@ -61,7 +61,7 @@ for f in $inferno_scripts; do
         esac
         case $line in
         *"&&"*|*"||"*)
-            warn "$f" "$n" "Inferno sh is rc-style: '&&'/'||' do not exist (use ';' or if {cmd} { ... }). See docs/LIMBO-FOR-GO-PROGRAMMERS.md, 'The shell'."
+            warn "$f" "$n" "Inferno sh is rc-style: '&&'/'||' do not exist (use ';' or if {cmd} { ... }). See docs/INFERNO-SHELL.md."
             ;;
         esac
     done < "$f"


### PR DESCRIPTION
## Summary

Maintainer question, correctly aimed: why were Inferno shell conventions filed under LIMBO-FOR-GO-PROGRAMMERS.md? Historical accretion — that doc was the material's first home and cross-references cemented it. Mis-filed by the corpus's own single-lookup-point standard: a test author who has never touched Go needs the translation table and would not look there.

- **New `docs/INFERNO-SHELL.md`** — the dialect reference: which scripts are which dialect, the POSIX→Inferno translation table, the two runtime gotchas that shipped as real bugs (null-list concatenation; failed redirections raising past `if{}`), and script conventions (shebang + `load std`, list variables and `$"`/`$#`/backquote, the mode-755 rule, backgrounded-server behavior, `raise skip:/fail:`, the sh-tk builtins), with `doc/sh.ms` and `man/1/sh` as the primary sources.
- **Every cross-reference re-pointed**: AGENTS.md's Coding Style line, CONTRIBUTING's "The Inferno Shell" section, CLAUDE.md's shell-differences section, DESIGN-PRINCIPLES' smell-table row, both style-gate messages, the limbo-dev skill, and the documentation index (Start Here).
- LIMBO-FOR-GO-PROGRAMMERS keeps a short "you'll also write Inferno sh" stub pointing at the new page — its scope returns to being purely the language.

## Testing

Docs plus two comment/message strings in `tools/style-gate.sh` (`sh -n` clean; behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Eo29oZp7mPig1XekwRPsq