### PR TITLE
fix(jit): typecom scratch overflow + emulator/tool fixes (INFR-421)

### DIFF
--- a/appl/veltro/tools/exec.b
+++ b/appl/veltro/tools/exec.b
@@ -221,8 +221,14 @@ exec(args: string): string
 	# Buffered capacity 1: goroutines can complete their send and exit
 	# even after the alt has moved on, preventing indefinite blocking.
 	result := chan[1] of string;
-	spawn runcommand(cmd, fds[1], result);
+	pidch := chan[1] of int;
+	spawn runcommand(cmd, fds[1], result, pidch);
 	fds[1] = nil;
+
+	# The worker reports its process-group id before it execs anything, so a
+	# timed-out or over-long command can be killed as a unit below rather
+	# than abandoned to keep running after this tool returns (INFR-421).
+	workerpid := <-pidch;
 
 	# Read output with timeout
 	output := "";
@@ -255,13 +261,20 @@ exec(args: string): string
 	# Close read fd to unblock readoutput goroutine if still blocked on read
 	fds[0] = nil;
 
-	# Wait for result
+	# Collect the command's exit status.  If it has not finished on its own
+	# it is still running after we stopped reading (timeout or output cap):
+	# leaving it alive orphans a process outside this tool's accounting.
+	# Two abandoned limbo.dis compiles left this way are what faulted the
+	# emulator in the escape campaign (INFR-421).  Kill the worker's whole
+	# process group so nothing survives the return; a killed group leader
+	# will not report back, so do not block waiting for it.
 	err := "";
 	alt {
 	e := <-result =>
 		err = e;
 	* =>
-		;  # Already done
+		killgrp(workerpid);
+		output += "\n... (command still running at return; process group terminated)";
 	}
 
 	if(output == "" && err != "")
@@ -278,12 +291,17 @@ exec(args: string): string
 
 # Run command in a separate thread with isolated fd group.
 # NEWFD prevents dup from affecting other goroutines' stdout/stderr.
-runcommand(cmd: string, outfd: ref Sys->FD, result: chan of string)
+runcommand(cmd: string, outfd: ref Sys->FD, result: chan of string, pidch: chan of int)
 {
+	# Become a process-group leader so the parent can kill this command and
+	# everything it spawns as one unit if it overruns its deadline (INFR-421).
+	# NEWPGRP returns this proc's pid, which is also the new group id.
+	pid := sys->pctl(Sys->NEWPGRP, nil);
+	pidch <-= pid;
+
 	# Open this worker's wait channel before NODEVS. The shell normally reaches
 	# it through #p or ambient /prog; retaining this one FD lets the namespace
 	# hide every process directory, including writable sibling ctl files.
-	pid := sys->pctl(0, nil);
 	waitfd := sys->open("#p/" + string pid + "/wait", Sys->OREAD);
 	if(waitfd == nil) {
 		result <-= sys->sprint("cannot open private wait channel: %r");
@@ -306,6 +324,20 @@ runcommand(cmd: string, outfd: ref Sys->FD, result: chan of string)
 
 	err := sh->systemfd(nil, cmd, waitfd);
 	result <-= err;
+}
+
+# Kill a worker's whole process group.  The exec tool is exempt from the
+# NODEVS restriction that hides /prog from other tools, so it can write here;
+# best-effort, so if /prog is absent the command keeps the pre-fix behaviour.
+killgrp(pid: int)
+{
+	if(pid <= 0)
+		return;
+	ctl := sys->open("/prog/" + string pid + "/ctl", Sys->OWRITE);
+	if(ctl == nil)
+		return;
+	msg := array of byte "killgrp";
+	sys->write(ctl, msg, len msg);
 }
 
 # Timer thread

--- a/emu/Linux/os.c
+++ b/emu/Linux/os.c
@@ -121,11 +121,23 @@ faultwhere(void *a)
 	return;
 #endif
 	fprint(2, "  PC=%p\n", pc);
-	if(dladdr(pc, &di) && di.dli_sname != nil)
+	/*
+	 * dladdr() only sees the dynamic symbol table, so a fault in a static
+	 * function (e.g. the JIT's own genw/typecom) resolves the image but
+	 * leaves dli_sname nil.  Reporting that as "not in any image" is wrong
+	 * and actively misleading: it sent INFR-421 chasing JIT-generated code
+	 * when the PC was in emu's own text the whole time.  Distinguish the
+	 * three cases: named symbol, image-but-no-symbol, and truly no image.
+	 */
+	if(dladdr(pc, &di) == 0)
+		fprint(2, "  PC not in any loaded image (JIT-generated code?)\n");
+	else if(di.dli_sname != nil)
 		fprint(2, "  PC in %s+%#lx\n", di.dli_sname,
 			(ulong)((uintptr)pc - (uintptr)di.dli_saddr));
 	else
-		fprint(2, "  PC not in any image (JIT-generated code?)\n");
+		fprint(2, "  PC in %s+%#lx (no exported symbol; static function — addr2line the offset)\n",
+			di.dli_fname != nil ? di.dli_fname : "?",
+			(ulong)((uintptr)pc - (uintptr)di.dli_fbase));
 	if(up != nil && up->nlocks > 0)
 		fprint(2, "  holding %d lock(s)\n", up->nlocks);
 }

