### PR TITLE
Bound blocked dials in the test suite, and add an offline opt-out

### DIFF
--- a/appl/lib/webclient.b
+++ b/appl/lib/webclient.b
@@ -27,6 +27,12 @@ include "publicnet.m";
 
 MAXREDIRECTS: con 10;
 
+# How long a connect (dial plus TLS handshake) may block before the
+# library abandons it. A connect held open by a host firewall prompt or a
+# blackholed route never fails on its own, so every caller would hang
+# forever waiting for it. Bound it and report a timeout error instead.
+CONNECTMS: con 10000;
+
 init(): string
 {
 	sys = load Sys Sys->PATH;
@@ -92,23 +98,136 @@ post(requrl, contenttype: string, body: array of byte): (ref Response, string)
 
 tlsdial(addr, servername: string): (ref Sys->FD, string)
 {
+	(conn, err) := tlsconnect(addr, servername);
+	if(err != nil)
+		return (nil, err);
+	return tlsconnfd(conn);
+}
+
+# [private]
+# Dial and complete the TLS handshake under a time bound, returning the
+# established connection. The dial and the handshake both block in host
+# read/connect calls that never fail on their own when a firewall holds
+# the connect open, so run them in a child proc, race the result against
+# a timer, and kill the child if the timer wins — a killed-but-blocked
+# child would otherwise keep the whole emulator alive at exit.
+tlsconnect(addr, servername: string): (ref Conn, string)
+{
 	err := loadtls();
 	if(err != nil)
 		return (nil, err);
 
+	res := chan of (ref Conn, string);
+	pch := chan of int;
+	spawn tlsconnectproc(addr, servername, pch, res);
+	pid := <-pch;
+	tch := chan of int;
+	spawn timerproc(tch, CONNECTMS);
+	alt {
+	r := <-res =>
+		return r;
+	<-tch =>
+		killproc(pid);
+		return (nil, sys->sprint("connect %s: no response within %dms", addr, CONNECTMS));
+	}
+}
+
+# [private]
+tlsconnectproc(addr, servername: string, pch: chan of int,
+	res: chan of (ref Conn, string))
+{
+	pch <-= sys->pctl(0, nil);
+
 	c := dial->dial(addr, nil);
-	if(c == nil)
-		return (nil, sys->sprint("dial %s: %r", addr));
+	if(c == nil) {
+		err := sys->sprint("dial %s: %r", addr);
+		alt {
+		res <-= (nil, err) =>
+			;
+		* =>
+			;
+		}
+		return;
+	}
 
 	cfg := tls->defaultconfig();
 	cfg.servername = servername;
-
 	(conn, terr) := tls->client(c.dfd, cfg);
-	if(terr != nil)
-		return (nil, "tls: " + terr);
+	if(terr != nil) {
+		alt {
+		res <-= (nil, "tls: " + terr) =>
+			;
+		* =>
+			;
+		}
+		return;
+	}
 
-	# Wrap TLS conn as a pipe-like FD pair
-	return tlsconnfd(conn);
+	alt {
+	res <-= (conn, nil) =>
+		;
+	* =>
+		;
+	}
+}
+
+# [private]
+# Dial under a time bound. Returns (connection, nil) or (nil, error).
+bounddial(addr: string): (ref Sys->Connection, string)
+{
+	res := chan of (ref Sys->Connection, string);
+	pch := chan of int;
+	spawn bounddialproc(addr, pch, res);
+	pid := <-pch;
+	tch := chan of int;
+	spawn timerproc(tch, CONNECTMS);
+	alt {
+	r := <-res =>
+		return r;
+	<-tch =>
+		killproc(pid);
+		return (nil, sys->sprint("dial %s: no response within %dms", addr, CONNECTMS));
+	}
+}
+
+# [private]
+bounddialproc(addr: string, pch: chan of int,
+	res: chan of (ref Sys->Connection, string))
+{
+	pch <-= sys->pctl(0, nil);
+	c := dial->dial(addr, nil);
+	err: string;
+	if(c == nil)
+		err = sys->sprint("dial %s: %r", addr);
+	alt {
+	res <-= (c, err) =>
+		;
+	* =>
+		;
+	}
+}
+
+# [private]
+timerproc(ch: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	alt {
+	ch <-= 1 =>
+		;
+	* =>
+		;
+	}
+}
+
+# [private]
+# Kill a process blocked in a host syscall. A blocked dialer cannot be
+# waited on or ignored: left alive it holds the emulator (and its bound
+# ports) after the caller has moved on.
+killproc(pid: int)
+{
+	ctl := sys->open(sys->sprint("/prog/%d/ctl", pid), Sys->OWRITE);
+	if(ctl != nil)
+		sys->write(ctl, array of byte "kill", 4);
 }
 
 # [private]
@@ -336,23 +455,15 @@ dorequest(method, requrl: string, hdrs: list of Header, body: array of byte, pub
 
 	fd: ref Sys->FD;
 	if(ishttps) {
-		err := loadtls();
-		if(err != nil)
-			return (nil, err);
-		c := dial->dial(addr, nil);
-		if(c == nil)
-			return (nil, sys->sprint("dial %s: %r", addr));
-		cfg := tls->defaultconfig();
-		cfg.servername = host;
-		(conn, terr) := tls->client(c.dfd, cfg);
+		(conn, terr) := tlsconnect(addr, host);
 		if(terr != nil)
-			return (nil, "tls: " + terr);
+			return (nil, terr);
 		# Use TLS conn's read/write directly
 		return dotlsrequest(conn, method, u, host, hdrs, body);
 	} else {
-		c := dial->dial(addr, nil);
+		(c, derr) := bounddial(addr);
 		if(c == nil)
-			return (nil, sys->sprint("dial %s: %r", addr));
+			return (nil, derr);
 		fd = c.dfd;
 	}
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -175,6 +175,13 @@ run_internal_tests() {
         RUNNER_ARGS=""
     fi
 
+    # Explicit offline opt-out: the runner declares the environment so
+    # network-dependent tests skip deterministically instead of inferring
+    # it from a dial that may block forever (host firewall in ask mode).
+    if [ "$INFERNODE_TESTS_OFFLINE" = "1" ]; then
+        RUNNER_ARGS="$RUNNER_ARGS -o"
+    fi
+
     # Run the emulator with the test runner
     # Capture output and parse results
     echo ""

--- a/tests/inferno/git_integration_test.sh
+++ b/tests/inferno/git_integration_test.sh
@@ -11,6 +11,15 @@ echo '=========================================='
 
 failed=0
 
+# Declared offline run: the runner (or the operator) declares the
+# environment instead of the test inferring it from a dial that may block
+# forever — a host firewall in ask mode never fails the connect, it blocks
+# until a human answers a dialog, and the skip-guard below never runs.
+if {cat /env/INFERNODE_TESTS_OFFLINE > /dev/null >[2] /dev/null} {
+	echo 'SKIP: INFERNODE_TESTS_OFFLINE set'
+	raise 'skip:INFERNODE_TESTS_OFFLINE set'
+}
+
 echo ''
 echo 'Step 1: Start network services'
 ndb/cs

--- a/tests/runner.b
+++ b/tests/runner.b
@@ -37,6 +37,7 @@ TestModule: module
 };
 
 verbosemode := 0;
+offlinemode := 0;
 ctxt: ref Draw->Context;
 
 # Counts
@@ -69,15 +70,29 @@ init(drawctxt: ref Draw->Context, args: list of string)
 	}
 
 	arg->init(args);
-	arg->setusage("runner [-v]");
+	arg->setusage("runner [-v] [-o]");
 
 	while((opt := arg->opt()) != 0) {
 		case opt {
 		'v' =>
 			verbosemode = 1;
+		'o' =>
+			offlinemode = 1;
 		* =>
 			arg->usage();
 		}
+	}
+
+	# Offline opt-out: a runner declares the environment instead of the
+	# tests inferring it from a dial that may block forever (host firewall
+	# in ask mode never fails the connect). Network-dependent tests check
+	# /env/INFERNODE_TESTS_OFFLINE and skip deterministically.
+	if(offlinemode) {
+		fd := sys->create("/env/INFERNODE_TESTS_OFFLINE", Sys->OWRITE, 8r666);
+		if(fd == nil)
+			sys->fprint(sys->fildes(2), "runner: cannot create /env/INFERNODE_TESTS_OFFLINE: %r\n");
+		else
+			sys->write(fd, array of byte "1", 1);
 	}
 
 	sys->fprint(sys->fildes(2), "=== LIMBO TESTS ===\n");

--- a/tests/tcp_test.b
+++ b/tests/tcp_test.b
@@ -62,41 +62,79 @@ run(name: string, testfn: ref fn(t: ref T))
 # ── bounded dial ──────────────────────────────────────────────────────────
 # sys->dial blocks in the host connect() until the kernel's SYN timeout, which
 # on an offline host is tens of seconds -- long enough to look like a hang and
-# stall the whole runner. Bound it: dial in a child proc, race it against a
-# timer, and report a timeout to the caller so the test can skip.
+# stall the whole runner. Worse: a host firewall in ask mode never completes
+# or fails the connect at all -- it blocks until a human answers a dialog.
+# Bound it: dial in a child proc, race it against a timer, and kill the child
+# on timeout. The kill matters as much as the timer: a proc left blocked in a
+# host connect keeps the emulator (and its bound ports) alive at exit even
+# after every test has reported.
 
 Dialres: adt {
 	ok:	int;
 	c:	Sys->Connection;
+	err:	string;
 };
 
-dialer(addr: string, ch: chan of ref Dialres)
+dialer(addr: string, pch: chan of int, ch: chan of ref Dialres)
 {
+	pch <-= sys->pctl(0, nil);
 	r := ref Dialres;
 	(r.ok, r.c) = sys->dial(addr, nil);
-	ch <-= r;
+	if(r.ok < 0)
+		r.err = sys->sprint("dial %s: %r", addr);
+	alt {
+	ch <-= r =>
+		;
+	* =>
+		;
+	}
 }
 
 timer(ch: chan of int, ms: int)
 {
 	sys->sleep(ms);
-	ch <-= 1;
+	alt {
+	ch <-= 1 =>
+		;
+	* =>
+		;
+	}
 }
 
-# returns (ok, connection, timedout). timedout=1 means the dial did not
-# complete within DIALMS (treat as "network unavailable", skip).
-dialTimeout(addr: string, ms: int): (int, Sys->Connection, int)
+# returns (ok, connection, timedout, errstr). timedout=1 means the dial did
+# not complete within DIALMS (treat as "network unavailable", skip). errstr
+# comes from the dialer proc: a failed dial sets errstr there, not here.
+dialTimeout(addr: string, ms: int): (int, Sys->Connection, int, string)
 {
 	dc := chan of ref Dialres;
+	pc := chan of int;
+	spawn dialer(addr, pc, dc);
+	pid := <-pc;
 	tc := chan of int;
-	spawn dialer(addr, dc);
 	spawn timer(tc, ms);
 	alt {
 	r := <-dc =>
-		return (r.ok, r.c, 0);
+		return (r.ok, r.c, 0, r.err);
 	<-tc =>
-		return (-1, Sys->Connection(nil, nil, nil), 1);
+		killproc(pid);
+		return (-1, Sys->Connection(nil, nil, nil), 1, "timeout");
 	}
+}
+
+killproc(pid: int)
+{
+	ctl := sys->open(sys->sprint("/prog/%d/ctl", pid), Sys->OWRITE);
+	if(ctl != nil)
+		sys->write(ctl, array of byte "kill", 4);
+}
+
+# A runner can declare the environment offline (INFERNODE_TESTS_OFFLINE=1
+# via run-tests.sh, which the runner turns into this env file) instead of
+# having the tests infer it from a dial that may never return.
+offline(): int
+{
+	(s, nil) := sys->stat("/env/INFERNODE_TESTS_OFFLINE");
+	return s >= 0;
 }
 
 # ── loopback (self-contained, always runs with any IP stack) ────────────────
@@ -160,27 +198,30 @@ testLoopback(t: ref T)
 # ── outbound Internet (opt-in; skip cleanly when offline) ───────────────────
 testTcpDialIp(t: ref T)
 {
-	(ok, c, tout) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
+	(ok, c, tout, derr) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
 	if(tout){ t.skip("dial timed out (offline)"); return; }
-	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
+	if(ok < 0){ t.skip("network unavailable: " + derr); return; }
 	t.assert(c.dfd != nil, "data fd should be valid");
 	t.log(sys->sprint("connected to 8.8.8.8:53, fd=%d", c.dfd.fd));
 }
 
 testTcpDialHostname(t: ref T)
 {
-	(ok, c, tout) := dialTimeout("tcp!google.com!80", DIALMS);
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
+	(ok, c, tout, derr) := dialTimeout("tcp!google.com!80", DIALMS);
 	if(tout){ t.skip("dial timed out (offline)"); return; }
-	if(ok < 0){ t.skip(sys->sprint("network unavailable or DNS failed: %r")); return; }
+	if(ok < 0){ t.skip("network unavailable or DNS failed: " + derr); return; }
 	t.assert(c.dfd != nil, "data fd should be valid");
 	t.log("connected to google.com:80");
 }
 
 testTcpWrite(t: ref T)
 {
-	(ok, c, tout) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
+	(ok, c, tout, derr) := dialTimeout("tcp!8.8.8.8!53", DIALMS);
 	if(tout){ t.skip("dial timed out (offline)"); return; }
-	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
+	if(ok < 0){ t.skip("network unavailable: " + derr); return; }
 	buf := array[1] of byte;
 	buf[0] = byte 0;
 	n := sys->write(c.dfd, buf, 1);
@@ -189,9 +230,10 @@ testTcpWrite(t: ref T)
 
 testHttpRequest(t: ref T)
 {
-	(ok, c, tout) := dialTimeout("tcp!google.com!80", DIALMS);
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
+	(ok, c, tout, derr) := dialTimeout("tcp!google.com!80", DIALMS);
 	if(tout){ t.skip("dial timed out (offline)"); return; }
-	if(ok < 0){ t.skip(sys->sprint("network unavailable: %r")); return; }
+	if(ok < 0){ t.skip("network unavailable: " + derr); return; }
 
 	request := "GET / HTTP/1.0\r\nHost: google.com\r\n\r\n";
 	buf := array of byte request;

--- a/tests/webclient_test.b
+++ b/tests/webclient_test.b
@@ -24,6 +24,15 @@ passed := 0;
 failed := 0;
 skipped := 0;
 
+# A runner can declare the environment offline (INFERNODE_TESTS_OFFLINE=1
+# via run-tests.sh, which the runner turns into this env file) instead of
+# having the tests infer it from a dial that may never return.
+offline(): int
+{
+	(s, nil) := sys->stat("/env/INFERNODE_TESTS_OFFLINE");
+	return s >= 0;
+}
+
 run(name: string, testfn: ref fn(t: ref T))
 {
 	t := testing->newTsrc(name, SRCFILE);
@@ -48,6 +57,7 @@ run(name: string, testfn: ref fn(t: ref T))
 
 testHttpsGet(t: ref T)
 {
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
 	(resp, err) := webclient->get("https://example.com");
 	if(err != nil) {
 		t.skip("network: " + err);
@@ -61,6 +71,7 @@ testHttpsGet(t: ref T)
 
 testRedirect(t: ref T)
 {
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
 	# HTTP to HTTPS redirect
 	(resp, err) := webclient->requestpublic("GET", "http://example.com", nil, nil);
 	if(err != nil) {
@@ -75,6 +86,7 @@ testRedirect(t: ref T)
 
 testTlsDial(t: ref T)
 {
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
 	(fd, err) := webclient->tlsdial("tcp!example.com!443", "example.com");
 	if(err != nil) {
 		t.skip("network: " + err);
@@ -97,6 +109,7 @@ testTlsDial(t: ref T)
 
 testPost(t: ref T)
 {
+	if(offline()){ t.skip("INFERNODE_TESTS_OFFLINE set"); return; }
 	body := array of byte "test=hello";
 	(resp, err) := webclient->post("https://httpbin.org/post",
 		"application/x-www-form-urlencoded", body);


### PR DESCRIPTION
## Summary

- `tests/inferno/git_integration_test.sh` has an environmental skip-guard (INFR-312) that only fires when the dial **fails**. A connect held open — a host firewall in ask mode, a blackholed route — never fails, so the guard never runs and the emulator sits with no output holding its ports.
- `webclient`'s `tlsdial` and `request()` now run dial plus TLS handshake in a child proc raced against a 10s timer, and kill the child on timeout. The kill is load-bearing: a proc blocked in `connect()` keeps the emulator alive after `init()` returns — 20s+ past test completion without it, 3.0s with it.
- `tcp_test.b`'s `dialTimeout` already bounded a blocked connect correctly; it got the same kill so it stops leaking the dialer.
- Adds `INFERNODE_TESTS_OFFLINE=1`, so a runner declares its environment instead of the suite inferring it from a dial that may never return. `run-tests.sh` passes `-o`, the runner writes `/env/INFERNODE_TESTS_OFFLINE`, and the network tests skip before dialing.

No module interface changed.

#### Test plan

- [x] Reproduced first, with an accept-and-never-respond listener: `discovering refs...` then nothing, killed at 45s with no PASS/FAIL/SKIP. A *refused* dial was run as contrast — the guard fires instantly, isolating the defect to the blocked connect
- [x] After: `connect tcp!127.0.0.1!18443: no response within 10000ms`, then `SKIP: clone failed`, at ~10s
- [x] Network present, which is the check that matters — a timeout must not turn a working test into a permanent skip: real clone of `octocat/Hello-World` passed all 10 steps; `webclient_test` passed all 4 network tests against real TLS; `tcp_test` passed Loopback/TcpDialIp/TcpWrite
- [x] `/env/INFERNODE_TESTS_OFFLINE` verified writable and readable inside the emulator

## Checklist

- [x] Commits signed
- [x] No behaviour change when the network is reachable

One thing found on the way and not fixed here: `git_integration_test.sh` starts `ndb/cs`, and a running `cs` keeps the emulator alive after the last test reports — a second, independent reason a suite run hangs at exit. Happy to send that separately; it needs a decision about who reaps it.
