### PR TITLE
fix(emu): keep pthread process leader alive

### DIFF
--- a/docs/VELTRO-ESCAPE-ROOM.md
+++ b/docs/VELTRO-ESCAPE-ROOM.md
@@ -219,6 +219,27 @@ expires is `INCONCLUSIVE` with a usage-limit reason.
 Abrupt runner, emulator, or host loss before the final checkpoint is a
 different failure class and must not be reported as a verified audit bundle.
 
+### Liveness and termination gate
+
+The runner's `Popen.poll()`/`wait()` result is authoritative for emulator
+termination. Do not infer termination from `ps` or the leader's
+`/proc/<pid>/status` state alone: pthread builds before September 2026 could
+show a zombie process leader while emulator worker threads were still live.
+For an operator-side diagnostic, use the thread-group-aware check:
+
+```sh
+stage=$HOME/.infernode/grind/current
+tests/agent-harness/emu-liveness.sh "$emu_pid" "$stage/quota-paused"
+```
+
+`LIVE ... state=quota-paused` is a healthy paused campaign, not a hung or dead
+one. Do not send a signal to it merely because output and active-time clocks
+have stopped. Raw `kill` is reserved for a confirmed containment breach, a
+host resource emergency, or an explicitly approved campaign abort. Before
+such an abort, record the liveness output, gateway health, recent audit
+checkpoint, UTC time, and reason in the private manifest. A diagnostic doubt
+is not sufficient grounds to terminate a live evidence-producing run.
+
 Build and run the Veltro security tests using the platform workflow described
 in [TESTING.md](TESTING.md). A failed deterministic test invalidates the live
 campaign; the model is not a replacement for ordinary tests.

--- a/emu/port/kproc-pthreads.c
+++ b/emu/port/kproc-pthreads.c
@@ -256,8 +256,9 @@ osyield(void)
 void
 ospause(void)
 {
-	/* main just wants this thread to go away */
-	pthread_exit(0);
+	/* Keep the process leader visible while the emulator workers run. */
+	for(;;)
+		pause();
 }
 
 void