--- a/emu/MacOSX/os.c
+++ b/emu/MacOSX/os.c
@@ -136,11 +136,18 @@ trapBUS(int signo, siginfo_t *info, void *context)
                 Dl_info di;
                 void *pc = (void*)uc->uc_mcontext->__ss.__pc;
                 void *lr = (void*)uc->uc_mcontext->__ss.__lr;
-                if(dladdr(pc, &di) && di.dli_sname != nil)
+                /* dladdr() sees only exported symbols: a static function
+                 * resolves the image but not a name, which must not be
+                 * reported as "not in any image" (INFR-421). */
+                if(dladdr(pc, &di) == 0)
+                    fprint(2, "  PC not in any loaded image (JIT-generated code?)\n");
+                else if(di.dli_sname != nil)
                     fprint(2, "  PC in %s+%#lx\n", di.dli_sname,
                         (ulong)((uintptr)pc - (uintptr)di.dli_saddr));
                 else
-                    fprint(2, "  PC not in any image (JIT-generated code?)\n");
+                    fprint(2, "  PC in %s+%#lx (no exported symbol; static function)\n",
+                        di.dli_fname != nil ? di.dli_fname : "?",
+                        (ulong)((uintptr)pc - (uintptr)di.dli_fbase));
                 if(dladdr(lr, &di) && di.dli_sname != nil)
                     fprint(2, "  LR in %s+%#lx\n", di.dli_sname,
                         (ulong)((uintptr)lr - (uintptr)di.dli_saddr));
@@ -210,11 +217,18 @@ trapSEGV(int signo, siginfo_t *info, void *context)
                 Dl_info di;
                 void *pc = (void*)uc->uc_mcontext->__ss.__pc;
                 void *lr = (void*)uc->uc_mcontext->__ss.__lr;
-                if(dladdr(pc, &di) && di.dli_sname != nil)
+                /* dladdr() sees only exported symbols: a static function
+                 * resolves the image but not a name, which must not be
+                 * reported as "not in any image" (INFR-421). */
+                if(dladdr(pc, &di) == 0)
+                    fprint(2, "  PC not in any loaded image (JIT-generated code?)\n");
+                else if(di.dli_sname != nil)
                     fprint(2, "  PC in %s+%#lx\n", di.dli_sname,
                         (ulong)((uintptr)pc - (uintptr)di.dli_saddr));
                 else
-                    fprint(2, "  PC not in any image (JIT-generated code?)\n");
+                    fprint(2, "  PC in %s+%#lx (no exported symbol; static function)\n",
+                        di.dli_fname != nil ? di.dli_fname : "?",
+                        (ulong)((uintptr)pc - (uintptr)di.dli_fbase));
                 if(dladdr(lr, &di) && di.dli_sname != nil)
                     fprint(2, "  LR in %s+%#lx\n", di.dli_sname,
                         (ulong)((uintptr)lr - (uintptr)di.dli_saddr));

--- a/include/interp.h
+++ b/include/interp.h
@@ -294,6 +294,7 @@ struct Module
 	Import**	ldt;	/* Internal linkage descriptor tables */
 	Handler*	htab;	/* Exception handler table */
 	ulong*	pctab;	/* dis pc to code pc when compiled */
+	ulong	jitsize;	/* bytes of executable memory at prog when compiled */
 	void*	dlm;		/* dynamic C module */
 };
 
@@ -401,6 +402,7 @@ extern	void*		checktype(void*, Type*, char*, int);
 extern	void		cmovw(void*, void*);
 extern	Channel*	cnewc(Type*, void (*)(void), int);
 extern	int		compile(Module*, int, Modlink*);
+extern	void		freejitcode(void*, ulong);
 extern	void		cqadd(Progq**, Prog*);
 extern	void		cqdel(Progq**);
 extern	void		cqdelp(Progq**, Prog*);

--- a/libinterp/comp-amd64.c
+++ b/libinterp/comp-amd64.c
@@ -2572,6 +2572,37 @@ comi(Type *t)
 }
 
 static uchar *typecom_tmp = nil;
