### PR TITLE
fix(sh): exec forking commands fail cleanly instead of panicking under NODEVS (INFR-436)

### DIFF
--- a/appl/cmd/sh/sh.b
+++ b/appl/cmd/sh/sh.b
@@ -690,9 +690,13 @@ runasync(ctxt: ref Context, copyenv: int, argv: list of ref Listnode, redirs: re
 
 	pid := sys->pctl(sys->FORKFD, nil);
 	if (DEBUG) debug(sprint("in async (len redirs: %d)", len redirs.r));
-	ctxt = ctxt.copy(copyenv);
 	exprop := ref Expropagate;
 	{
+		# copy() reopens the wait file, which can fail under a restricted
+		# namespace (INFR-436).  Keep it inside the guarded block so the
+		# failure is reported to the parent through startchan below rather
+		# than killing this process before it ever syncs.
+		ctxt = ctxt.copy(copyenv);
 		newfdl := doredirs(ctxt, redirs);
 		redirs = nil;
 		if (newfdl != nil)
@@ -1061,7 +1065,14 @@ waitfd(): ref Sys->FD
 	if (waitfd == nil)
 		waitfd = sys->open("/prog/"+wf, Sys->OREAD);
 	if (waitfd == nil)
-		panic(sys->sprint("cannot open wait file: %r"));
+		# A process that cannot open its own wait file cannot reap
+		# children.  In normal operation this never happens; it does when
+		# a command runs in a namespace with the process filesystem hidden
+		# (e.g. the Veltro exec tool applies NODEVS for containment, so a
+		# forked sub-shell cannot open #p).  Raise a catchable failure
+		# rather than panic() the interpreter (INFR-436): the caller turns
+		# it into a clean command error instead of a broken shell.
+		raise "fail:cannot open wait file (process filesystem not available): " + sys->sprint("%r");
 	return waitfd;
 }
 

--- a/tests/host/exec_fork_no_panic_test.sh
+++ b/tests/host/exec_fork_no_panic_test.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Regression test for INFR-436: a command run through the Veltro exec tool
+# that makes the shell fork a sub-process (a redirect, pipe, ';' sequence, or
+# background job) must not panic the interpreter.
+#
+# The exec worker applies NODEVS for containment, which hides the process
+# filesystem (#p / /prog). sh's waitfd() reopens #p/<pid>/wait on every fork
+# (runasync / Context.copy); under NODEVS that open fails, and it used to
+# panic() — aborting the whole shell and, because the panic happened in the
+# forked sub-shell before it synced with its parent, hanging the exec worker
+# until its 5s timeout killed the process group.
+#
+# Fix: waitfd() raises a catchable "fail:" instead of panic(), and runasync
+# performs its context copy inside the guarded block, so the failure is
+# reported to the parent as a clean command error. Normal (unrestricted)
+# shell forking is unaffected: waitfd() only fails when the process
+# filesystem is hidden.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$(dirname "$0")/common.sh"
+set -u
+
+fails=0
+SH_SRC="$ROOT/appl/cmd/sh/sh.b"
+if grep -q 'panic(sys->sprint("cannot open wait file' "$SH_SRC"; then
+	echo "FAIL: waitfd() still panics when it cannot open the wait file"; fails=$((fails+1)); fi
+grep -q 'raise "fail:cannot open wait file' "$SH_SRC" || { echo "FAIL: waitfd() does not raise a catchable failure"; fails=$((fails+1)); }
+[ "$fails" -eq 0 ] && echo "PASS: source contract (waitfd raises instead of panicking)"
+
+[ -x "$EMU" ] || { echo "SKIP: emu not found at $EMU"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+[ -f "$ROOT/dis/veltro/tools9p.dis" ] || { echo "SKIP: tools9p.dis not built"; [ "$fails" -eq 0 ] && exit 0 || exit 1; }
+
+DRIVE="$ROOT/tmp/exec_fork_no_panic_drive.sh"
+LOG="$(mktemp)"
+trap 'rm -f "$DRIVE" "$LOG"' EXIT HUP INT TERM
+
+# 1. exec: a redirect (forks a sub-shell) must not panic.
+# 2. normal shell (unrestricted): redirect, pipe and backquote still work.
+cat >"$DRIVE" <<'EOF'
+path=(/dis/veltro /dis/cmd /dis .)
+rm -r /tmp/veltro/probe-sdk >[2] /dev/null
+mkdir -p /tmp/veltro/probe-sdk
+tools9p -a 1 -p /tmp/veltro/probe-sdk:rw write list exec & sleep 2
+echo '@@EXECREDIR'
+echo 'echo hi > /tmp/veltro/probe-sdk/out.txt' > /tool/exec/ctl
+cat /tool/exec/ctl
+echo ''
+echo '@@NORMALSHELL'
+load std
+echo r-`{echo bq} > /tmp/normalshell.txt
+cat /tmp/normalshell.txt
+echo p-abc | tr a-z A-Z
+echo '@@DRIVEDONE'
+EOF
+
+timeout 60 "$EMU" -r"$ROOT" /dis/sh.dis -c "run /tmp/exec_fork_no_panic_drive.sh" >"$LOG" 2>&1
+rc=$?
+case "$rc" in 0|124|137) ;; *) echo "FAIL: driver exited with status $rc"; sed -n '1,40p' "$LOG"; exit 1 ;; esac
+out="$(grep -vE '^JIT|sdl3_pre|mounted on' "$LOG")"
+
+# The whole point: no panic, and no interpreter break.
+if echo "$out" | grep -qiE 'sh panic:|Broken: .?panic'; then
+	echo "FAIL: exec forking command still panics the shell"
+	echo "$out" | sed -n '1,40p'; exit 1; fi
+if ! echo "$out" | grep -q '@@DRIVEDONE'; then
+	echo "FAIL: driver did not run to completion (shell likely crashed)"
+	echo "$out" | sed -n '1,40p'; exit 1; fi
+
+# Normal, unrestricted shell forking must still work.
+if ! echo "$out" | grep -q 'r-bq'; then
+	echo "FAIL: normal shell redirect+backquote regressed"; echo "$out" | sed -n '1,40p'; exit 1; fi
+if ! echo "$out" | grep -q 'P-ABC'; then
+	echo "FAIL: normal shell pipe regressed"; echo "$out" | sed -n '1,40p'; exit 1; fi
+
+echo "PASS: exec forking command fails cleanly (no panic); normal shell forking intact"
+[ "$fails" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Fixes INFR-436 (split from INFR-435): a command run through the Veltro `exec` tool that makes the shell fork a sub-process — a redirect, pipe, `;` sequence, or background job — aborted with

```
sh panic: cannot open wait file: '/prog/<pid>' file does not exist
[Sh] Broken: "panic"
```

and broke the interpreter. Single external commands (the qualification compile/execute steps) work; only commands that fork inside the shell failed.

## Root cause

The exec worker applies `NODEVS` for containment — without it the agent's shell code could `bind '#p'` and read or signal other processes (emu's prog device enumerates all processes and gates access only by owner/`progmode`, and the escape target runs single-user, so `#p` must be blocked). `NODEVS` hides the process filesystem, so `sh`'s `waitfd()` — which reopens `#p/<pid>/wait` on every fork (`runasync`, `Context.copy`) — can't open it and used to `panic()`. Worse, the panic fired in the forked sub-shell *before* it synced with its parent, so the exec worker then hung until its 5s timeout killed the process group.

## Fix

`waitfd()` raises a catchable `fail:` instead of `panic()`, and `runasync` does its context copy inside the guarded block so the failure is reported to the parent through `startchan` as a clean command error. A forking command under exec now fails **immediately** with a clear message — no panic, no interpreter break, no 5s hang.

Normal, unrestricted shell forking is unaffected: `waitfd()` only fails when the process filesystem is hidden, which never happens outside a NODEVS-restricted namespace.

## Validation (deterministic, no LLM)

- **stock:** `echo hi > file` under exec → `sh panic: cannot open wait file`, exit 1.
- **fixed:** same command → `error: cannot open wait file (process filesystem not available)`, no panic, no timeout.
- Normal shell (unrestricted) still works: redirect, append, pipe, pipe→redirect, nested backquotes, async jobs, `;` sequences — all verified.
- Existing controls pass: `exec_confinement_test` PASS, `tools9p_activity_ns_test` 4/4.
- New `tests/host/exec_fork_no_panic_test.sh` (source pin + a redirect under exec does not panic + normal shell forking intact), negative-controlled against stock.

## Scope / follow-up

This makes exec **robust** against forking commands (clean failure), but does not yet let them **reap** sub-processes under `NODEVS` — that needs a process-group-scoped `/prog` proxy mounted before `NODEVS`, which is a larger, containment-reviewed change. It is low-priority because #571 (COW overlay sharing) removed the main reason an agent reached for shell-native `echo > file`: `write` and `exec` now share the granted path, so the qualification flow uses separate single-command exec calls, which work. Details on the ticket.

Depends conceptually on nothing; branches off current master (includes #570). Related: INFR-435 (#571), INFR-421 (#570).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
