### PR TITLE
fix(agent-harness): propagate CNSA mode to emulator

### DIFF
--- a/tests/agent-harness/serve-agent.sh
+++ b/tests/agent-harness/serve-agent.sh
@@ -77,6 +77,15 @@ EOF
 	exit 1
 fi
 
+cnsa_truthy() {
+	case "${1:-}" in
+		""|0*|n*|N*) return 1 ;;
+		*)           return 0 ;;
+	esac
+}
+if cnsa_truthy "${CNSAMODE:-}"; then CNSAMODE=1; else CNSAMODE=0; fi
+export CNSAMODE
+
 export SERVE_LLM_AUTH="$LISTEN_MODE"
 export SERVE_LLM_KEY="$KEY_INFPATH"
 
@@ -86,6 +95,7 @@ serve-agent: $(date -Iseconds) starting
   root    = $ROOT
   profile = $PROFILE_INF
   listen  = $LISTEN_MODE (loopback only)
+  cnsa    = $CNSAMODE (1 = ML-KEM-1024 + ML-DSA-87; 0 = ML-KEM-768)
   /mnt/llm  = tcp!127.0.0.1!5640
   /mnt/ui   = tcp!127.0.0.1!5641
   keyfile = $KEY_HOSTPATH (in-emu: $KEY_INFPATH)

--- a/tests/host/serve_agent_cnsa_test.sh
+++ b/tests/host/serve_agent_cnsa_test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+mkdir -p "$WORK/tests/agent-harness" "$WORK/emu/Linux" "$WORK/emu/MacOSX"
+cp "$ROOT/tests/agent-harness/serve-agent.sh" "$WORK/tests/agent-harness/serve-agent.sh"
+touch "$WORK/tests/agent-harness/serve-agent"
+cat > "$WORK/fake-emu" <<'EOF'
+#!/bin/sh
+printf 'CNSAMODE=%s\n' "${CNSAMODE-unset}"
+printf 'SERVE_LLM_AUTH=%s\n' "${SERVE_LLM_AUTH-unset}"
+printf 'ARGS=%s\n' "$*"
+EOF
+chmod +x "$WORK/tests/agent-harness/serve-agent.sh" "$WORK/fake-emu"
+cp "$WORK/fake-emu" "$WORK/emu/Linux/o.emu"
+cp "$WORK/fake-emu" "$WORK/emu/MacOSX/o.emu"
+
+WRAPPER="$WORK/tests/agent-harness/serve-agent.sh"
+
+check_mode() {
+	input=$1
+	want=$2
+	if [ "$input" = unset ]; then
+		out=$(unset CNSAMODE; "$WRAPPER" --anon-lan 2>&1)
+	else
+		out=$(CNSAMODE="$input" "$WRAPPER" --anon-lan 2>&1)
+	fi
+	echo "$out" | grep -q "^CNSAMODE=$want$" || {
+		echo "serve_agent_cnsa_test: input=$input: expected CNSAMODE=$want" >&2
+		echo "$out" >&2
+		exit 1
+	}
+	echo "$out" | grep -q "  cnsa    = $want " || {
+		echo "serve_agent_cnsa_test: input=$input: startup banner disagrees" >&2
+		echo "$out" >&2
+		exit 1
+	}
+	echo "$out" | grep -q '^SERVE_LLM_AUTH=anon$' || {
+		echo "serve_agent_cnsa_test: auth mode not propagated" >&2
+		exit 1
+	}
+}
+
+check_mode unset 0
+check_mode 0 0
+check_mode no 0
+check_mode Never 0
+check_mode 1 1
+check_mode yes 1
+
+printf 'serve_agent_cnsa_test: PASS\n'


### PR DESCRIPTION
## Summary
- normalize `CNSAMODE` in the host-side agent-harness launcher using the emulator's truthiness rules
- export the resolved mode before launching emu so harness and serve-llm negotiate matching keyring algorithms
- add a hermetic host regression using a fake emulator

#### Test plan
- [x] `tests/host/serve_agent_cnsa_test.sh`
- [x] `sh -n tests/host/serve_agent_cnsa_test.sh tests/agent-harness/serve-agent.sh`
- [x] `tools/verify-sh-exec.sh`
- [x] `git diff --check`

Generated with [Devin](https://devin.ai)