+static ulong typecom_tmp_size = 0;
+
+/*
+ * Upper bound on the code comi() + comd() emit for t.
+ *
+ * Both walk t->map, which holds t->np bytes of pointer bitmap, so at most
+ * t->np*8 pointer slots.  Per slot comi() emits one modrm (8 bytes worst
+ * case: REX, opcode, modrm, SIB, disp32) and comd() emits one modrm plus
+ * one rbra (5 bytes), so 21 bytes across the two; 24 leaves headroom.  The
+ * fixed part is a con64 (11) and two RETs.
+ *
+ * This bound is the only thing standing between a pointer-rich type and a
+ * wild write off the end of the measurement buffer, so it is deliberately
+ * generous and is checked after the fact below (INFR-421).
+ */
+#define TYPECOM_FIXED	64
+#define TYPECOM_PERPTR	24
+#define TYPECOM_SLACK	4096	/* absorbs an under-estimate so the check can fire */
+
+static ulong
+typecom_bound(Type *t)
+{
+	uvlong n;
+
+	if(t->np < 0)
+		return 0;
+	n = (uvlong)TYPECOM_FIXED + (uvlong)t->np * 8 * TYPECOM_PERPTR;
+	if(n > 64*1024*1024)		/* refuse absurd type maps rather than try */
+		return 0;
+	return (ulong)n;
+}
 
 /*
  * Slab allocator for typecom init/destroy code blocks.
@@ -2631,23 +2662,41 @@ typecom(Type *t)
 {
 	int n;
 	uchar *tmp;
+	ulong need;
 
 	if(t == nil || t->initialize != 0)
 		return;
 
+	/*
+	 * The scratch buffer must hold everything comi() and comd() can emit
+	 * for this type.  It used to be a fixed 8KB, which a type with a large
+	 * pointer map overruns: /dis/limbo.dis carries one with np=542, needing
+	 * ~100KB, and the overrun wrote past the end of the mapping (INFR-421).
+	 */
+	need = typecom_bound(t);
+	if(need == 0)
+		error(exNomem);
+	if(need > typecom_tmp_size) {
+		if(typecom_tmp != nil) {
 #ifdef __APPLE__
-	if(typecom_tmp == nil) {
-		typecom_tmp = mallocz(8192*sizeof(uchar), 0);
+			free(typecom_tmp);
+#else
+			jitfree(typecom_tmp, typecom_tmp_size);
+#endif
+			typecom_tmp = nil;
+			typecom_tmp_size = 0;
+		}
+#ifdef __APPLE__
+		typecom_tmp = mallocz(need + TYPECOM_SLACK, 0);
 		if(typecom_tmp == nil)
 			error(exNomem);
-	}
 #else
-	if(typecom_tmp == nil) {
-		typecom_tmp = jitmalloc(8192*sizeof(uchar));
+		typecom_tmp = jitmalloc(need + TYPECOM_SLACK);
 		if(typecom_tmp == NULL)
 			error(exNomem);
-	}
 #endif
+		typecom_tmp_size = need + TYPECOM_SLACK;
+	}
 	tmp = typecom_tmp;
 
 	code = tmp;
@@ -2656,6 +2705,16 @@ typecom(Type *t)
 	code = tmp;
 	comd(t);
 	n += code - tmp;
+
+	/*
+	 * If this ever trips the bound above is wrong for the current
+	 * generators.  The slack means we are still inside the buffer, so fail
+	 * loudly here rather than corrupt whatever follows it.
+	 */
+	if((ulong)n > need) {
+		print("typecom: emitted %d > bound %lud for np=%d\n", n, need, t->np);
+		urk();
+	}
 
 	code = typecom_alloc(n);
 	if(code == nil)

--- a/libinterp/comp-amd64.c
+++ b/libinterp/comp-amd64.c
@@ -2712,6 +2712,24 @@ patchex(Module *m, uvlong *p)
 }
 
 /*
+ * Release a compiled module's executable text.  Called from freemod()
+ * when the module's last reference goes away (INFR-421).
+ */
+void
+freejitcode(void *p, ulong size)
+{
+	if(p == nil || size == 0)
+		return;
+#ifdef _WIN32
+	/* jitmalloc() hands back a pointer past an unwind header, and the
+	 * registration has to be undone before the memory is released. */
+	jitfree(p, size);
+#else
+	munmap(p, size);
+#endif
+}
+
+/*
  * Main compilation entry point
  */
 static uchar *compile_tmp = nil;
@@ -2876,6 +2894,7 @@ compile(Module *m, int size, Modlink *ml)
 	free(tinit);
 	free(m->prog);
 	m->prog = (Inst*)base;
+	m->jitsize = n + nlit;
 	m->compiled = 1;
 
 #ifndef __APPLE__

--- a/libinterp/comp-arm64.c
+++ b/libinterp/comp-arm64.c
@@ -2563,17 +2563,39 @@ comd(Type *t)
 	RET_X30();
 }
 
