### PR TITLE
fix(emu): zero Fsinfo so devfs dir reads cannot fault (INFR-421)

### DIFF
--- a/emu/port/devfs-posix.c
+++ b/emu/port/devfs-posix.c
@@ -133,6 +133,39 @@ fsfree(Chan *c)
 	free(FS(c));
 }
 
+/*
+ * Allocate a Chan's Fsinfo.
+ *
+ * smalloc() is emu's pool allocator (alloc.c); it does not zero, so a
+ * recycled block arrives holding whatever the previous occupant left.
+ * Fsinfo embeds a QLock (oq), which fsread() takes on every directory
+ * read.  qlock() on a QLock built from stale bytes either spins for ever
+ * on a non-zero use.val, or - when use.val happens to be zero and
+ * locked/tail do not - writes through the stale tail pointer:
+ *
+ *	SEGV: addr=aaaaaaaaaaaaaaca  PC in qlock+0x34
+ *
+ * A fresh arena is zero-filled by the host, so this stayed latent until a
+ * long-running process recycled enough memory: an agent campaign churning
+ * thousands of namespace shadow directories, every walk allocating and
+ * freeing an Fsinfo.  Zero the whole struct so each field, present and
+ * future, starts defined; then set the non-zero defaults.  (INFR-421)
+ *
+ * Every Fsinfo must come from here.  Allocating one directly at a call
+ * site reintroduces the fault; tests/host/devfs_fsinfo_init_test.sh pins
+ * that.
+ */
+static Fsinfo*
+fsinfoalloc(void)
+{
+	Fsinfo *f;
+
+	f = smalloc(sizeof(Fsinfo));
+	memset(f, 0, sizeof(Fsinfo));
+	f->fd = -1;
+	return f;
+}
+
 Chan*
 fsattach(char *spec)
 {
@@ -150,11 +183,7 @@ fsattach(char *spec)
 
 	c = devattach('U', spec);
 	c->qid = fsqid(&st);
-	c->aux = smalloc(sizeof(Fsinfo));
-	FS(c)->dir = nil;
-	FS(c)->de = nil;
-	FS(c)->fd = -1;
-	FS(c)->issocket = 0;
+	c->aux = fsinfoalloc();
 	FS(c)->gid = st.st_gid;
 	FS(c)->uid = st.st_uid;
 	FS(c)->mode = st.st_mode;
@@ -241,7 +270,7 @@ fswalk(Chan *c, Chan *nc, char **name, int nname)
 			cclose(wq->clone);
 		wq->clone = nil;
 	}else if(wq->clone){
-		nc->aux = smalloc(sizeof(Fsinfo));
+		nc->aux = fsinfoalloc();
 		nc->type = c->type;
 		if(nname > 0 && gotstat) {
 			FS(nc)->gid = st.st_gid;
@@ -257,9 +286,6 @@ fswalk(Chan *c, Chan *nc, char **name, int nname)
 		FS(nc)->name = current;
 		FS(nc)->spec = FS(c)->spec;
 		FS(nc)->rootqid = rootqid;
-		FS(nc)->fd = -1;
-		FS(nc)->dir = nil;
-		FS(nc)->de = nil;
 	}
 	return wq;
 }

