### PR TITLE
Recover text tool calls and handle a non-SSE response body

### DIFF
--- a/appl/lib/llmclient.b
+++ b/appl/lib/llmclient.b
@@ -1033,9 +1033,14 @@ parseopenairesponse(body: string, req: ref AskRequest): (ref AskResponse, string
 						if(idv != nil) pick iv := idv { String => id = iv.s; }
 						if(fnv != nil) {
 							nv := fnv.get("name");
-							av := fnv.get("arguments");
+							av := jsontoolargs(fnv);
 							if(nv != nil) pick n := nv { String => name = n.s; }
-							if(av != nil) pick a := av { String => args = a.s; }
+							if(av != nil) {
+								pick a := av {
+								String => args = a.s;
+								* => args = av.text();
+								}
+							}
 						}
 						toolcalls = (id, name, args) :: toolcalls;
 					}
@@ -1194,8 +1199,13 @@ _ssehandle_event(jv: ref JValue, st: ref _SseState, req: ref AskRequest)
 					if(fnv != nil) {
 						nv := fnv.get("name");
 						if(nv != nil) pick n := nv { String => if(n.s != "") st.tcnames = listset(st.tcnames, idx, listget(st.tcnames, idx) + n.s); }
-						av := fnv.get("arguments");
-						if(av != nil) pick a := av { String => st.tcargs = listset(st.tcargs, idx, listget(st.tcargs, idx) + a.s); }
+						av := jsontoolargs(fnv);
+						if(av != nil) {
+							pick a := av {
+							String => st.tcargs = listset(st.tcargs, idx, listget(st.tcargs, idx) + a.s);
+							* => st.tcargs = listset(st.tcargs, idx, av.text());
+							}
+						}
 					}
 				}
 			}