+/*
+ * Worst-case instructions comi() + comd() emit per pointer slot: a mem()
+ * that may need its offset materialised, a con() of a 64-bit address, and
+ * a BLR.  24 leaves headroom over the ~16 they actually take.
+ */
+#define TYPECOM_FIXED	64
+#define TYPECOM_PERPTR	24
+#define TYPECOM_SLACK	1024
+
 void
 typecom(Type *t)
 {
 	int n;
 	u32int *tmp, *start;
-	ulong sz;
+	ulong sz, need;
 
 	if(t == nil || t->initialize != 0)
 		return;
 
-	tmp = mallocz(4096 * sizeof(u32int), 0);
+	/*
+	 * The scratch buffer must hold every instruction comi() and comd() can
+	 * emit for this type.  It used to be a fixed 4096 words, which a type
+	 * with a large pointer map overruns: both walk t->map's t->np bytes, so
+	 * up to t->np*8 pointer slots, and comd() alone emits a mem(), a con()
+	 * of the MacFRP address and a BLR per slot.  /dis/limbo.dis carries a
+	 * type with np=542.  The overrun scribbled past a heap buffer
+	 * (INFR-421; the amd64 side of the same defect faulted outright).
+	 */
+	if(t->np < 0 || (uvlong)t->np * 8 * TYPECOM_PERPTR > 16*1024*1024)
+		error(exNomem);
+	need = TYPECOM_FIXED + (ulong)t->np * 8 * TYPECOM_PERPTR;
+
+	tmp = mallocz((need + TYPECOM_SLACK) * sizeof(u32int), 0);
 	if(tmp == nil)
 		error(exNomem);
 
@@ -2583,6 +2605,17 @@ typecom(Type *t)
 	code = tmp;
 	comd(t);
 	n += code - tmp;
+
+	/*
+	 * If this trips, the bound is wrong for the current generators.  The
+	 * slack keeps us inside the buffer, so fail loudly rather than corrupt
+	 * whatever follows it.
+	 */
+	if((ulong)n > need) {
+		free(tmp);
+		print("typecom: emitted %d > bound %lud for np=%d\n", n, need, t->np);
+		error(exCompile);
+	}
 	free(tmp);
 
 	sz = n * sizeof(u32int);

--- a/libinterp/comp-arm64.c
+++ b/libinterp/comp-arm64.c
@@ -2637,6 +2637,19 @@ patchex(Module *m, ulong *p)
 	}
 }
 
+/*
+ * Release a compiled module's executable text.  Called from freemod()
+ * when the module's last reference goes away (INFR-421).  Without it
+ * every compiled module's mapping leaked for the life of the process.
+ */
+void
+freejitcode(void *p, ulong size)
+{
+	if(p == nil || size == 0)
+		return;
+	munmap(p, size);
+}
+
 int
 compile(Module *m, int size, Modlink *ml)
 {
@@ -2646,7 +2659,7 @@ compile(Module *m, int size, Modlink *ml)
 	u32int *s, *tmp = nil;
 
 	/* JIT enabled */
-	ulong codesize;
+	ulong codesize = 0;
 
 	ulong tmpsize;
 
@@ -2849,6 +2862,7 @@ compile(Module *m, int size, Modlink *ml)
 
 	free(m->prog);
 	m->prog = (Inst*)base;
+	m->jitsize = codesize;
 	m->compiled = 1;
 	free(tinit);
 	free(tmp);
@@ -2857,5 +2871,8 @@ bad:
 	free(patch);
 	free(tinit);
 	free(tmp);
+	if(base != nil && codesize != 0)
+		munmap(base, codesize);
+	base = nil;
 	return 0;
 }

--- a/libinterp/load.c
+++ b/libinterp/load.c
@@ -831,7 +831,18 @@ freemod(Module *m)
 	}
 	free(m->name);
 #if defined(__aarch64__) || defined(__x86_64__) || defined(_M_X64)
-	if(!m->compiled)
+	/*
+	 * On these targets a compiled module's text is an executable
+	 * mapping from the JIT allocator, not pool memory: free() would
+	 * be wrong, so it must be unmapped instead.  Omitting this leaked
+	 * every compiled module's code for the life of the process, which
+	 * an agent can drive without bound simply by running commands
+	 * (INFR-421).  The 32-bit compilers mallocz() their code buffer,
+	 * so free() below is still correct for them.
+	 */
+	if(m->compiled)
+		freejitcode(m->prog, m->jitsize);
+	else
 #endif
 	free(m->prog);
 	free(m->path);

