### PR TITLE
Check for mk and limbo before the macOS builds

### DIFF
--- a/build-macos-headless.sh
+++ b/build-macos-headless.sh
@@ -27,7 +27,11 @@ for tool in mk limbo; do
 done
 if [[ -n "$missing_tools" ]]; then
     echo "Error: required native build tool(s) not found: $missing_tools" >&2
-    echo "Run ./makemk.sh, then build libmath, libbio, lib9, and libsec in order before rebuilding limbo." >&2
+    echo "Bootstrap them from the repository root; the whole sequence takes about 30 seconds:" >&2
+    echo '  export ROOT="$PWD" PATH="$PWD/MacOSX/arm64/bin:$PATH"' >&2
+    echo '  SYSTARG=MacOSX OBJTYPE=arm64 ./makemk.sh' >&2
+    echo '  for d in lib9 libbio libmp libsec libmath utils/iyacc limbo; do (cd $d && mk install); done' >&2
+    echo "Then re-run this script." >&2
     exit 1
 fi
 

--- a/build-macos-headless.sh
+++ b/build-macos-headless.sh
@@ -19,6 +19,18 @@ export PATH="$ROOT/MacOSX/arm64/bin:$PATH"
 export AWK=awk
 export SHELLNAME=sh
 
+missing_tools=""
+for tool in mk limbo; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        missing_tools="${missing_tools:+$missing_tools }$tool"
+    fi
+done
+if [[ -n "$missing_tools" ]]; then
+    echo "Error: required native build tool(s) not found: $missing_tools" >&2
+    echo "Run ./makemk.sh, then build libmath, libbio, lib9, and libsec in order before rebuilding limbo." >&2
+    exit 1
+fi
+
 echo "Building for: SYSHOST=$SYSHOST OBJTYPE=$OBJTYPE"
 echo "GUI Backend: headless (no display)"
 echo ""

--- a/build-macos-sdl3.sh
+++ b/build-macos-sdl3.sh
@@ -51,7 +51,11 @@ for tool in mk limbo; do
 done
 if [[ -n "$missing_tools" ]]; then
     echo "Error: required native build tool(s) not found: $missing_tools" >&2
-    echo "Run ./makemk.sh, then build libmath, libbio, lib9, and libsec in order before rebuilding limbo." >&2
+    echo "Bootstrap them from the repository root; the whole sequence takes about 30 seconds:" >&2
+    echo '  export ROOT="$PWD" PATH="$PWD/MacOSX/arm64/bin:$PATH"' >&2
+    echo '  SYSTARG=MacOSX OBJTYPE=arm64 ./makemk.sh' >&2
+    echo '  for d in lib9 libbio libmp libsec libmath utils/iyacc limbo; do (cd $d && mk install); done' >&2
+    echo "Then re-run this script." >&2
     exit 1
 fi
 

--- a/build-macos-sdl3.sh
+++ b/build-macos-sdl3.sh
@@ -43,6 +43,18 @@ export PATH="$ROOT/MacOSX/arm64/bin:$PATH"
 export AWK=awk
 export SHELLNAME=sh
 
+missing_tools=""
+for tool in mk limbo; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        missing_tools="${missing_tools:+$missing_tools }$tool"
+    fi
+done
+if [[ -n "$missing_tools" ]]; then
+    echo "Error: required native build tool(s) not found: $missing_tools" >&2
+    echo "Run ./makemk.sh, then build libmath, libbio, lib9, and libsec in order before rebuilding limbo." >&2
+    exit 1
+fi
+
 echo "Building for: SYSHOST=$SYSHOST OBJTYPE=$OBJTYPE"
 echo "GUI Backend: SDL3"
 echo ""