@@ -1364,9 +1374,24 @@ parseopenaisseresponse(body: string, req: ref AskRequest): (ref AskResponse, str
 #   1. <function=name>\n<parameter=args>\nvalue\n</parameter>\n</function>
 #   2. <tool_call>\n{"name": "...", "arguments": {...}}\n</tool_call>
 #   3. <|tool_call|>\n{"name": "...", "arguments": {...}}\n<|/tool_call|>
+#   4. a lone JSON object {"name":"...","arguments"|"parameters":{...}}
 # Returns (remaining_text, list of (id, name, args) tuples).
 extracttexttoolcalls(content: string, tooldefs: list of ref ToolDef): (string, list of (string, string, string))
 {
+	# Whole-content bare object first. Surrounding prose is not a call.
+	#
+	# A fenced block is deliberately not accepted, common though it is as a
+	# way for a model to emit JSON. The whole-content check is what stops a
+	# quoted example from being executed, and stripping a fence ahead of it
+	# would let an injected fenced block fire. Relax this only with that
+	# trade-off in view.
+	(bmatched, bname, bargs) := trybarejsontoolcall(content);
+	if(bmatched && validtoolname(bname, tooldefs)) {
+		id := sys->sprint("fallback_%d", 0);
+		sys->fprint(stderr, "llmclient: fallback tool parser: extracted 1 tool calls from text\n");
+		return ("", (id, bname, bargs) :: nil);
+	}
+
 	calls: list of (string, string, string);
 	remaining := "";
 	nextid := 0;
@@ -1550,7 +1575,7 @@ trytoolcalltag(s: string, pos: int, opentag, closetag: string): (int, int, strin
 	if(name == "")
 		return (0, 0, "", "");
 
-	argsv := jv.get("arguments");
+	argsv := jsontoolargs(jv);
 	args := "{}";
 	if(argsv != nil)
 		args = argsv.text();
@@ -1634,7 +1659,7 @@ trytoolcallsarray(s: string, pos: int): (int, int, list of (string, string))
 			if(namev != nil) pick nv := namev { String => name = nv.s; }
 			if(name == "")
 				continue;
-			argsv := entry.get("arguments");
+			argsv := jsontoolargs(entry);
 			args := "{}";
 			if(argsv != nil)
 				args = argsv.text();
@@ -1650,6 +1675,77 @@ trytoolcallsarray(s: string, pos: int): (int, int, list of (string, string))
 		rev = hd calls :: rev;
 
 	return (1, j, rev);
+}
+
+# jsontoolargs prefers "arguments" and accepts "parameters" as a synonym.
+jsontoolargs(jv: ref JValue): ref JValue
+{
+	if(jv == nil)
+		return nil;
+	av := jv.get("arguments");
+	if(av == nil)
+		av = jv.get("parameters");
+	return av;
+}
+
+# trybarejsontoolcall accepts content only when the whole string
+# (whitespace-stripped) is one JSON object with a string "name" and
+# either "arguments" or "parameters". Surrounding prose is rejected
+# so a quoted example cannot become a silent tool invocation.
+trybarejsontoolcall(content: string): (int, string, string)
+{
+	s := strip(content);
+	if(len s < 2 || s[0] != '{')
+		return (0, "", "");
+	if(jsonobjectend(s) != len s)
+		return (0, "", "");
+	(jv, jerr) := readjsonstring(s);
+	if(jerr != nil || jv == nil || !jv.isobject())
+		return (0, "", "");
+	namev := jv.get("name");
+	name := "";
+	if(namev != nil) pick nv := namev { String => name = nv.s; }
+	if(name == "")
+		return (0, "", "");
+	argsv := jsontoolargs(jv);
+	if(argsv == nil)
+		return (0, "", "");
+	return (1, name, argsv.text());
+}
+
+# jsonobjectend returns the index after the matching '}' for an object
+# starting at s[0], or -1. String-aware so braces in values are ignored.
+jsonobjectend(s: string): int
+{
+	if(len s == 0 || s[0] != '{')
+		return -1;
+	depth := 0;
+	inq := 0;
+	esc := 0;
+	for(j := 0; j < len s; j++) {
+		c := s[j];
+		if(esc) {
+			esc = 0;
+			continue;
+		}
+		if(inq) {
+			if(c == '\\')
+				esc = 1;
+			else if(c == '"')
+				inq = 0;
+			continue;
+		}
+		if(c == '"')
+			inq = 1;
+		else if(c == '{')
+			depth++;
+		else if(c == '}') {
+			depth--;
+			if(depth == 0)
+				return j + 1;
+		}
+	}
+	return -1;
 }
 
 # validtoolname checks whether name matches one of the provided tool definitions.

--- a/appl/lib/llmclient.b
+++ b/appl/lib/llmclient.b
@@ -597,6 +597,7 @@ _sseconsume(conn: Sys->Connection, rch: chan of (int, array of byte),
 	headersbuf := array[0] of byte;
 	bodybuf := array[0] of byte;
 	in_body := 0;
+	bodymode := 0;	# 0=unknown, 1=json object, 2=SSE
 	status := "";
 	idle_ms := 0;
 	done := 0;
@@ -650,10 +651,14 @@ _sseconsume(conn: Sys->Connection, rch: chan of (int, array of byte),
 				bodybuf[len old:] = rdata[0:n];
 			}
 			if(in_body) {
-				(remaining, ssedone) := _ssedrain_lines(bodybuf, st, req);
-				bodybuf = remaining;
-				if(ssedone)
-					done = 1;
+				if(bodymode == 0)
+					bodymode = ssebodymode(bodybuf);
+				if(bodymode == 2) {
+					(remaining, ssedone) := _ssedrain_lines(bodybuf, st, req);
+					bodybuf = remaining;
+					if(ssedone)
+						done = 1;
+				}
 			}
 		* =>
 			sys->sleep(HTTP_POLL_MS);
@@ -669,6 +674,8 @@ _sseconsume(conn: Sys->Connection, rch: chan of (int, array of byte),
 			}
 		}
 	}
+	if(bodymode == 1)
+		return parseopenairesponse(string bodybuf, req);
 	return _ssebuild_response(st, req);
 }
 