--- a/tests/host/amd64_jit_code_leak_test.sh
+++ b/tests/host/amd64_jit_code_leak_test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Regression test for INFR-421: a compiled module's executable text must be
+# released when the module is freed.
+#
+# freemod() skips free(m->prog) on amd64/arm64 because a compiled module's
+# text is an mmap'd JIT mapping rather than pool memory.  Until the matching
+# freejitcode() was added, nothing unmapped it, so every module load/unload
+# cycle leaked one PROT_EXEC mapping for the life of the process.  Ordinary
+# command execution drives that without bound (each `ls` reloads Ls), so an
+# agent could exhaust vm.max_map_count (65530 by default) and the JIT's
+# near-text address window.
+#
+# The test runs a fixed number of module reloads and asserts the emulator's
+# executable-mapping count does not grow with them.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+[ "$OBJTYPE" = amd64 ] || { echo "SKIP: amd64 JIT test"; exit 77; }
+[ -x "$EMU" ] || { echo "SKIP: emu not found at $EMU"; exit 77; }
+[ -r /proc/self/maps ] || { echo "SKIP: needs /proc/<pid>/maps"; exit 77; }
+
+# Source pin.  The behavioural check below needs a readable /proc/<pid>/maps
+# for the emulator, which some sandboxes and yama ptrace_scope settings deny.
+# These assertions have no such dependency, so the contract stays enforced
+# even when the measurement has to skip.
+fails=0
+if ! grep -q 'freejitcode(m->prog, m->jitsize)' "$ROOT/libinterp/load.c"; then
+	echo "FAIL: freemod() does not release compiled module text"
+	fails=$((fails + 1))
+fi
+for c in comp-amd64 comp-arm64; do
+	if ! grep -q '^freejitcode(void \*p, ulong size)' "$ROOT/libinterp/$c.c"; then
+		echo "FAIL: $c.c does not define freejitcode()"
+		fails=$((fails + 1))
+	fi
+done
+if ! grep -q 'ulong	jitsize;' "$ROOT/include/interp.h"; then
+	echo "FAIL: Module has no jitsize field to size the unmap with"
+	fails=$((fails + 1))
+fi
+[ "$fails" -eq 0 ] || exit 1
+echo "PASS: source contract (freemod releases JIT text on amd64/arm64)"
+
+REPRO="$ROOT/tmp/amd64_jit_code_leak_repro.sh"
+LOG="$(mktemp)"
+trap 'rm -f "$REPRO" "$LOG"' EXIT HUP INT TERM
+
+# Report the executable-mapping count at a low and a high reload count from
+# inside one process, so the two samples are directly comparable.
+cat >"$REPRO" <<'EOF'
+#!/dis/sh.dis
+
+load std
+path=(/dis .)
+
+for (i in `{seq 1 100}) {
+	ls /dis > /dev/null
+}
+echo '@@LEAK mark early'
+for (i in `{seq 1 400}) {
+	ls /dis > /dev/null
+}
+echo '@@LEAK mark late'
+# Stay alive so the host side can sample /proc/<pid>/maps at this point.
+sleep 60
+echo '@@LEAK done'
+EOF
+
+"$EMU" -c1 -r"$ROOT" /dis/sh.dis /tmp/amd64_jit_code_leak_repro.sh >"$LOG" 2>&1 &
+emupid=$!
+
+# emu rewrites its argv, so track the pid we spawned directly.
+sample() {
+	awk '$2 ~ /x/ { n++ } END { print n+0 }' "/proc/$emupid/maps" 2>/dev/null
+}
+
+early=""
+late=""
+waited=0
+while [ "$waited" -lt 300 ]; do
+	if [ -z "$early" ] && grep -q '@@LEAK mark early' "$LOG" 2>/dev/null; then
+		early="$(sample)"
+	fi
+	if grep -q '@@LEAK mark late' "$LOG" 2>/dev/null; then
+		late="$(sample)"
+		break
+	fi
+	[ -d "/proc/$emupid" ] || break
+	sleep 1
+	waited=$((waited + 1))
+done
+kill -9 "$emupid" 2>/dev/null
+wait "$emupid" 2>/dev/null
+
+if ! grep -q '^@@LEAK mark late$' "$LOG"; then
+	echo "FAIL: repro did not reach the late mark"
+	sed -n '1,40p' "$LOG"
+	exit 1
+fi
+if [ -z "$early" ] || [ -z "$late" ] || [ "$early" -eq 0 ]; then
+	echo "SKIP: could not sample executable mappings (early='$early' late='$late')"
+	exit 77
+fi
+
+# 400 further reloads leaked ~400 mappings before the fix.  Allow generous
+# headroom for legitimately resident modules and allocator noise, while
+# still failing decisively on per-reload growth.
+limit=$((early + 64))
+echo "executable mappings: after 100 reloads=$early, after 500=$late (limit $limit)"
+if [ "$late" -gt "$limit" ]; then
+	echo "FAIL: JIT mappings grow with module reloads — compiled module text is leaking"
+	exit 1
+fi
+
+echo "PASS: compiled module text is released on unload"

