### PR TITLE
fix(veltro): share COW overlays across tools by keying on path (INFR-435)

### DIFF
--- a/appl/veltro/nsconstruct.b
+++ b/appl/veltro/nsconstruct.b
@@ -1215,10 +1215,26 @@ directwritepath(path: string): int
 	return path == "/mnt/msg/draft" || path == "/mnt/msg/flag";
 }
 
+# Stable 32-bit FNV-1a hash of a path, rendered as 8 hex digits.  The COW
+# overlay for a granted writable path must be keyed by the path itself, not by
+# where it happens to sit in a per-call list: exec stages a different (larger)
+# writable set than the in-process tools, so a positional index put the same
+# granted path on different overlays for exec vs write/list/read — a file
+# written by one tool was then invisible to another (INFR-435).
+overlaykey(path: string): string
+{
+	h := int 16r811c9dc5;
+	b := array of byte path;
+	for(i := 0; i < len b; i++) {
+		h = h ^ int b[i];
+		h = h * 16r01000193;
+	}
+	return sys->sprint("%8.8ux", h);
+}
+
 overlaywritepaths(paths: list of string, actid: int): string
 {
 	cowfs: Cowfs;
-	seq := 0;
 	for(p := paths; p != nil; p = tl p) {
 		fullpath := hd p;
 		if(directwritepath(fullpath))
@@ -1231,8 +1247,9 @@ overlaywritepaths(paths: list of string, actid: int): string
 		(ok, nil) := sys->stat(fullpath);
 		if(ok < 0)
 			continue;
-		overlaydir := sys->sprint("/tmp/veltro/cow/%d-%d", actid, seq);
-		seq++;
+		# Keyed by (activity, path) so every tool that is granted the same
+		# writable path shares one overlay and sees the same files.
+		overlaydir := sys->sprint("/tmp/veltro/cow/%d-%s", actid, overlaykey(fullpath));
 		merr := mkdirp(overlaydir);
 		if(merr != nil)
 			return sys->sprint("cowfs overlay %s: %s", overlaydir, merr);

--- a/tests/host/tools9p_write_exec_view_test.sh
+++ b/tests/host/tools9p_write_exec_view_test.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Regression test for INFR-435: write, list, read and exec must resolve a
+# granted writable path to the same backing object.
+#
+# Each tool invocation forks a namespace and stages every granted writable
+# path through a cowfs overlay (nsconstruct.overlaywritepaths). The overlay
+# used to be keyed by /tmp/veltro/cow/<actid>-<seq>, where <seq> was the
+# position of the path in that invocation's writable-path list. exec stages a
+# larger writable set than the in-process tools (execwritepaths adds
+# /lib/veltro, /lib/certs, /dis/veltro), so the same granted path landed at a
+# different index — and therefore a different, empty overlay — for exec than
+# for write/list/read. A file written through write was then invisible to a
+# command run through exec, even at the identical absolute path, which blocked
+# the source-assisted red-team qualification gate.
+#
+# The fix keys the overlay by the path itself (a stable hash), so every tool
+# granted the same writable path shares one overlay.
+#
+# This drives the real per-invocation asyncexec/restrictns/cowfs path via
+# tools9p -a 1 (an activity-scoped namespace, the same construction a
+# delegated child gets), not a host filesystem shortcut.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+fails=0
+NS="$ROOT/appl/veltro/nsconstruct.b"
+grep -q 'overlaykey(' "$NS" || { echo "FAIL: overlaywritepaths does not key the cow overlay by path"; fails=$((fails+1)); }
+if grep -q 'cow/%d-%d", actid, seq' "$NS"; then
+	echo "FAIL: cow overlay still keyed by positional seq, not path"; fails=$((fails+1)); fi
+[ "$fails" -eq 0 ] && echo "PASS: source contract (cow overlay keyed by path, shared across tools)"
+
+[ -x "$EMU" ] || { echo "SKIP: emu not found at $EMU"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+[ -f "$ROOT/dis/veltro/tools9p.dis" ] || { echo "SKIP: tools9p.dis not built"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+[ -f "$ROOT/dis/limbo.dis" ] || { echo "SKIP: limbo.dis not built"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+
+DRIVE="$ROOT/tmp/tools9p_write_exec_view_drive.sh"
+LOG="$(mktemp)"
+trap 'rm -f "$DRIVE" "$LOG"' EXIT HUP INT TERM
+
+cat >"$DRIVE" <<'EOF'
+path=(/dis/veltro /dis/cmd /dis .)
+rm -r /tmp/veltro/probe-sdk /tmp/veltro/cow >[2] /dev/null
+mkdir -p /tmp/veltro/probe-sdk/dis
+cp /dis/limbo.dis /tmp/veltro/probe-sdk/dis/limbo.dis
+cp -r /module /tmp/veltro/probe-sdk/module
+tools9p -a 1 -p /tmp/veltro/probe-sdk:rw write list read exec & sleep 2
+echo '/tmp/veltro/probe-sdk/qualification-probe.b
+implement Probe;
+include "sys.m";
+	sys: Sys;
+include "draw.m";
+Probe: module { init: fn(nil: ref Draw->Context, nil: list of string); };
+init(nil: ref Draw->Context, nil: list of string)
+{
+	sys = load Sys Sys->PATH;
+	sys->print("INFR434_PROBE_OK");
+}' > /tool/write/ctl
+cat /tool/write/ctl
+echo '@@LIST'
+echo '/tmp/veltro/probe-sdk' > /tool/list/ctl
+cat /tool/list/ctl
+echo '@@COMPILE'
+echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/qualification-probe.dis /tmp/veltro/probe-sdk/qualification-probe.b' > /tool/exec/ctl
+cat /tool/exec/ctl
+echo '@@RUN'
+echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl
+cat /tool/exec/ctl
+echo '@@DRIVEDONE'
+EOF
+
+timeout 90 "$EMU" -r"$ROOT" /dis/sh.dis -c "run /tmp/tools9p_write_exec_view_drive.sh" >"$LOG" 2>&1
+rc=$?
+case "$rc" in 0|124|137) ;; *) echo "FAIL: driver exited with status $rc"; sed -n '1,40p' "$LOG"; exit 1 ;; esac
+
+out="$(grep -vE '^JIT|sdl3_pre|mounted on' "$LOG")"
+
+# list must see the written file
+if ! echo "$out" | grep -q 'qualification-probe.b'; then
+	echo "FAIL: list tool did not see the written probe"; echo "$out" | sed -n '1,40p'; exit 1; fi
+
+# exec's compiler must OPEN the write-tool file (the bug reported 'file does not exist')
+if echo "$out" | grep -q 'qualification-probe.b.*file does not exist'; then
+	echo "FAIL: exec cannot see the file written through write (INFR-435 not fixed)"
+	echo "$out" | sed -n '1,40p'; exit 1; fi
+
+# and the whole compile+run effect must succeed with the probe marker
+if ! echo "$out" | grep -q '^INFR434_PROBE_OK'; then
+	echo "FAIL: write->compile->exec did not produce INFR434_PROBE_OK"
+	echo "$out" | sed -n '1,40p'; exit 1; fi
+
+echo "PASS: write/list/exec share the granted writable path (compile+run INFR434_PROBE_OK)"
+[ "$fails" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Fixes INFR-435: a delegated agent granted a writable path saw **inconsistent namespaces across tools** — `write` created a file, `list`/`read` saw it, but a command run through `exec` reported the same absolute path did not exist. That made a truthful-looking writable capability non-composable and blocked the source-assisted red-team qualification gate (the agent did the required work; the compiler just couldn't open the file it had written).

## Root cause

Every tool invocation forks a namespace and stages each granted writable path through a cowfs overlay in `nsconstruct.overlaywritepaths()`. The overlay directory was `/tmp/veltro/cow/<actid>-<seq>`, where `<seq>` was the **position of the path in that invocation's writable-path list**.

- In-process tools (`write`/`list`/`read`) stage `genwritepaths()` — just the granted rw paths. `probe-sdk` → index 0 → overlay `…/1-0`.
- `exec` stages `execwritepaths()`, which prepends `/lib/veltro`, `/lib/certs`, `/dis/veltro`. `probe-sdk` → index 3 → overlay `…/1-3`.

So the same granted path resolved to a **different, empty overlay** for exec than for the other tools. Proven on disk from the reproducer:

```
/tmp/veltro/cow/1-0/probe.b     <- write tool put it here
/tmp/veltro/cow/1-1  1-2  1-3   <- exec's probe-sdk overlay (empty)
```

Pre-staged files (`dis/`, `module/`, `tests/`) live in the cowfs **lower** layer (the real dir) and were always visible — which is why exec could run the staged `nsaudit.dis`/`limbo.dis` but never a file the agent *wrote*.

## Fix

Key the overlay by the **path** (a stable 32-bit FNV-1a hash) instead of a positional index, so every tool granted the same writable path shares one overlay:

```
/tmp/veltro/cow/<actid>-<hash(path)>
```

One overlay per (activity, path). No change to attenuation — only explicitly granted writable subtrees are shared.

## Validation

Deterministic, no-LLM, on a delegated-style namespace (`tools9p -a 1`, the same asyncexec/restrictns/cowfs construction a delegated child gets):

- **stock:** `write` succeeds → `exec` compile: `can't open …/qualification-probe.b: file does not exist` (the exact campaign symptom).
- **fixed:** `write` → `exec` compile (no output = success) → `exec` run → **`INFR434_PROBE_OK`**.

New `tests/host/tools9p_write_exec_view_test.sh` (source pin + the write→list→compile→run effect), negative-controlled against stock. Namespace regression suite unchanged with the fix: `namespace_manifest_invariants` 6/6, `nsaudit_path_semantics` PASS, `tools9p_activity_ns` 4/4, `exec_confinement` PASS. (`tools9p_basics` fails identically on stock — pre-existing environmental "tools9p failed to start", not this change.)

## Not in this PR

The `/prog/<pid>/wait` panic on compound exec commands (also listed on INFR-435) is a **separate** issue: the exec worker applies `NODEVS` for containment, and `sh`'s per-fork `waitfd()` needs `#p`/`/prog`, which `NODEVS` blocks — so any exec command that forks (redirects, pipes, sequences) panics, while single commands work. `#p` (`proggen`) is **not** process-group-scoped, so there's no trivial way to hand the child a working `/prog` without exposing other processes; a correct fix needs a restricted-progdev proxy or an exec process-model change, with containment review. It is reduced in impact by this fix — the agent no longer needs shell-native `echo > file`, since `write`+`exec` now compose — and should be its own change. Details on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