@@ -1578,7 +1585,7 @@ trytoolcalltag(s: string, pos: int, opentag, closetag: string): (int, int, strin
 	argsv := jsontoolargs(jv);
 	args := "{}";
 	if(argsv != nil)
-		args = argsv.text();
+		args = jsonunslash(argsv.text());
 
 	return (1, endpos, name, args);
 }
@@ -1662,7 +1669,7 @@ trytoolcallsarray(s: string, pos: int): (int, int, list of (string, string))
 			argsv := jsontoolargs(entry);
 			args := "{}";
 			if(argsv != nil)
-				args = argsv.text();
+				args = jsonunslash(argsv.text());
 			calls = (name, args) :: calls;
 		}
 	* =>
@@ -1688,6 +1695,37 @@ jsontoolargs(jv: ref JValue): ref JValue
 	return av;
 }
 
+# json.text() escapes '/' as '\/' so "</tag>" cannot look like XML.
+# Tool args are not XML; keep the slash so paths survive on the TOOL: line.
+jsonunslash(s: string): string
+{
+	out := "";
+	for(i := 0; i < len s; i++) {
+		if(s[i] == '\\' && i + 1 < len s && s[i+1] == '/') {
+			out[len out] = '/';
+			i++;
+		} else
+			out[len out] = s[i];
+	}
+	return out;
+}
+
+# First non-whitespace byte of an HTTP body: '{' means a complete
+# chat.completion object (server ignored stream:true), anything else
+# is treated as SSE. 0 if the body is still empty or all whitespace.
+ssebodymode(buf: array of byte): int
+{
+	for(i := 0; i < len buf; i++) {
+		c := int buf[i];
+		if(c == ' ' || c == '\t' || c == '\r' || c == '\n')
+			continue;
+		if(c == '{')
+			return 1;
+		return 2;
+	}
+	return 0;
+}
+
 # trybarejsontoolcall accepts content only when the whole string
 # (whitespace-stripped) is one JSON object with a string "name" and
 # either "arguments" or "parameters". Surrounding prose is rejected
@@ -1710,7 +1748,7 @@ trybarejsontoolcall(content: string): (int, string, string)
 	argsv := jsontoolargs(jv);
 	if(argsv == nil)
 		return (0, "", "");
-	return (1, name, argsv.text());
+	return (1, name, jsonunslash(argsv.text()));
 }
 
 # jsonobjectend returns the index after the matching '}' for an object

--- a/module/llmclient.m
+++ b/module/llmclient.m
@@ -94,6 +94,10 @@ Llmclient: module
 	# bytes matter for Anthropic prompt-cache prefix matching.
 	buildanthropicrequest: fn(req: ref AskRequest): string;
 
+	# Recover tool calls embedded in assistant text when the model
+	# did not use the structured tool_calls field. Exposed for tests.
+	extracttexttoolcalls: fn(content: string, tooldefs: list of ref ToolDef): (string, list of (string, string, string));
+
 	# JSON escape helper
 	jsonescapestr:  fn(s: string): string;
 };

--- a/tests/llmclient_sse_fallback_test.b
+++ b/tests/llmclient_sse_fallback_test.b
@@ -448,7 +448,7 @@ mockserver_sse_trailer(port: string, ready, done: chan of int)
 	done <-= 1;
 }
 
-# INF-46. Once a stream has been consumed incrementally, the response must
+# Once a stream has been consumed incrementally, the response must
 # be built from what was streamed. The old code re-sniffed whatever was
 # left in the buffer and, if it began with '{', parsed that as a whole
 # response instead - so the caller was handed the answer a second time and

--- a/tests/llmclient_sse_fallback_test.b
+++ b/tests/llmclient_sse_fallback_test.b
@@ -323,6 +323,163 @@ mockserverws(port: string, ready, done: chan of int)
 	done <-= 1;
 }
 
