### PR TITLE
fix(veltro): initialize audit client before publishing

### DIFF
--- a/appl/veltro/nsconstruct.b
+++ b/appl/veltro/nsconstruct.b
@@ -1429,9 +1429,11 @@ emitauditlog(id: string, ops: list of string)
 	# be quietly edited after the fact. No-op when the install does not
 	# audit — /mnt/audit/log is simply not bound and audit->log returns -1.
 	if(audit == nil) {
-		audit = load Audit Audit->PATH;
-		if(audit != nil)
-			audit->init();
+		a := load Audit Audit->PATH;
+		if(a != nil) {
+			a->init();
+			audit = a;
+		}
 	}
 	if(kr == nil)
 		kr = load Keyring Keyring->PATH;

--- a/tests/veltro_concurrent_test.b
+++ b/tests/veltro_concurrent_test.b
@@ -190,36 +190,41 @@ testConcurrentRestrictNs(t: ref T)
 
 restrictnsworker(done: chan of int, errors: chan of string)
 {
-	# Each worker forks its own namespace
-	sys->pctl(Sys->FORKNS, nil);
+	{
+		# Each worker forks its own namespace
+		sys->pctl(Sys->FORKNS, nil);
 
-	caps := ref NsConstruct->Capabilities(
-		"read" :: nil,
-		nil,
-		nil,
-		nil,
-		0 :: 1 :: 2 :: nil,
-		nil,
-		0,
-		0,
-		-1,
-		nil
-	, nil);
+		caps := ref NsConstruct->Capabilities(
+			"read" :: nil,
+			nil,
+			nil,
+			nil,
+			0 :: 1 :: 2 :: nil,
+			nil,
+			0,
+			0,
+			-1,
+			nil
+		, nil);
 
-	err := nsconstruct->restrictns(caps);
-	if(err != nil) {
-		errors <-= sys->sprint("restrictns failed: %s", err);
-		return;
+		err := nsconstruct->restrictns(caps);
+		if(err != nil) {
+			errors <-= sys->sprint("restrictns failed: %s", err);
+			return;
+		}
+
+		# Verify basic restrictions held
+		(ok, nil) := sys->stat("/dis/lib");
+		if(ok < 0) {
+			errors <-= "/dis/lib should exist after restrictns";
+			return;
+		}
+
+		done <-= 1;
+	} exception e {
+	"*" =>
+		errors <-= "restrictns raised: " + e;
 	}
-
-	# Verify basic restrictions held
-	(ok, nil) := sys->stat("/dis/lib");
-	if(ok < 0) {
-		errors <-= "/dis/lib should exist after restrictns";
-		return;
-	}
-
-	done <-= 1;
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- initialize a local Audit module completely before publishing it to concurrent namespace workers
- report worker exceptions through the concurrency test channel instead of hanging

## Security impact

Concurrent `restrictns()` calls could observe the shared Audit module after `load` but before `Audit.init()` set its Sys dependency. The affected worker broke with `module not loaded`, and the test waited indefinitely.

## Verification

Fresh Ubuntu 24.04 x86-64 KVM guest:

- `veltro_concurrent_test`: 3/3 passed
- concurrency suite repeated 10 times: 10/10 passed
- `veltro_security_test`: 34 passed, 1 environment-dependent `/n/local` skip
- Codex gateway, llmctl, nsaudit profile, and nsaudit path host tests all green

Found while smoke-testing the Veltro escape-room protocol in #530.