### PR TITLE
ci: include runtime in GoDis artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,7 @@ jobs:
           emu/Linux/o.emu
           Linux/amd64/bin/limbo
           Linux/amd64/bin/mk
+          dis/
         retention-days: 14
 
   # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- include the freshly built `dis/` runtime in the Linux AMD64 artifact consumed by the downstream GoDis job
- restore GoDis E2E execution after #559 stopped tracking runtime bytecode

#### Test plan
- [x] `./tools/verify-dis-build.sh`
- [x] `go test ./...` in `tools/godis`
- [x] PR #567 Linux AMD64 and macOS jobs pass with the full-runtime build fix

Follow-up to #567 and #559.

Generated with [Devin](https://devin.ai)