+# Mock server that streams incremental SSE chunks (`data: {...}\n\n`).
+mockserver_sse(port: string, ready, done: chan of int)
+{
+	addr := "tcp!127.0.0.1!" + port;
+	(ok, c) := sys->announce(addr);
+	if(ok < 0) {
+		ready <-= -1;
+		done <-= -1;
+		return;
+	}
+	ready <-= 1;
+
+	(lok, lc) := sys->listen(c);
+	if(lok < 0) {
+		done <-= -1;
+		return;
+	}
+
+	dfd := sys->open(lc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil) {
+		done <-= -1;
+		return;
+	}
+
+	buf := array[8192] of byte;
+	sys->read(dfd, buf, len buf);
+
+	hdrs := "HTTP/1.0 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n";
+	hdata := array of byte hdrs;
+	sys->write(dfd, hdata, len hdata);
+
+	# Send 2 SSE content deltas followed by [DONE]
+	c1 := "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"content\":\"I am \"}}]}\n\n";
+	d1 := array of byte c1;
+	sys->write(dfd, d1, len d1);
+
+	c2 := "data: {\"id\":\"2\",\"choices\":[{\"delta\":{\"content\":\"Veltro.\"}}]}\n\n";
+	d2 := array of byte c2;
+	sys->write(dfd, d2, len d2);
+
+	c3 := "data: [DONE]\n\n";
+	d3 := array of byte c3;
+	sys->write(dfd, d3, len d3);
+
+	dfd = nil;
+	done <-= 1;
+}
+
+testIncrementalSseNoDuplication(t: ref T)
+{
+	ready := chan[1] of int;
+	done := chan[1] of int;
+	spawn mockserver_sse("29995", ready, done);
+	rok := <-ready;
+	if(rok < 0) {
+		t.skip("port in use");
+		return;
+	}
+	baseurl := "http://127.0.0.1:29995/v1";
+	req := mkreq(1);
+	(resp, err) := llmclient->askopenai(baseurl, "", req);
+	<-done;
+	if(err != nil || resp == nil) {
+		t.error(sys->sprint("askopenai SSE: err=%s resp=%d", err, resp != nil));
+		return;
+	}
+	t.log("response: " + resp.response);
+	t.assertseq(resp.response, "I am Veltro.",
+		"incremental SSE response must be assembled cleanly without repetition");
+}
+
+# Mock server that finishes a clean SSE stream and then, in the same write,
+# leaves trailing bytes that begin with '{'. A backend does this when it
+# follows [DONE] with a final non-SSE object on the same connection.
+mockserver_sse_trailer(port: string, ready, done: chan of int)
+{
+	addr := "tcp!127.0.0.1!" + port;
+	(ok, c) := sys->announce(addr);
+	if(ok < 0) {
+		ready <-= -1;
+		done <-= -1;
+		return;
+	}
+	ready <-= 1;
+
+	(lok, lc) := sys->listen(c);
+	if(lok < 0) {
+		done <-= -1;
+		return;
+	}
+
+	dfd := sys->open(lc.dir + "/data", Sys->ORDWR);
+	if(dfd == nil) {
+		done <-= -1;
+		return;
+	}
+
+	buf := array[8192] of byte;
+	sys->read(dfd, buf, len buf);
+
+	hdrs := "HTTP/1.0 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n";
+	hdata := array of byte hdrs;
+	sys->write(dfd, hdata, len hdata);
+
+	c1 := "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"content\":\"I am \"}}]}\n\n";
+	d1 := array of byte c1;
+	sys->write(dfd, d1, len d1);
+
+	c2 := "data: {\"id\":\"2\",\"choices\":[{\"delta\":{\"content\":\"Veltro.\"}}]}\n\n";
+	d2 := array of byte c2;
+	sys->write(dfd, d2, len d2);
+
+	# [DONE] and the trailing object in one write, so both land in the
+	# same read and the trailer is still in the buffer when the drain
+	# stops. The trailer carries the answer a second time, which is what
+	# the pane showed.
+	c3 := "data: [DONE]\n\n{\"choices\":[{\"message\":{\"content\":" +
+		"\"I am Veltro. I am Veltro.\"}}]}";
+	d3 := array of byte c3;
+	sys->write(dfd, d3, len d3);
+
+	dfd = nil;
+	done <-= 1;
+}
+
+# INF-46. Once a stream has been consumed incrementally, the response must
+# be built from what was streamed. The old code re-sniffed whatever was
+# left in the buffer and, if it began with '{', parsed that as a whole
+# response instead - so the caller was handed the answer a second time and
+# the conversation pane repeated it.
+#
+# The existing IncrementalSseNoDuplication case cannot catch this: its mock
+# leaves nothing after [DONE], so the re-sniff never fires and the case
+# passes against the unfixed code too.
+testSseTrailerNotReparsed(t: ref T)
+{
+	ready := chan[1] of int;
+	done := chan[1] of int;
+	spawn mockserver_sse_trailer("29994", ready, done);
+	rok := <-ready;
+	if(rok < 0) {
+		t.skip("port in use");
+		return;
+	}
+	baseurl := "http://127.0.0.1:29994/v1";
+	req := mkreq(1);
+	(resp, err) := llmclient->askopenai(baseurl, "", req);
+	<-done;
+	if(err != nil || resp == nil) {
+		t.error(sys->sprint("askopenai SSE trailer: err=%s resp=%d", err, resp != nil));
+		return;
+	}
+	t.log("response: " + resp.response);
+	t.assertseq(resp.response, "I am Veltro.",
+		"trailing JSON after [DONE] must not replace the streamed response");
+}
+
 # Tiny strstr — returns the index of needle in haystack, or -1.
 # Avoids pulling in the String module just for one substring search.
 strstr(haystack, needle: string): int
