### PR TITLE
Close announced sockets on hangup

### DIFF
--- a/emu/FreeBSD/ipif.c
+++ b/emu/FreeBSD/ipif.c
@@ -342,9 +342,10 @@ so_hangup(int fd, int linger)
 	osenter();
 	if(linger)
 		setsockopt(fd, SOL_SOCKET, SO_LINGER, (char*)&l, sizeof(l));
-	r = shutdown(fd, 2);
-	if(r >= 0)
-		r = close(fd);
+	/* shutdown can reject an announced socket with ENOTCONN; close still owns
+	 * the actual teardown and must not be skipped. */
+	shutdown(fd, 2);
+	r = close(fd);
 	osleave();
 	return r;
 }

--- a/emu/port/ipif-posix.c
+++ b/emu/port/ipif-posix.c
@@ -346,9 +346,10 @@ so_hangup(int fd, int nolinger)
 	osenter();
 	if(nolinger)
 		setsockopt(fd, SOL_SOCKET, SO_LINGER, (char*)&l, sizeof(l));
-	r = shutdown(fd, 2);
-	if(r >= 0)
-		r = close(fd);
+	/* shutdown can reject an announced socket with ENOTCONN; close still owns
+	 * the actual teardown and must not be skipped. */
+	shutdown(fd, 2);
+	r = close(fd);
 	osleave();
 	return r;
 }

--- a/emu/port/ipif6-posix.c
+++ b/emu/port/ipif6-posix.c
@@ -471,9 +471,10 @@ so_hangup(int fd, int nolinger)
 	osenter();
 	if(nolinger)
 		setsockopt(fd, SOL_SOCKET, SO_LINGER, (char*)&l, sizeof(l));
-	r = shutdown(fd, 2);
-	if(r >= 0)
-		r = close(fd);
+	/* shutdown can reject an announced socket with ENOTCONN; close still owns
+	 * the actual teardown and must not be skipped. */
+	shutdown(fd, 2);
+	r = close(fd);
 	osleave();
 	return r;
 }

--- a/tests/tcp_test.b
+++ b/tests/tcp_test.b
@@ -157,6 +157,26 @@ testLoopback(t: ref T)
 		t.error("acceptor: " + e);
 }
 
+testAnnounceHangupReleasesPort(t: ref T)
+{
+	addr := "tcp!127.0.0.1!18798";
+	(aok, ac) := sys->announce(addr);
+	if(aok < 0){
+		t.skip(sys->sprint("no IP stack (announce failed): %r"));
+		return;
+	}
+	b := array of byte "hangup";
+	if(sys->write(ac.cfd, b, len b) != len b){
+		t.fatal(sys->sprint("announced socket hangup failed: %r"));
+		return;
+	}
+
+	(bok, bc) := sys->announce(addr);
+	t.assert(bok >= 0, "hangup releases an announced TCP port for reuse");
+	if(bok >= 0)
+		sys->write(bc.cfd, b, len b);
+}
+
 # ── outbound Internet (opt-in; skip cleanly when offline) ───────────────────
 testTcpDialIp(t: ref T)
 {
@@ -239,6 +259,7 @@ init(nil: ref Draw->Context, args: list of string)
 
 	# Always-on, self-contained assertion first.
 	run("Loopback", testLoopback);
+	run("AnnounceHangupReleasesPort", testAnnounceHangupReleasesPort);
 
 	# Opt-in outbound tests; each skips (does not hang) when offline.
 	run("TcpDialIp", testTcpDialIp);

--- a/tests/tcp_test.b
+++ b/tests/tcp_test.b
@@ -157,6 +157,11 @@ testLoopback(t: ref T)
 		t.error("acceptor: " + e);
 }
 
+# Only discriminates on BSD-family hosts. POSIX makes shutdown() on a listening
+# socket ENOTCONN and macOS and FreeBSD return it, which is where the descriptor
+# leaks; Linux permits it as the idiom for unblocking a thread parked in accept(),
+# so the close happens there either way and this passes with or without the fix.
+# Most of the CI runners are Linux. Do not remove it after watching it pass there.
 testAnnounceHangupReleasesPort(t: ref T)
 {
 	addr := "tcp!127.0.0.1!18798";


### PR DESCRIPTION
## What this changes

`so_hangup` skipped `close()` whenever `shutdown()` failed:

```c
r = shutdown(fd, 2);
if(r >= 0)
	r = close(fd);
```

An announced socket has no peer, so `shutdown()` returns ENOTCONN on it and the
descriptor is never closed. The write to the control file reports the error, and
the descriptor leaks — one per hangup, for the life of the emulator.

`shutdown` is now best-effort and `close` always runs. Same change in
`emu/port/ipif-posix.c`, `emu/port/ipif6-posix.c` and `emu/FreeBSD/ipif.c`,
which carry the same function. `emu/Nt/ipif.c` and `emu/Nt/ipif6.c` go straight
to `closesocket()` and never had this.

## Test

`tests/tcp_test.b` gains `AnnounceHangupReleasesPort`: announce
`tcp!127.0.0.1!18798`, write `hangup` to the control file, announce the same
address again. It skips cleanly when there is no IP stack.

The test only discriminates on BSD-family hosts, and says so in a comment.
POSIX makes `shutdown()` on a listening socket ENOTCONN and macOS and FreeBSD
return it; Linux permits it as the idiom for unblocking a thread parked in
`accept()`, so the close happens there either way and the test passes with or
without the change. Most of the CI runners are Linux, so only the macOS runner
exercises this.

Against unfixed code, on macOS ARM64:

```
=== RUN   AnnounceHangupReleasesPort
--- FAIL: AnnounceHangupReleasesPort (0.00s)
    /tests/tcp_test.b:/testAnnounceHangupReleasesPort/
    announced socket hangup failed: Socket is not connected
```

With the fix:

```
--- PASS: AnnounceHangupReleasesPort (0.00s)
4 passed, 2 skipped
```

The two skips are the outbound-network tests, skipped offline.
