### PR TITLE
fix(jit): roll over exhausted typecom slab (INFR-421)

### DIFF
--- a/libinterp/comp-amd64.c
+++ b/libinterp/comp-amd64.c
@@ -2578,10 +2578,11 @@ static uchar *typecom_tmp = nil;
  * Each type needs a small (tens-to-hundreds of bytes) block of
  * near-text executable memory. Calling jitmalloc per type consumes
  * one VMA slot each, exhausting the 1024-hint scan after a few
- * hundred types. Instead, grab one large slab and bump-allocate.
- * Type code is never freed individually, so bump is ideal.
+ * hundred types. Instead, grab large slabs and bump-allocate.
+ * Type code is never freed individually, so full slabs remain mapped
+ * while allocation continues in a new slab.
  */
-#define TYPECOM_SLAB_SIZE	(2*1024*1024)	/* 2MB — enough for ~thousands of types */
+#define TYPECOM_SLAB_SIZE	(2*1024*1024)	/* 2MB holds thousands of types */
 static uchar *typecom_slab = nil;
 static ulong typecom_slab_used = 0;
 
@@ -2591,8 +2592,10 @@ typecom_alloc(int n)
 	uchar *p;
 	ulong aligned;
 
+	if(n <= 0 || n > TYPECOM_SLAB_SIZE)
+		return nil;
 	aligned = (n + 15) & ~15;	/* 16-byte align for code */
-	if(typecom_slab == nil) {
+	if(typecom_slab == nil || typecom_slab_used > TYPECOM_SLAB_SIZE-aligned) {
 #ifdef __APPLE__
 		typecom_slab = mmap(0, TYPECOM_SLAB_SIZE,
 			PROT_READ|PROT_WRITE|PROT_EXEC,
@@ -2616,9 +2619,8 @@ typecom_alloc(int n)
 			return nil;
 		memset(typecom_slab, 0, TYPECOM_SLAB_SIZE);
 #endif
+		typecom_slab_used = 0;
 	}
-	if(typecom_slab_used + aligned > TYPECOM_SLAB_SIZE)
-		return nil;
 	p = typecom_slab + typecom_slab_used;
 	typecom_slab_used += aligned;
 	return p;
@@ -2657,7 +2659,7 @@ typecom(Type *t)
 
 	code = typecom_alloc(n);
 	if(code == nil)
-		return;
+		error(exNomem);
 
 #ifdef __APPLE__
 	pthread_jit_write_protect_np(0);

--- a/tests/host/amd64_jit_typecom_slab_test.sh
+++ b/tests/host/amd64_jit_typecom_slab_test.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Regression test for INFR-421: exhausting one typecom slab must not
+# leave a compiled frame type with a nil initializer.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+[ "$OBJTYPE" = amd64 ] || {
+	echo "SKIP: amd64 JIT test"
+	exit 77
+}
+[ -x "$EMU" ] || {
+	echo "SKIP: emu not found at $EMU"
+	exit 77
+}
+
+REPRO="$ROOT/tmp/amd64_jit_typecom_slab_repro.sh"
+LOG="$(mktemp)"
+trap 'rm -f "$REPRO" "$ROOT/tmp/amd64-jit-typecom-copy" "$LOG"' EXIT HUP INT TERM
+
+cat >"$REPRO" <<'EOF'
+#!/dis/sh.dis
+
+load std
+path=(/dis .)
+
+for (i in `{seq 1 2400}) {
+	cp /README.md /tmp/amd64-jit-typecom-copy
+}
+echo '@@TYPECOM-SLAB PASS'
+EOF
+
+rc=0
+timeout 30 "$EMU" -c1 -r"$ROOT" /dis/sh.dis /tmp/amd64_jit_typecom_slab_repro.sh \
+	>"$LOG" 2>&1 || rc=$?
+
+case "$rc" in
+	0|124|137) ;;
+	*)
+		echo "FAIL: amd64 JIT exited with status $rc"
+		cat "$LOG"
+		exit 1
+		;;
+esac
+
+if ! grep -q '^@@TYPECOM-SLAB PASS$' "$LOG"; then
+	echo "FAIL: amd64 JIT did not survive typecom slab rollover"
+	cat "$LOG"
+	exit 1
+fi
+
+echo "PASS: amd64 JIT survives typecom slab rollover"


### PR DESCRIPTION
## Summary
- allocate a fresh near-text typecom slab when the current 2 MiB slab fills
- raise `exNomem` if executable type code cannot be allocated instead of compiling a nil call target
- add an amd64 JIT churn regression that crosses the former slab limit

## Root cause
Repeated short-lived module loads consume type initializer/destructor code from a process-lifetime slab. Once `typecom_slab_used` reached exactly 2 MiB, `typecom_alloc()` returned nil, but `typecom()` returned normally and module compilation continued. `MacFRAM` later called the nil `Type.initialize` pointer and faulted at PC 0.

GDB captured the failing `cp.dis` JIT call site with `typecom_slab_used=2097152` and `capacity=2097152`.

## Validation
- new regression: PASS after 2,400 repeated `cp.dis` loads under `-c1`; unfixed master exits 139
- preserved audit-export replay: 3/3 rounds complete; unfixed master crashes during round 1
- JIT correctness suite: 181/181 passed
- original and enhanced JIT benchmarks completed
- Linux amd64 headless emulator rebuilt successfully

The broader build reported an existing `appl/cmd/git/push.b` / `Git.readcredentials` interface mismatch, but still rebuilt the emulator; this PR does not touch that code.