@@ -372,6 +529,8 @@ init(nil: ref Draw->Context, args: list of string)
 	run("NonStreamingBaseline", testNonStreamingBaseline);
 	run("StreamFallbackTolerantOfLeadingWhitespace", testStreamFallbackTolerantOfLeadingWhitespace);
 	run("ToolCallsArrayFromSpecial66", testToolCallsArrayFromSpecial66);
+	run("IncrementalSseNoDuplication", testIncrementalSseNoDuplication);
+	run("SseTrailerNotReparsed", testSseTrailerNotReparsed);
 
 	if(testing->summary(passed, failed, skipped) > 0)
 		raise "fail:tests failed";

--- a/tests/llmclient_texttools_test.b
+++ b/tests/llmclient_texttools_test.b
@@ -1,0 +1,196 @@
+implement TexttoolsTest;
+
+#
+# llmclient_texttools_test.b - Text-embedded tool-call recovery.
+#
+# Some OpenAI-shaped local models emit a tool call as ordinary message
+# content instead of the structured tool_calls field. extracttexttoolcalls
+# must recognise a lone JSON object with name plus arguments/parameters,
+# and must not treat surrounding prose or unrelated JSON as a tool call.
+#
+# To run: emu -r. /tests/llmclient_texttools_test.dis [-v]
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "bufio.m";
+	bufio: Bufio;
+
+include "json.m";
+	json: JSON;
+	JValue: import json;
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+include "llmclient.m";
+	llmclient: Llmclient;
+	ToolDef: import Llmclient;
+
+TexttoolsTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/llmclient_texttools_test.b";
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" => ;
+	"fail:skip" => ;
+	* => t.failed = 1;
+	}
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+saytools(): list of ref ToolDef
+{
+	td := ref ToolDef("say", "Speak text",
+		"{\"type\":\"object\",\"properties\":{\"text\":{\"type\":\"string\"}},\"required\":[\"text\"]}");
+	return td :: nil;
+}
+
+# Read the "text" field out of a tool-args JSON object.
+argtext(args: string): string
+{
+	bio := bufio->aopen(array of byte args);
+	if(bio == nil)
+		return "";
+	(jv, err) := json->readjson(bio);
+	if(jv == nil || err != "")
+		return "";
+	tv := jv.get("text");
+	if(tv == nil)
+		return "";
+	pick t := tv {
+	String =>
+		return t.s;
+	}
+	return "";
+}
+
+ncalls(calls: list of (string, string, string)): int
+{
+	n := 0;
+	for(; calls != nil; calls = tl calls)
+		n++;
+	return n;
+}
+
+# Observed payload: bare object, "parameters" spelling, no wrapper tags.
+testBareParameters(t: ref T)
+{
+	content := "{\"name\": \"say\", \"parameters\": {\"text\": \"local llm working\"}}";
+	(remaining, calls) := llmclient->extracttexttoolcalls(content, saytools());
+	t.asserteq(ncalls(calls), 1, "bare parameters: one tool call");
+	if(calls == nil)
+		return;
+	(nil, name, args) := hd calls;
+	t.assertseq(name, "say", "bare parameters: name");
+	t.assertseq(argtext(args), "local llm working", "bare parameters: text arg");
+	t.assertseq(remaining, "", "bare parameters: no leftover text");
+}
+
+# Same shape with the OpenAI "arguments" spelling.
+testBareArguments(t: ref T)
+{
+	content := "{\"name\": \"say\", \"arguments\": {\"text\": \"local llm working\"}}";
+	(remaining, calls) := llmclient->extracttexttoolcalls(content, saytools());
+	t.asserteq(ncalls(calls), 1, "bare arguments: one tool call");
+	if(calls == nil)
+		return;
+	(nil, name, args) := hd calls;
+	t.assertseq(name, "say", "bare arguments: name");
+	t.assertseq(argtext(args), "local llm working", "bare arguments: text arg");
+	t.assertseq(remaining, "", "bare arguments: no leftover text");
+}
+
+# Leading/trailing whitespace around a lone object is still a tool call.
+testBareWhitespace(t: ref T)
+{
+	content := "\n  {\"name\": \"say\", \"parameters\": {\"text\": \"local llm working\"}}  \n";
+	(remaining, calls) := llmclient->extracttexttoolcalls(content, saytools());
+	t.asserteq(ncalls(calls), 1, "whitespace: one tool call");
+	if(calls == nil)
+		return;
+	(nil, name, args) := hd calls;
+	t.assertseq(name, "say", "whitespace: name");
+	t.assertseq(argtext(args), "local llm working", "whitespace: text arg");
+	t.assertseq(remaining, "", "whitespace: leftover stripped");
+}
+
+# Surrounding prose must not become a silent tool invocation.
+testBareProseNotACall(t: ref T)
+{
+	content := "Here you go: {\"name\": \"say\", \"parameters\": {\"text\": \"local llm working\"}}";
+	(remaining, calls) := llmclient->extracttexttoolcalls(content, saytools());
+	t.asserteq(ncalls(calls), 0, "prose: not a tool call");
+	t.assertseq(remaining, content, "prose: original text preserved");
+}
+
+# A lone JSON object that is not a tool-call shape must stay as text.
+testBareUnrelatedJson(t: ref T)
+{
+	content := "{\"reply\": \"hello\", \"ok\": true}";
+	(remaining, calls) := llmclient->extracttexttoolcalls(content, saytools());
+	t.asserteq(ncalls(calls), 0, "unrelated JSON: not a tool call");
+	t.assertseq(remaining, content, "unrelated JSON: original text preserved");
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing: %r\n");
+		raise "fail:cannot load testing";
+	}
+	bufio = load Bufio Bufio->PATH;
+	if(bufio == nil) {
+		sys->fprint(sys->fildes(2), "cannot load bufio: %r\n");
+		raise "fail:cannot load bufio";
+	}
+	json = load JSON JSON->PATH;
+	if(json == nil) {
+		sys->fprint(sys->fildes(2), "cannot load json: %r\n");
+		raise "fail:cannot load json";
+	}
+	json->init(bufio);
+	llmclient = load Llmclient Llmclient->PATH;
+	if(llmclient == nil) {
+		sys->fprint(sys->fildes(2), "cannot load llmclient: %r\n");
+		raise "fail:cannot load llmclient";
+	}
+	llmclient->init();
+
+	testing->init();
+	for(a := args; a != nil; a = tl a)
+		if(hd a == "-v")
+			testing->verbose(1);
+
+	run("BareParameters", testBareParameters);
+	run("BareArguments", testBareArguments);
+	run("BareWhitespace", testBareWhitespace);
+	run("BareProseNotACall", testBareProseNotACall);
+	run("BareUnrelatedJson", testBareUnrelatedJson);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -47,6 +47,7 @@ TARG=\
 	json_test.dis\
 	llmclient_think_gating_test.dis\
 	llmclient_reqshape_test.dis\