--- a/tests/host/amd64_jit_typecom_bound_test.sh
+++ b/tests/host/amd64_jit_typecom_bound_test.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Regression test for INFR-421: typecom()'s measurement scratch buffer must
+# be sized for the type it is measuring.
+#
+# comi() and comd() both walk t->map, which covers t->np*8 pointer slots, and
+# emit per-slot code into a scratch buffer.  That buffer was a fixed 8KB
+# (amd64) / 4096 words (arm64).  /dis/limbo.dis carries a type with np=542,
+# needing ~100KB, so measuring it ran off the end of the buffer:
+#
+#   genw (comp-amd64.c:580)  *(u32int*)code = (u32int)o;
+#     code = typecom_tmp + 8191, buffer is 8192
+#   -> SIGSEGV, page-aligned address, si_code=1 (unmapped)
+#
+# emu's fault handler reported it as "PC not in any image (JIT-generated
+# code?)" because genw is static and dladdr cannot name it, which is why it
+# read like a JIT codegen bug rather than a buffer overflow in the compiler.
+#
+# Loading limbo.dis under -c1 is enough to trigger it.  Several concurrent
+# loads make it near-certain and match the shape the escape-room campaign hit
+# (an exec tool that abandons its child on timeout, leaving orphaned shells
+# each loading the compiler).
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+[ "$OBJTYPE" = amd64 ] || { echo "SKIP: amd64 JIT test"; exit 77; }
+[ -x "$EMU" ] || { echo "SKIP: emu not found at $EMU"; exit 77; }
+[ -f "$ROOT/dis/limbo.dis" ] || { echo "SKIP: limbo.dis not built"; exit 77; }
+
+fails=0
+if ! grep -q 'typecom_bound' "$ROOT/libinterp/comp-amd64.c"; then
+	echo "FAIL: comp-amd64.c does not size the typecom scratch from the type"
+	fails=$((fails + 1))
+fi
+if grep -q 'typecom_tmp = jitmalloc(8192\*sizeof(uchar))' "$ROOT/libinterp/comp-amd64.c"; then
+	echo "FAIL: comp-amd64.c still uses a fixed 8KB typecom scratch buffer"
+	fails=$((fails + 1))
+fi
+if grep -q 'tmp = mallocz(4096 \* sizeof(u32int), 0)' "$ROOT/libinterp/comp-arm64.c"; then
+	echo "FAIL: comp-arm64.c still uses a fixed 4096-word typecom scratch buffer"
+	fails=$((fails + 1))
+fi
+[ "$fails" -eq 0 ] || exit 1
+echo "PASS: source contract (typecom scratch is sized from t->np)"
+
+REPRO="$ROOT/tmp/amd64_jit_typecom_bound_repro.sh"
+LOG="$(mktemp)"
+trap 'rm -f "$REPRO" "$LOG" "$ROOT/tmp/infr421_bound_probe.b" "$ROOT/tmp/infr421_bound_probe".*.dis' EXIT HUP INT TERM
+
+cat >"$ROOT/tmp/infr421_bound_probe.b" <<'EOF'
+implement Probe;
+include "sys.m";
+include "draw.m";
+sys: Sys;
+Probe: module { init: fn(nil: ref Draw->Context, nil: list of string); };
+init(nil: ref Draw->Context, nil: list of string)
+{
+	sys = load Sys Sys->PATH;
+	sys->print("INFR421_BOUND_OK\n");
+}
+EOF
+
+cat >"$REPRO" <<'EOF'
+#!/dis/sh.dis
+
+load std
+path=(/dis .)
+
+# Several concurrent limbo.dis loads, as the campaign's abandoned exec
+# children produced.  Each load compiles the type that overran the buffer.
+for (r in `{seq 1 8}) {
+	limbo -o /tmp/infr421_bound_probe.1.dis /tmp/infr421_bound_probe.b &
+	limbo -o /tmp/infr421_bound_probe.2.dis /tmp/infr421_bound_probe.b &
+	limbo -o /tmp/infr421_bound_probe.3.dis /tmp/infr421_bound_probe.b &
+	ls /dis > /dev/null
+	sleep 1
+}
+sleep 4
+echo '@@BOUND done'
+EOF
+
+timeout 240 "$EMU" -c1 -r"$ROOT" /dis/sh.dis /tmp/amd64_jit_typecom_bound_repro.sh \
+	>"$LOG" 2>&1
+rc=$?
+case "$rc" in
+	0|124|137) ;;
+	*) echo "FAIL: emulator exited with status $rc"; sed -n '1,40p' "$LOG"; exit 1 ;;
+esac
+
+if ! grep -q '^@@BOUND done$' "$LOG"; then
+	echo "FAIL: repro did not run to completion"
+	sed -n '1,40p' "$LOG"
+	exit 1
+fi
+if grep -q 'segmentation violation' "$LOG" || grep -q '^SEGV' "$LOG"; then
+	echo "FAIL: typecom scratch overrun still faults"
+	grep -nE 'SEGV|segmentation violation|PC=' "$LOG" | sed -n '1,10p'
+	exit 1
+fi
+if grep -q 'typecom: emitted' "$LOG"; then
+	echo "FAIL: emitted code exceeded the typecom size bound"
+	grep -n 'typecom: emitted' "$LOG" | sed -n '1,5p'
+	exit 1
+fi
+
+echo "PASS: concurrent limbo.dis loads compile without overrunning the scratch"

--- a/tests/host/exec_timeout_kill_test.sh
+++ b/tests/host/exec_timeout_kill_test.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Regression test for INFR-421 (follow-up): the exec tool must not abandon a
+# command that overruns its deadline.
+#
+# exec.b spawns the command in a worker goroutine and returns after a 5s
+# timeout (or a 16KB output cap).  It used to just stop reading, leaving the
+# command running unsupervised outside the tool's accounting.  Two such
+# abandoned limbo.dis compiles are what were still JIT-compiling when the
+# emulator faulted in the escape campaign, and INFR-434's step-9 exec never
+# returned because a state-modifying command was left blocked with nothing to
+# release it.
+#
+# The fix makes the worker a process-group leader (NEWPGRP), reports its pid,
+# and — if the command is still running when the tool stops reading — writes
+# "killgrp" to /prog/<pid>/ctl so the whole subtree dies with the tool call.
+#
+# This test checks two things without needing the full tools9p COW stack
+# (which the tools9p_* tests already exercise):
+#   1. source contract — exec.b wires the pid channel, NEWPGRP and killgrp;
+#   2. mechanism — killgrp on a NEWPGRP leader actually terminates the group.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+fails=0
+E="$ROOT/appl/veltro/tools/exec.b"
+grep -q 'sys->pctl(Sys->NEWPGRP, nil)'          "$E" || { echo "FAIL: exec.b worker is not a process-group leader"; fails=$((fails+1)); }
+grep -q 'killgrp(workerpid)'                    "$E" || { echo "FAIL: exec.b does not kill the worker group when still running"; fails=$((fails+1)); }
+grep -q 'killgrp(pid: int)'                     "$E" || { echo "FAIL: exec.b has no killgrp helper"; fails=$((fails+1)); }
+grep -q '"killgrp"'                             "$E" || { echo "FAIL: exec.b killgrp does not write the killgrp control message"; fails=$((fails+1)); }
+[ "$fails" -eq 0 ] && echo "PASS: source contract (exec.b kills the worker group on timeout/overrun)"
+
+[ -x "$EMU" ] || { echo "SKIP: emu not found at $EMU"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+[ -x "$LIMBO" ] || {
+	echo "SKIP: native limbo not built — source contract only"
+	[ "$fails" -eq 0 ] && exit 0 || exit 1
+}
+
+WORK="$ROOT/tmp/exec_killgrp_mech"
+SRC="$WORK.b"
+DIS="$WORK.dis"
+trap 'rm -f "$SRC" "$DIS"' EXIT HUP INT TERM
+
+cat >"$SRC" <<'EOF'
+implement KillgrpMech;
+include "sys.m";
+	sys: Sys;
+include "draw.m";
+KillgrpMech: module { init: fn(nil: ref Draw->Context, nil: list of string); };
+
+# Mirror exec.b: a worker becomes a process-group leader, reports its pid,
+# spawns a long child, and idles.  killgrp on that pid must take out both.
+worker(pidch: chan of int)
+{
+	pid := sys->pctl(Sys->NEWPGRP, nil);
+	pidch <-= pid;
+	spawn longchild();
+	sys->sleep(60000);
+}
+longchild() { sys->sleep(60000); }
+
+exists(pid: int): int
+{
+	fd := sys->open("/prog/" + string pid + "/status", Sys->OREAD);
+	if(fd == nil) return 0;
+	return 1;
+}
+killgrp(pid: int)
+{
+	ctl := sys->open("/prog/" + string pid + "/ctl", Sys->OWRITE);
+	if(ctl == nil) return;
+	msg := array of byte "killgrp";
+	sys->write(ctl, msg, len msg);
+}
+init(nil: ref Draw->Context, nil: list of string)
+{
+	sys = load Sys Sys->PATH;
+	pidch := chan of int;
+	spawn worker(pidch);
+	wpid := <-pidch;
+	sys->sleep(500);
+	before := exists(wpid);
+	killgrp(wpid);
+	sys->sleep(500);
+	after := exists(wpid);
+	if(before == 1 && after == 0)
+		sys->print("MECH: PASS\n");
+	else
+		sys->print("MECH: FAIL before=%d after=%d\n", before, after);
+}
+EOF
+
+"$LIMBO" -I"$ROOT/module" -o "$DIS" "$SRC" || {
+	echo "FAIL: could not compile the mechanism probe"; exit 1; }
+
+OUT="$(timeout 30 "$EMU" -r"$ROOT" /dis/sh.dis -c "${DIS#$ROOT}" 2>&1)"
+if echo "$OUT" | grep -q '^MECH: PASS$'; then
+	echo "PASS: killgrp terminates a NEWPGRP worker group"
+else
+	echo "FAIL: killgrp did not terminate the group"
+	echo "$OUT" | grep -vE '^JIT|sdl3_pre' | tail -5
+	exit 1
+fi
+
+[ "$fails" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Root-causes and fixes the JIT crash that stopped the source-aware escape-room campaigns (INFR-421). The reported fault was **not** the suspects named on the ticket (typecom slab exhaustion / a JIT mapping leak) — it is a buffer overflow in the compiler's own `typecom()`, misreported as JIT-generated code by an over-eager fault handler.

Deterministic, no-LLM/no-credit reproducer: several concurrent loads of `limbo.dis` under `-c1`. On stock `a3a7a626` that gives **90 SIGSEGVs, all at one PC and one page-aligned address**, matching the campaign evidence exactly; with this branch, **none**.

> Rebased onto current master. The INFR-434 grind.py scorer fix that this branch originally carried is now dropped — #569 landed the same fix independently, so this PR is purely the INFR-421 emulator/JIT/tool work and no longer touches `tests/agent-harness/grind.py`.

## What the crash actually was

`typecom()` measures the code `comi()`/`comd()` will emit by generating it into a scratch buffer first. Both walk `t->map` (up to `t->np*8` pointer slots); the buffer was a fixed 8KB on amd64 / 4096 words on arm64, with no bound. `/dis/limbo.dis` carries a type with `np=542` needing ~100KB, so measuring it runs off the end:

```
genw (comp-amd64.c:580)  *(u32int*)code = (u32int)o;
  code = typecom_tmp + 8191, buffer is 8192   ->  SIGSEGV, next (unmapped) page
```

It read as a JIT codegen bug because emu's handler prints "PC not in any image (JIT-generated code?)": `genw` is `static`, so `dladdr` can't name it and the handler guessed. The faulting PC was in emu's own text the whole time.

The agent that triggered it was doing exactly what the qualification gate asked — compiling a trivial probe — and the exec tool abandoned two timed-out `limbo.dis` compiles that were still running when the fault hit.

## Commits

- **`fix(jit): size the typecom scratch buffer from the type`** — the crash. Size the scratch from `t->np` with a documented per-slot bound, grow on demand, and check the emitted size against the bound afterwards with slack. Both 64-bit compilers.
- **`fix(jit): release compiled module text on unload`** — a real, separate leak found on the way: `freemod()` skips `free(m->prog)` for compiled modules on amd64/arm64 (the text is an mmap'd mapping) but nothing unmapped it, so every compiled module's code leaked for the process lifetime. `ls /dis` ×1100 → 1,932 live executable mappings; with the fix, 11 and flat.
- **`fix(emu): report faults in static functions as in-image, not JIT`** — distinguish named symbol / image-without-symbol / truly-no-image, so a static-function fault prints the image + offset to `addr2line` instead of the misleading "JIT-generated code?".
- **`fix(veltro): kill a timed-out exec command's process group`** — the worker is a `NEWPGRP` leader; on timeout/overrun the tool `killgrp`s it instead of abandoning it. This is what left two compiles running into the fault, and why INFR-434's step-9 exec never returned.

## Validation

- Concurrent-`limbo` reproducer: **90 SEGV → 0** (re-confirmed after rebase).
- Full internal suite under `-c1`: zero faults, same three pre-existing environmental failures.
- `jittest` 181/181; `jitbug`/`jitbug2`/`jitshift`/`jitcrash` pass; `amd64_jit_typecom_slab` pass.
- New tests, each negative-controlled against stock:
  - `amd64_jit_typecom_bound_test.sh` — source pin + concurrent-load behavioural check
  - `amd64_jit_code_leak_test.sh` — mapping count flat vs stock's linear growth (539→1034 reverted; 31→31 fixed)
  - `exec_timeout_kill_test.sh` — `killgrp` removes the NEWPGRP group from `/prog`

## Security note

The typecom defect is memory corruption, not just availability: an unbounded write sized by `t->np` from a Dis type descriptor, landing next to the JIT's executable mappings. Here it hit an unmapped page and faulted; on arm64 the same overrun runs past a heap buffer and corrupts silently. This run showed no escape or exfiltration (audit chain verifies clean, no canary hits, no unexpected egress), but "candidate agent-triggerable DoS" understates it. Controllability was not investigated.

## Not in this PR

Rerunning the campaign stages (source-control → qualification → live) — operational, needs the rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