--- a/tests/agent-harness/emu-liveness.sh
+++ b/tests/agent-harness/emu-liveness.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Report emulator liveness without mistaking a zombie leader for a dead process.
+
+set -eu
+
+usage()
+{
+	echo "usage: emu-liveness.sh pid [quota-pause-marker]" >&2
+	exit 2
+}
+
+[ "$#" -ge 1 ] && [ "$#" -le 2 ] || usage
+pid=$1
+case "$pid" in
+	*[!0-9]*|'') usage ;;
+esac
+[ "$pid" -gt 0 ] || usage
+
+proc=${PROC_ROOT:-/proc}
+pause=${2:-}
+quota=running
+[ -n "$pause" ] && [ -e "$pause" ] && quota=quota-paused
+
+taskdir=$proc/$pid/task
+if [ -d "$taskdir" ]; then
+	total=0
+	live=0
+	leader=unknown
+	for status in "$taskdir"/*/status; do
+		[ -r "$status" ] || continue
+		state=$(awk '/^State:/{print $2; exit}' "$status")
+		[ -n "$state" ] || continue
+		total=$((total + 1))
+		case "$status" in
+			"$taskdir/$pid/status") leader=$state ;;
+		esac
+		case "$state" in
+			Z|X|x) ;;
+			*) live=$((live + 1)) ;;
+		esac
+	done
+	if [ "$live" -gt 0 ]; then
+		echo "LIVE pid=$pid leader_state=$leader live_threads=$live total_threads=$total state=$quota"
+		exit 0
+	fi
+	if [ "$total" -gt 0 ]; then
+		echo "EXITED pid=$pid leader_state=$leader live_threads=0 total_threads=$total state=$quota"
+		exit 1
+	fi
+fi
+
+if kill -0 "$pid" 2>/dev/null; then
+	echo "LIVE_UNVERIFIED pid=$pid state=$quota"
+	exit 0
+fi
+
+echo "EXITED pid=$pid state=$quota"
+exit 1

--- a/tests/host/emu_liveness_test.sh
+++ b/tests/host/emu_liveness_test.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Regression checks for emulator thread-group liveness diagnosis.
+
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+CHECK="$ROOT/tests/agent-harness/emu-liveness.sh"
+[ -x "$CHECK" ] || { echo "FAIL: $CHECK missing or not executable" >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/emu-liveness-test.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+proc=$work/proc
+
+mkdir -p "$proc/42/task/42" "$proc/42/task/43"
+printf 'State:\tZ (zombie)\n' > "$proc/42/task/42/status"
+printf 'State:\tS (sleeping)\n' > "$proc/42/task/43/status"
+
+out=$(PROC_ROOT="$proc" "$CHECK" 42)
+echo "$out" | grep -q '^LIVE .*leader_state=Z .*live_threads=1' || {
+	echo "FAIL: zombie leader with live worker was not reported live: $out" >&2
+	exit 1
+}
+
+: > "$work/quota-paused"
+out=$(PROC_ROOT="$proc" "$CHECK" 42 "$work/quota-paused")
+echo "$out" | grep -q 'state=quota-paused$' || {
+	echo "FAIL: quota pause was not reported as live state: $out" >&2
+	exit 1
+}
+
+printf 'State:\tZ (zombie)\n' > "$proc/42/task/43/status"
+if out=$(PROC_ROOT="$proc" "$CHECK" 42); then
+	echo "FAIL: all-zombie thread group was reported live: $out" >&2
+	exit 1
+fi
+echo "$out" | grep -q '^EXITED .*live_threads=0' || {
+	echo "FAIL: all-zombie result is malformed: $out" >&2
+	exit 1
+}
+
+if "$CHECK" invalid >/dev/null 2>&1; then
+	echo "FAIL: invalid pid was accepted" >&2
+	exit 1
+fi
+
+echo "emu_liveness_test: PASS"

--- a/tests/host/emulator_leader_lifecycle_test.sh
+++ b/tests/host/emulator_leader_lifecycle_test.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# A long-lived pthread emulator must keep its advertised process leader alive.
+
+set -eu
+
+ROOT=${ROOT:-}
+. "$(dirname "$0")/common.sh"
+
+[ "$EMUHOST" = Linux ] || { echo "SKIP: Linux /proc test"; exit 77; }
+[ -r /proc/self/status ] || { echo "SKIP: /proc unavailable"; exit 77; }
+[ -x "$EMU" ] || { echo "SKIP: emulator not found at $EMU"; exit 77; }
+[ -f "$ROOT/dis/sh.dis" ] || { echo "SKIP: sh.dis not built"; exit 77; }
+command -v setsid >/dev/null 2>&1 || { echo "SKIP: setsid unavailable"; exit 77; }
+
+work=${TMPDIR:-/tmp}/infernode-leader-$$
+mkdir -p "$work"
+pid=
+watchdog=
+cleanup()
+{
+	if [ -n "$watchdog" ]; then
+		kill "$watchdog" 2>/dev/null || true
+		wait "$watchdog" 2>/dev/null || true
+	fi
+	if [ -n "$pid" ]; then
+		kill -KILL -"$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+	fi
+	rm -rf "$work"
+}
+trap cleanup EXIT HUP INT TERM
+
+setsid "$EMU" -r"$ROOT" /dis/sh.dis -c 'sleep 30' >"$work/emu.log" 2>&1 &
+pid=$!
+
+n=0
+while [ "$n" -lt 50 ]; do
+	state=$(awk '/^State:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)
+	threads=$(awk '/^Threads:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)
+	[ -n "$state" ] && [ "${threads:-0}" -gt 1 ] && break
+	sleep 0.1
+	n=$((n + 1))
+done
+
+if [ -z "${state:-}" ] || [ "${threads:-0}" -le 1 ]; then
+	echo "FAIL: emulator did not reach its worker-thread run state"
+	cat "$work/emu.log"
+	exit 1
+fi
+
+if [ "$state" = Z ]; then
+	echo "FAIL: emulator process leader is a zombie while $threads threads run"
+	exit 1
+fi
+
+timeout_marker=$work/shutdown-timeout
+(
+	sleep 5
+	: >"$timeout_marker"
+	kill -KILL -"$pid" 2>/dev/null || true
+) &
+watchdog=$!
+
+kill -TERM "$pid"
+set +e
+wait "$pid" 2>/dev/null
+set -e
+pid=
+kill "$watchdog" 2>/dev/null || true
+wait "$watchdog" 2>/dev/null || true
+watchdog=
+
+[ ! -e "$timeout_marker" ] || {
+	echo "FAIL: emulator did not terminate after SIGTERM"
+	exit 1
+}
+
+echo "PASS: emulator leader state=$state with $threads threads; SIGTERM stopped it"

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -12,10 +12,8 @@ trustworthy.
 > through, and eventually even a trivial test is killed at exit. There was
 > **no OOM** (`dmesg` clean, RAM free) and the thread/proc count stayed flat,
 > so those deaths are a *sandbox watchdog*, **not** an InferNode leak or
-> crash. Host RSS introspection is also unreliable there because the emu forks
-> a worker and the visible pid is a zombie stub. **Run these on a real host
-> (bare metal / VM you control) to get a real verdict.** Tracked for hardware
-> validation alongside the IPv6 task.
+> crash. **Run these on a real host (bare metal / VM you control) to get a real
+> verdict.** Tracked for hardware validation alongside the IPv6 task.
 
 ## churn — connection-churn leak / stability
 


### PR DESCRIPTION
## Summary

- keep the pthread emulator process leader parked instead of exiting it
- add a Linux regression that checks the visible PID is non-zombie while workers run
- verify SIGTERM still terminates the emulator and remove obsolete zombie-stub guidance

## Why

The pthread backend launched the emulator worker and then called `pthread_exit(0)` from the thread-group leader. On Linux, `/proc/<pid>/status` consequently reported `State: Z` even though worker threads remained active. During an escape-room quota pause this caused a live campaign to be misdiagnosed and terminated for forensics.

The clone backend already parks this thread with `pause()`. This change gives the pthread backend the same observable lifecycle.

## Verification

- `./build-linux-amd64.sh headless` on the mini-PC: PASS
- `tests/host/emulator_leader_lifecycle_test.sh`: PASS (`state=R`, 4 threads, SIGTERM shutdown)
- archived pre-fix campaign binary under the same workload: reproduced `State: Z`, 4 threads
- `sh -n tests/host/emulator_leader_lifecycle_test.sh`: PASS
- `git diff --check`: PASS

The affected campaign manifest was append-only corrected and resealed; no campaign evidence or local configuration is included in this PR.