+	llmclient_texttools_test.dis\
 	llmsrv_test.dis\
 	keyring_test.dis\
 	mail_provision_test.dis\

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -48,6 +48,7 @@ TARG=\
 	llmclient_think_gating_test.dis\
 	llmclient_reqshape_test.dis\
 	llmclient_texttools_test.dis\
+	llmclient_sse_fallback_test.dis\
 	llmsrv_test.dis\
 	keyring_test.dis\
 	mail_provision_test.dis\

--- a/tools/dis-manifest.txt
+++ b/tools/dis-manifest.txt
@@ -701,6 +701,7 @@ dis/tests/keyringinst_test.dis
 dis/tests/lists_test.dis
 dis/tests/llmclient_reqshape_test.dis
 dis/tests/llmclient_sse_fallback_test.dis
+dis/tests/llmclient_texttools_test.dis
 dis/tests/llmclient_think_gating_test.dis
 dis/tests/llmsrv_test.dis
 dis/tests/lucibridge_approval_test.dis


### PR DESCRIPTION
## What this changes

Two things in the OpenAI-compatible client, both about responses that do not
arrive in the shape the code assumed.

**Tool calls emitted as bare JSON text.** Some models answer a tool-enabled
request with the call as ordinary assistant content instead of filling the
structured `tool_calls` field, so the call is never made and the user sees raw
JSON. `extracttexttoolcalls` already recovered three shapes; this adds a
fourth, a lone `{"name":..., "arguments"|"parameters":{...}}` object.