--- a/tests/host/build_macos_preflight_test.sh
+++ b/tests/host/build_macos_preflight_test.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Verify the macOS build scripts refuse to start when a native build tool is
+# absent, and name the bootstrap in the message.
+#
+# Both tools matter. makemk.sh builds mk alone, so mk present and limbo absent
+# is the state a half-finished bootstrap leaves behind, and it is the case the
+# build used to hit as a bare "limbo: command not found" minutes in.
+
+set -eu
+
+ROOT=$(CDPATH= cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/build-macos-preflight.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+# Keep dirname available while controlling which build tools are on PATH.
+ln -s "$(command -v dirname)" "$TMP/dirname"
+
+# The SDL3 script probes for the library before anything else. Satisfy that
+# probe so this test isolates the build-tool preflight and does not depend on
+# SDL3 being installed.
+cat > "$TMP/pkg-config" <<'STUB'
+#!/bin/sh
+case "$1" in
+--exists) exit 0 ;;
+--modversion) echo "0.0.0-stub" ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/pkg-config"
+
+expect_refusal() {
+	script=$1
+	missing=$2
+	if output=$(env PATH="$TMP" "$ROOT/$script" 2>&1); then
+		echo "$script: unexpectedly succeeded without $missing" >&2
+		exit 1
+	fi
+	for want in "required native build tool(s) not found: $missing" "Run ./makemk.sh,"; do
+		if ! printf '%s\n' "$output" | grep -F "$want" >/dev/null; then
+			echo "$script [$missing]: expected the message to contain: $want" >&2
+			echo "got:" >&2
+			printf '%s\n' "$output" | sed 's/^/  /' >&2
+			exit 1
+		fi
+	done
+}
+
+for script in build-macos-headless.sh build-macos-sdl3.sh; do
+	# Neither tool present.
+	rm -f "$TMP/mk"
+	expect_refusal "$script" "mk limbo"
+
+	# mk present, limbo absent — the half-bootstrapped case.
+	printf '#!/bin/sh\nexit 0\n' > "$TMP/mk"
+	chmod +x "$TMP/mk"
+	expect_refusal "$script" "limbo"
+done
+
+echo "build_macos_preflight: PASS"

--- a/tests/host/build_macos_preflight_test.sh
+++ b/tests/host/build_macos_preflight_test.sh
@@ -10,28 +10,24 @@ set -eu
 
 ROOT=$(CDPATH= cd "$(dirname "$0")/../.." && pwd)
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/build-macos-preflight.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
 
 # Both build scripts prepend "$ROOT/MacOSX/arm64/bin" to PATH before the
 # preflight check, so an empty PATH is not enough to hide the tools on a
 # machine where they are actually built — the preflight would never fire and
-# the test would fail on exactly the platform it is written for. Move the
-# native tools aside for the duration so the script's own PATH line finds
-# nothing either, and restore them on the way out.
-BIN="$ROOT/MacOSX/arm64/bin"
-STASH="$TMP/bin-stash"
-mkdir -p "$STASH"
-stash_native_tools() {
-	for t in mk limbo; do
-		if [ -e "$BIN/$t" ]; then mv "$BIN/$t" "$STASH/$t"; fi
-	done
-}
-restore_native_tools() {
-	for t in mk limbo; do
-		if [ -e "$STASH/$t" ]; then mv "$STASH/$t" "$BIN/$t"; fi
-	done
-}
-stash_native_tools
-trap 'restore_native_tools; rm -rf "$TMP"' EXIT HUP INT TERM
+# the test would fail on exactly the platform it is written for.
+#
+# Hiding the real tools by moving them aside is not an option: a SIGKILL
+# between the stash and the restore (CI timeout kill, OOM kill) would leave
+# the tree without its native build tools and no way to notice. Instead the
+# test never touches the real tree at all. It copies the two scripts into a
+# fake tree under $TMP with an empty MacOSX/arm64/bin and runs them from
+# there. Both scripts derive ROOT from "$0", so they find the empty bin
+# directory on their own, the preflight fires, and the tree's real tools are
+# untouched no matter how the test dies.
+FAKETREE="$TMP/faketree"
+mkdir -p "$FAKETREE/MacOSX/arm64/bin"
+cp "$ROOT/build-macos-headless.sh" "$ROOT/build-macos-sdl3.sh" "$FAKETREE/"
 
 # Keep dirname available while controlling which build tools are on PATH.
 ln -s "$(command -v dirname)" "$TMP/dirname"
