### PR TITLE
fix(emu): report PC and symbol on Linux memory faults (INFR-421)

### DIFF
--- a/emu/Linux/os.c
+++ b/emu/Linux/os.c
@@ -1,6 +1,7 @@
 #include	<sys/types.h>
 #include	<time.h>
 #include	<termios.h>
+#include	<sys/ucontext.h>
 #include	<signal.h>
 #include 	<pwd.h>
 #include	<sched.h>
@@ -64,16 +65,85 @@ isnilref(siginfo_t *si)
 	return si != 0 && (si->si_addr == (void*)~(uintptr_t)0 || (uintptr_t)si->si_addr < 512);
 }
 
+/*
+ * Report where a memory fault happened before handing it to disfault().
+ *
+ * A nil dereference from Limbo is an ordinary exception and needs no
+ * commentary.  Anything else is an emulator bug, and the campaign that
+ * motivated this (INFR-421) had to be re-run because all it left behind
+ * was rc=-11: the ucontext was discarded here, so no PC, no symbol, no
+ * faulting function.  The MacOSX port already prints this; keeping the
+ * two in step means a Linux crash is diagnosable from its log alone,
+ * whether or not a core was allowed.
+ *
+ * dladdr() is not async-signal-safe, strictly.  We are already on a
+ * path that ends in disfault or death, the same trade the MacOSX
+ * handler makes, and an unresolved PC is itself a finding: it means the
+ * fault was in JIT-generated code.
+ *
+ * dladdr and REG_RIP live behind _GNU_SOURCE, which cannot be set here:
+ * it makes features.h force _XOPEN_SOURCE to 700 and lib9.h then
+ * redefines it to 500, warning on every build.  Declare the two pieces
+ * we need instead.  REG_RIP/REG_EIP are fixed by the x86 psABI.
+ */
+typedef struct {
+	const char	*dli_fname;
+	void		*dli_fbase;
+	const char	*dli_sname;
+	void		*dli_saddr;
+} Dlinfo;
+
+extern int dladdr(const void*, Dlinfo*);
+
+enum {
+	Gregrip	= 16,	/* REG_RIP */
+	Gregeip	= 14,	/* REG_EIP */
+};
+
+static void
+faultwhere(void *a)
+{
+	ucontext_t *uc;
+	Dlinfo di;
+	void *pc;
+
+	if(a == nil)
+		return;
+	uc = (ucontext_t*)a;
+#if defined(__x86_64__)
+	pc = (void*)uc->uc_mcontext.gregs[Gregrip];
+#elif defined(__i386__)
+	pc = (void*)uc->uc_mcontext.gregs[Gregeip];
+#elif defined(__aarch64__)
+	pc = (void*)uc->uc_mcontext.pc;
+#else
+	USED(uc);
+	return;
+#endif
+	fprint(2, "  PC=%p\n", pc);
+	if(dladdr(pc, &di) && di.dli_sname != nil)
+		fprint(2, "  PC in %s+%#lx\n", di.dli_sname,
+			(ulong)((uintptr)pc - (uintptr)di.dli_saddr));
+	else
+		fprint(2, "  PC not in any image (JIT-generated code?)\n");
+	if(up != nil && up->nlocks > 0)
+		fprint(2, "  holding %d lock(s)\n", up->nlocks);
+}
+
 static void
 trapmemref(int signo, siginfo_t *si, void *a)
 {
-	USED(a);	/* ucontext_t*, could fetch pc in machine-dependent way */
 	if(isnilref(si))
 		disfault(nil, exNilref);
-	else if(signo == SIGBUS)
+	else if(signo == SIGBUS){
+		fprint(2, "BUS: addr=%p code=%d\n", si->si_addr, si->si_code);
+		faultwhere(a);
 		sysfault("bad address addr=", si->si_addr);	/* eg, misaligned */
-	else
+	}else{
+		fprint(2, "SEGV: addr=%p code=%d\n", si->si_addr, si->si_code);
+		faultwhere(a);
 		sysfault("segmentation violation addr=", si->si_addr);
+	}
 }
 
 static void


### PR DESCRIPTION
## Summary

Diagnostic plumbing for INFR-421, not a fix for the recurrence.

The Linux memory-fault handler discarded the one thing that identifies a crash. It had the `ucontext` and threw it away:

```c
USED(a);	/* ucontext_t*, could fetch pc in machine-dependent way */
```

So a Linux SIGSEGV yields the faulting address and nothing about the faulting code. macOS has printed address, registers and a `dladdr`-resolved symbol for some time.

That asymmetry has already cost two campaigns. The first INFR-421 crash was root-caused only because the defect also reproduced on macOS, where the log said `PC in qlock+0x34`. The post-fix recurrence on `6876d8cc` left nothing usable: no core (guest core limit `0`, apport kept no report) and no PC — so `emu_rc=-11` is the entire finding, and diagnosing it currently requires burning another live run.

This prints the address, PC, resolving symbol, and held-lock count before handing off to `disfault()`. A PC that resolves to no image is itself informative: the fault was in JIT-generated code.

`dladdr` and `REG_RIP` sit behind `_GNU_SOURCE`, which cannot be set in this file — `features.h` then forces `_XOPEN_SOURCE` to 700, `lib9.h` redefines it to 500, and every build warns. I tried that first and backed it out. The struct and function are declared locally instead, with the two register indices named; the x86 psABI fixes them.

## Test plan

- [x] Compiles on the Linux amd64 target (`Ubuntu-mini`, gcc, `mk os.o`) with **zero** warnings. I verified the `_GNU_SOURCE` variant produced a warning and this one does not.
- [x] Borrowed lab worktree restored afterwards; `emu/Linux/o.emu` still hashes to `1c1f471cadf674c656c6c0e3fdab8ff65e4e3fd3c8a14c3e7116f4617dfb9ff0`, the SHA recorded in the ticket, so the campaign binary is unmodified.
- [x] The identical logic on macOS is what produced `PC in qlock+0x34` during the original root-cause.
- [ ] **Not** yet exercised by a real fault on Linux. It is unreachable without a crash, and I would rather ship it before the next campaign than manufacture one to tick a box.

No behaviour change on any non-faulting path; the handler's control flow into `disfault()` is unchanged.

## Evidence review that motivated this

From the sealed recurrence evidence (`RUN-20260826T020902Z-SOURCE-6876d8cc`), the driver marker stream ends at:

```
@@GRIND followthrough settled status=idle
@@GRIND children terminal=yes
```

The audit chain holds 728 records, 13 signed checkpoints, `capture=complete` and a final checkpoint at seq 727, with zero payload-hash failures — but `@@GRIND audit verified` never printed. That places the fault in **audit finalization**, the verification pass that reads back the 356 KB `chain` and 460 KB `venti.data`, and not in namespace/shadow churn. There is no `dir: bad path` this time.

Worth naming rather than burying: `children terminal=yes` is the dynamic `/mnt/ui/activity` enumeration added in #548 (INFR-414), so it sits inside the suspect window. I have no evidence it is implicated, only that it is new and adjacent.

I am deliberately not proposing a root-cause fix for the recurrence. With no PC and no core, anything I wrote would be a guess presented as a diagnosis.

Generated with [Devin](https://devin.ai)