It only accepts content that is *entirely* one JSON object, whitespace aside.
Prose around it is rejected, so a model quoting an example of a tool call
cannot turn that example into a real invocation. `jsonobjectend` is
string-aware, so braces inside string values do not end the object early, and
`jsonunslash` undoes the `\/` escaping `json.text()` applies, which otherwise
mangles paths on the `TOOL:` line.

**A JSON body from a server that ignored `stream:true`.** The client asked for
a stream and then parsed whatever came back as SSE. A server that answers a
streaming request with one complete `chat.completion` object produced an empty
response and no error. `ssebodymode` looks at the first non-whitespace byte of
the body: `{` means a complete object, anything else is treated as SSE.

## Tests

`tests/llmclient_texttools_test.b` is new: five cases over
`extracttexttoolcalls`, including the rejections.

`tests/llmclient_sse_fallback_test.b` gains the non-SSE cases. Both files are
added to `tests/mkfile` TARG — they are built and run rather than sitting in
the tree unwired.

Against the current `dis/lib/llmclient.dis`, before the fix:

```
--- FAIL: StreamFallbackOnPlainJson (0.20s)
--- PASS: NonStreamingBaseline (0.20s)
--- FAIL: StreamFallbackTolerantOfLeadingWhitespace (0.21s)
--- FAIL: ToolCallsArrayFromSpecial66 (0.20s)
--- PASS: IncrementalSseNoDuplication (0.41s)
--- PASS: SseTrailerNotReparsed (0.41s)
3 passed, 3 failed
```

After, on macOS ARM64:

```
llmclient_sse_fallback       6 passed
llmclient_texttools          5 passed
llmclient_reqshape           4 passed
llmclient_think_gating       5 passed
llmsrv                       62 passed
```

`IncrementalSseNoDuplication` and `SseTrailerNotReparsed` pass before and
after on purpose. They pin behaviour this branch must not break: that a
streamed reply is assembled once, and that JSON arriving after `[DONE]` does
not replace it. An early version of the body-mode check did break the second
one, which is why it is pinned here.

`module/llmclient.m` gains one function, so `llmsrv` was rebuilt against it;
its bytecode is unchanged and its 62 tests still pass.