@@ -52,13 +48,15 @@ chmod +x "$TMP/pkg-config"
 expect_refusal() {
 	script=$1
 	missing=$2
-	if output=$(env PATH="$TMP" "$ROOT/$script" 2>&1); then
+	if output=$(env PATH="$TMP" "$FAKETREE/$script" 2>&1); then
 		echo "$script: unexpectedly succeeded without $missing" >&2
 		exit 1
 	fi
 	for want in \
 		"required native build tool(s) not found: $missing" \
 		"./makemk.sh" \
+		'SYSTARG=MacOSX OBJTYPE=arm64 ./makemk.sh' \
+		'export ROOT="$PWD" PATH="$PWD/MacOSX/arm64/bin:$PATH"' \
 		"lib9 libbio libmp libsec libmath utils/iyacc limbo"; do
 		if ! printf '%s\n' "$output" | grep -F "$want" >/dev/null; then
 			echo "$script [$missing]: expected the message to contain: $want" >&2

--- a/tests/host/build_macos_preflight_test.sh
+++ b/tests/host/build_macos_preflight_test.sh
@@ -10,7 +10,28 @@ set -eu
 
 ROOT=$(CDPATH= cd "$(dirname "$0")/../.." && pwd)
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/build-macos-preflight.XXXXXX")
-trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+# Both build scripts prepend "$ROOT/MacOSX/arm64/bin" to PATH before the
+# preflight check, so an empty PATH is not enough to hide the tools on a
+# machine where they are actually built — the preflight would never fire and
+# the test would fail on exactly the platform it is written for. Move the
+# native tools aside for the duration so the script's own PATH line finds
+# nothing either, and restore them on the way out.
+BIN="$ROOT/MacOSX/arm64/bin"
+STASH="$TMP/bin-stash"
+mkdir -p "$STASH"
+stash_native_tools() {
+	for t in mk limbo; do
+		if [ -e "$BIN/$t" ]; then mv "$BIN/$t" "$STASH/$t"; fi
+	done
+}
+restore_native_tools() {
+	for t in mk limbo; do
+		if [ -e "$STASH/$t" ]; then mv "$STASH/$t" "$BIN/$t"; fi
+	done
+}
+stash_native_tools
+trap 'restore_native_tools; rm -rf "$TMP"' EXIT HUP INT TERM
 
 # Keep dirname available while controlling which build tools are on PATH.
 ln -s "$(command -v dirname)" "$TMP/dirname"
@@ -35,7 +56,10 @@ expect_refusal() {
 		echo "$script: unexpectedly succeeded without $missing" >&2
 		exit 1
 	fi
-	for want in "required native build tool(s) not found: $missing" "Run ./makemk.sh,"; do
+	for want in \
+		"required native build tool(s) not found: $missing" \
+		"./makemk.sh" \
+		"lib9 libbio libmp libsec libmath utils/iyacc limbo"; do
 		if ! printf '%s\n' "$output" | grep -F "$want" >/dev/null; then
 			echo "$script [$missing]: expected the message to contain: $want" >&2
 			echo "got:" >&2


### PR DESCRIPTION
## What this changes

`build-macos-headless.sh` and `build-macos-sdl3.sh` assumed `mk` and `limbo`
were already on PATH. Neither checked, so a missing tool surfaced as a bare
`command not found` from inside the build rather than as a statement of what to
do about it.

`makemk.sh` builds `mk` alone. `limbo` still needs libmath, libbio, lib9 and
libsec built after that, so "mk present, limbo absent" is the state a
half-finished bootstrap leaves behind, and it is the one that costs time: the
build gets several minutes in, through the whole emulator compile, before it
reaches `limbo` and dies.

Both scripts now refuse up front when either tool is missing, name which one,
and name the bootstrap.

Both, because the hole is identical in each and `build-macos-sdl3.sh` is the
one AGENTS.md lists first.

## Tests

`tests/host/build_macos_preflight_test.sh` is new. For each script it covers
neither tool present, and `mk` present with `limbo` absent. It stubs
`pkg-config` so the SDL3 probe cannot decide the result, and a failed assertion
prints what it expected and what it got.

Against each script before this change:

```
neither present   build starts, fails inside mk
mk present        build starts, dies later at "limbo: command not found"
```

After:

```
build_macos_preflight: PASS
```

The exit status was already correct in both. `set -e` is set and each ends in an
explicit `exit 1`; a failing step has always returned non-zero. Only the
preflight was missing.