--- a/tests/host/devfs_fsinfo_init_test.sh
+++ b/tests/host/devfs_fsinfo_init_test.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+# devfs_fsinfo_init_test.sh - INFR-421
+#
+# The host filesystem device (emu/port/devfs-posix.c) keeps its per-Chan
+# state in an Fsinfo, allocated with smalloc().  smalloc() is emu's pool
+# allocator and does NOT zero, so a recycled block arrives holding the
+# previous occupant's bytes.  Fsinfo embeds a QLock (oq) that fsread()
+# takes on every directory read, so a stale block meant qlock() either
+# spun for ever on a non-zero use.val or wrote through a stale tail
+# pointer:
+#
+#	SEGV: addr=aaaaaaaaaaaaaaca  PC in qlock+0x34
+#
+# A fresh arena is zero-filled by the host, so the fault only appeared
+# once a long-running emu had recycled enough memory - an agent campaign
+# churning namespace shadow directories, thousands of walks each
+# allocating and freeing an Fsinfo.  The fix routes both allocation sites
+# through fsinfoalloc(), which zeroes the struct.
+#
+# Part 1 is a source pin: it cannot observe behaviour, only that no call
+# site bypasses the zeroing constructor.
+# Part 2 is a contract test: it drives the walk/read/stat paths that
+# allocate and free Fsinfo, so a constructor that stopped zeroing, or
+# that dropped the fd = -1 default, fails here.
+
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+
+DEVFS="$ROOT/emu/port/devfs-posix.c"
+failures=0
+
+fail() {
+    echo "FAIL: $1"
+    failures=$((failures + 1))
+}
+
+pass() {
+    echo "PASS: $1"
+}
+
+[ -f "$DEVFS" ] || { echo "SKIP: $DEVFS not found"; exit 77; }
+
+# --- Part 1: source pin ------------------------------------------------
+
+# Every Fsinfo must come from the zeroing constructor.  Allow the one
+# occurrence inside fsinfoalloc() itself.
+bare=$(grep -c 'smalloc(sizeof(Fsinfo))' "$DEVFS" || true)
+if [ "$bare" -eq 1 ]; then
+    pass "single smalloc(sizeof(Fsinfo)) site"
+else
+    fail "expected exactly 1 smalloc(sizeof(Fsinfo)) (inside fsinfoalloc), found $bare"
+fi
+
+if grep -q 'memset(f, 0, sizeof(Fsinfo))' "$DEVFS"; then
+    pass "fsinfoalloc zeroes the struct"
+else
+    fail "fsinfoalloc must zero Fsinfo - the QLock oq is used uninitialised otherwise"
+fi
+
+# Both call sites must use it: fsattach and fswalk.
+sites=$(grep -c '= fsinfoalloc();' "$DEVFS" || true)
+if [ "$sites" -eq 2 ]; then
+    pass "fsattach and fswalk both use fsinfoalloc"
+else
+    fail "expected 2 fsinfoalloc() call sites (fsattach, fswalk), found $sites"
+fi
+
+if grep -q '^fsinfoalloc(void)' "$DEVFS"; then
+    pass "fsinfoalloc defined"
+else
+    fail "fsinfoalloc definition not found"
+fi
+
+# --- Part 2: contract test -------------------------------------------
+
+[ -x "$EMU" ] || { echo "SKIP: no emulator at $EMU"; exit 77; }
+
+mkdir -p "$ROOT/tmp"
+SCRIPT="$ROOT/tmp/infr421-fsinfo.sh"
+LOG="$ROOT/tmp/infr421-fsinfo.log"
+CHURN="$ROOT/tmp/infr421-churn"
+
+rm -rf "$CHURN" "$LOG"
+mkdir -p "$CHURN"
+
+# Nested tree shaped like the veltro shadow trees that exposed this:
+# shadow/<a>/.veltro-ns/shadow/<b>/... Each level is a separate walk,
+# so each read allocates a fresh Fsinfo.
+i=1
+while [ "$i" -le 12 ]; do
+    d="$CHURN/$i/.veltro-ns/shadow/inner"
+    mkdir -p "$d"
+    echo "payload-$i" > "$d/file"
+    i=$((i + 1))
+done
+
+# Exactly 10 bytes, for the stat assertion below.
+printf '0123456789' > "$CHURN/statprobe"
+
+cat > "$SCRIPT" <<'EOS'
+#!/dis/sh.dis
+load std
+
+base = /tmp/infr421-churn
+
+# Walk and read every level, repeatedly.  Each walk allocates a fresh
+# Fsinfo and each directory read takes FS(c)->oq, so this is the path
+# that faulted; the repetition recycles pool blocks.
+for pass in 1 2 3 4 5 {
+	for i in 1 2 3 4 5 6 7 8 9 10 11 12 {
+		ls $base >/dev/null
+		ls $base/$i >/dev/null
+		ls $base/$i/.veltro-ns >/dev/null
+		ls $base/$i/.veltro-ns/shadow >/dev/null
+		ls $base/$i/.veltro-ns/shadow/inner >/dev/null
+	}
+}
+
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 {
+	got = `{cat $base/$i/.veltro-ns/shadow/inner/file}
+	if {~ $got payload-^$i} {
+		echo VERIFIED
+	}
+}
+
+# Stat a file through a walked-but-unopened chan.  fsstat() consults
+# FS(c)->fd when it is >= 0, so without the fd = -1 default it fstat()s
+# descriptor 0 and reports emu's stdin instead of the file.
+echo -n 'STATPROBE '
+ls -l $base/statprobe
+
+echo '=== SCRIPT DONE ==='
+EOS
+
+# emu never self-exits while a proc is backgrounded, so bound it and
+# poll the log for the sentinel.
+( "$EMU" -c1 -r"$ROOT" /dis/sh.dis "/tmp/infr421-fsinfo.sh" > "$LOG" 2>&1 ) &
+emupid=$!
+
+waited=0
+while [ "$waited" -lt 60 ]; do
+    if grep -q '=== SCRIPT DONE ===' "$LOG" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$emupid" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+kill -9 "$emupid" 2>/dev/null || true
+wait "$emupid" 2>/dev/null || true
+
+if grep -qE 'SEGV|panic:|Segmentation' "$LOG"; then
+    fail "emulator faulted during directory churn:"
+    grep -E 'SEGV|panic:|Segmentation' "$LOG" | head -5
+else
+    pass "no fault during directory churn"
+fi
+
+if grep -q '=== SCRIPT DONE ===' "$LOG"; then
+    pass "directory churn completed (no spin in qlock)"
+else
+    fail "workload did not complete within 60s - see $LOG"
+fi
+
+verified=$(grep -c '^VERIFIED' "$LOG" 2>/dev/null || true)
+if [ "$verified" -eq 12 ]; then
+    pass "all 12 files read correctly through freshly walked chans"
+else
+    fail "expected 12 verified file reads, got $verified"
+fi
+
+# statprobe is 10 bytes.  With fd defaulting to 0 instead of -1, fsstat
+# reports emu's stdin: size 0 and the wrong mode.
+if grep -q '^STATPROBE .* 10 ' "$LOG"; then
+    pass "stat through unopened chan reports the file (fd = -1 default held)"
+else
+    fail "stat reported the wrong file - Fsinfo fd default is not -1: $(grep '^STATPROBE' "$LOG" || echo 'no STATPROBE line')"
+fi
+
+if grep -q 'fsqid: top-bit dev' "$LOG"; then
+    fail "fsqid saw a bogus dev - Fsinfo fields uninitialised"
+else
+    pass "no fsqid dev warnings"
+fi
+
+rm -rf "$CHURN" "$SCRIPT"
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures check(s) failed"
+    exit 1
+fi
+echo "all checks passed"
+exit 0


### PR DESCRIPTION
## Summary

INFR-421: emu died with SIGSEGV during the namespace-audit adversarial stage. The ticket flagged shadow-directory lifetime in `tools9p.b`/`nsconstruct.b` as the suspected area, with `dir: bad path` warnings as the lead. Neither turned out to be the defect.

The crash is an uninitialised-memory bug in the host filesystem device, `emu/port/devfs-posix.c`. The Limbo shadow-churn workload is what *exposes* it, not what causes it.

### Root cause

`Fsinfo` (per-Chan state for `#U`) was allocated with `smalloc()`. That is emu's own pool allocator (`emu/port/alloc.c` overrides `malloc`), and it does **not** zero. Both allocation sites — `fsattach` and `fswalk` — set some fields by hand and left the rest holding the previous occupant's bytes.

One of the fields nobody initialised is `oq`, the `QLock` that `fsread()` takes on **every directory read**:

```c
if(c->qid.type & QTDIR){
        qlock(&FS(c)->oq);
```

`qlock()` on a `QLock` made of stale bytes fails two ways:

| stale state | outcome |
|---|---|
| `use.val != 0` | `lock()` spins for ever on a lock nobody holds — hang / DoS |
| `use.val == 0`, `locked != 0`, `tail != 0` | queueing path executes `p->qnext = up` through the stale `tail` — wild write, SIGSEGV |

A fresh arena is zero-filled by the host, so the residue is harmless at first. It only becomes dangerous once the pool has recycled memory containing non-zero data — which an agent campaign reaches easily: thousands of namespace shadow directories, every walk allocating and freeing an `Fsinfo`, and the cleanup paths (`removeshadowdir`, `removepidshadows`, `cleanshadows`) reading those directories continuously.

### Evidence

Modelling recycled-but-released memory (`use.val` zeroed, other fields stale) in `fswalk` reproduced the reported fault exactly:

```
INFR421 fsread dir name=.../dis oq.val=0 oq.locked=-1431655766 oq.head=aaaaaaaaaaaaaaaa oq.tail=aaaaaaaaaaaaaaaa
SEGV: addr=aaaaaaaaaaaaaaca code=2
  PC in qlock+0x34
  LR in qlock+0x24
panic: fault while holding 1 lock(s): Segmentation violation
```

`0xaaaaaaaaaaaaaaca` is the stale `tail` plus the offset of `qnext` — i.e. the wild write, in `qlock`, on a directory read. Filling the block uniformly instead (so `use.val` is non-zero) produced the hang variant rather than the crash, as predicted.

`dir: bad path` is a co-symptom, not a cause: it is `fsdirread` reporting an `xstat` failure when a `readdir` races a concurrent shadow removal — the same workload, a different and harmless output.

### Fix

Both allocations now go through `fsinfoalloc()`, which zeroes the struct and applies the one non-zero default (`fd = -1`). Zeroing wholesale rather than field-by-field keeps fields added later defined by construction.

## Test plan

New `tests/host/devfs_fsinfo_init_test.sh`, in two parts:

- **Source pin** — exactly one `smalloc(sizeof(Fsinfo))` (inside the constructor), the constructor zeroes, and both call sites use it. Labelled a pin; it cannot observe behaviour.
- **Contract test** — builds a nested tree shaped like the veltro shadow trees, walks and reads every level repeatedly, then reads back all 12 files and stats one through a walked-but-unopened chan. Asserts no `SEGV`/`panic`, completion within the timeout (catching the spin variant), correct contents, and no `fsqid` warnings.

Verified in both directions — a test that cannot fail guards nothing:

- [x] Positive: all 9 checks pass with the fix.
- [x] Negative control: dropping `f->fd = -1` fails 2 checks (`STATPROBE --rw-rw-rw- U 0 root wheel 0` — emu's stdin instead of the 10-byte file — plus the `fsqid: top-bit dev` warning).

Controls, all passing on the fixed build:

- [x] `mount_clone_walk_test.sh` (devfs chan lifecycle)
- [x] `namespace_manifest_invariants_test.sh` (6 passed)
- [x] `nsaudit_path_semantics_test.sh`
- [x] `veltro_security_test` (37 passed, 1 skipped), `veltro_concurrent_test` (3 passed)
- [x] `spawn_test` (12), `tempfile_test` (3), `edit_test` (9)

## Note for a follow-up ticket

While building the reproducer I filled **every** `smalloc()` block with a non-zero pattern. With this fix applied, emu still fails to boot under that condition — it hangs in `emuinit` → `namec("#/")` → `walk` → `lock()`:

```
frame #3: o.emu`lock(l=0x100b1cea0) at lock.c:41
frame #5: o.emu`walk(...) at chan.c:776
frame #6: o.emu`namec(aname="#/", ...) at chan.c:1218
```

So `devfs-posix.c` is not the only place depending on accidentally-zero pool memory; the chan layer has at least one more. That is a separate defect class and out of scope here, but worth its own ticket. I deliberately did **not** ship the poison knob I used, since a diagnostic that cannot boot emu is a trap rather than a facility; it is a three-line local patch to `smalloc()` for whoever picks that up.

## Design principles

- Mechanism, not policy: the fix is an initialisation invariant at the allocation boundary, not a check bolted onto the read path.
- No namespace or capability semantics change; no Limbo, `.dis`, or interface changes. Restriction, attenuation, and fail-closed behaviour are untouched.
- Scope held to the defect: the unrelated `dis/tests/*.dis` rebuild churn from `mk install` was reverted rather than carried along.

Generated with [Devin](https://devin.ai)
