### PR TITLE
Fix the ClusterFuzzLite build: fuzz_dis_parser cannot link freejitcode

### DIFF
--- a/.clusterfuzzlite/fuzz_dis_parser.c
+++ b/.clusterfuzzlite/fuzz_dis_parser.c
@@ -285,6 +285,20 @@ readmod(char *path, Module *m, int sync)
 	return nil;
 }
 
+/*
+ * freemod() in load.c calls freejitcode() on 64-bit targets to unmap a
+ * compiled module's JIT text. Only the JIT compilers define it, and this
+ * harness never compiles a module — compile() above is a no-op, so
+ * m->compiled is never set — so the call is unreachable here; the stub
+ * only completes the link.
+ */
+void
+freejitcode(void *p, ulong size)
+{
+	USED(p);
+	USED(size);
+}
+
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {


### PR DESCRIPTION
## Summary

- `ClusterFuzzLite` has been failing on `master` since #570. The `fuzz_dis_parser` target no longer links.
- `load.c`'s `freemod()` calls `freejitcode()` on 64-bit targets. Only the JIT compilers define it, and `.clusterfuzzlite/build.sh` links the harness plus `load.c` and nothing else.
- The harness never compiles a module: `parsemod()` zeroes the `Module`, `m->compiled = 1` is set only in `comp-amd64.c` / `comp-arm64.c`, and the harness's own `compile()` is a no-op. The call is unreachable there.
- So this defines a no-op `freejitcode` in the harness to complete the link. `load.c` is untouched and the emulator is unchanged.

Linking a JIT compiler into the target instead would drag in the code generator and change what the fuzzer covers. Changing the guard in `load.c` would change the emulator to suit a test harness.

#### Test plan

- [x] Reproduced the failure at `master`: `undefined symbol _freejitcode referenced from _freemod` — arm64 hits the same `__aarch64__` guard as CI's amd64
- [x] `fuzz_dis_parser` links and runs 200k libFuzzer iterations clean
- [x] `fuzz_9p_messages` links and runs 5k clean, confirming no second break behind the first
- [x] `Fuzz (PR)` green on a branch whose merge commit is `master` + this change

## Checklist

- [x] No behaviour change outside `.clusterfuzzlite/`
- [x] Commit signed
