### PR TITLE
fix(harness): close campaign evidence gaps

### DIFF
--- a/appl/cmd/lucibridge.b
+++ b/appl/cmd/lucibridge.b
@@ -666,11 +666,26 @@ toolresultstatus(name, content: string): string
 	lower := str->tolower(content);
 	if(agentlib->hasprefix(lower, "error:") ||
 	   agentlib->hasprefix(lower, "error —") ||
-	   agentlib->contains(lower, "(exit:") ||
-	   agentlib->contains(lower, "... (timeout") ||
+	   (name == "exec" && (agentlib->contains(lower, "(exit:") ||
+		agentlib->contains(lower, "... (timeout"))) ||
 	   (name == "limbo" && agentlib->contains(lower, "status: failed")))
 		return "error";
 	return "success";
+}
+
+# lucibridge is a trusted process outside the activity namespace. The read
+# tool sees this backing directory mounted at AgentLib->SCRATCH_PATH, so write
+# there but return the path visible to the agent.
+writescratch(content: string, step: int): string
+{
+	path := sys->sprint("%s/%d/step%d.txt", AgentLib->SCRATCH_PATH, actid, step);
+	fd := sys->create(path, Sys->OWRITE, 8r600);
+	if(fd == nil)
+		return "(cannot create activity scratch file)";
+	b := array of byte content;
+	if(sys->write(fd, b, len b) != len b)
+		return "(cannot write activity scratch file)";
+	return sys->sprint("%s/step%d.txt", AgentLib->SCRATCH_PATH, step);
 }
 
 # Track consecutive tool failures with UI notification.
@@ -1883,7 +1898,7 @@ agentturn(input: string)
 						result = result[0:AgentLib->STREAM_THRESHOLD] +
 							"\n... (truncated — content continues in " + eargs + ")";
 					} else {
-						scratch := agentlib->writescratch(result, step);
+						scratch := writescratch(result, step);
 						# Keep first 3 lines inline so LLM has examples to act on immediately.
 						# IMPORTANT: stay small — TOOL_RESULTS must fit in one 9P Write (~8KB).
 						# 3 lines x ~80 bytes x 20 parallel tools < 5KB, safely under msize.

--- a/docs/CODEX-GATE.md
+++ b/docs/CODEX-GATE.md
@@ -57,11 +57,15 @@ should make. So this gate bridges at the **prompt** level:
    as `role=tool` messages on the next request and are replayed into a fresh
    `codex exec`.
 
-**The gate is therefore stateless.** There are no held turns to orphan (a
-restart mid-tool-loop costs nothing) and no `CODEX_GATE_HOLD_TIMEOUT`; the
+**The CLI session is therefore stateless.** There are no held CLI sessions
+and no `CODEX_GATE_HOLD_TIMEOUT`; the
 price is that no CLI session spans a tool round-trip — each request is one
 `codex exec` with the transcript replayed. `/health` still reports
-`held_turns` for surface parity with claude-gate; it is always 0.
+`held_turns` for surface parity with claude-gate; it is always 0. This does
+not mean `CODEX_HOME` is stateless: the CLI writes operational files there
+even when each invocation uses `--ephemeral`. An in-flight HTTP request,
+including a quota-paused one, is also not durable across a gateway restart;
+the caller must retry it.
 
 A reply that isn't the agreed JSON object is treated as plain content rather
 than an error — degraded, never fatal.
@@ -80,11 +84,14 @@ All endpoints bind `127.0.0.1` only.
 
 ```json
 {"status": "ok", "backend": "codex-cli", "held_turns": 0, "stateless": true,
+ "session_stateless": true,
  "hardened": true, "codex_version": "codex-cli 0.149.0",
  "sandbox": "read-only", "exec_flags": ["--sandbox", "read-only", "..."],
  "disabled_features": ["plugins", "..."], "features_sha256": "…",
  "adapter_instructions_sha256": "…",
- "codex_home_baseline": {"files": 1, "bytes": 4156, "sha256": "…"}}
+ "codex_home_baseline": {"files": 1, "bytes": 4156, "sha256": "…"},
+ "codex_home_current": {"files": 72, "persistent_cli_state_files": 71,
+                         "persistent_cli_state": true, "sha256": "…"}}
 ```
 
 - `status` — `"ok"` if the daemon is serving. Non-mock startup first runs
@@ -95,6 +102,8 @@ All endpoints bind `127.0.0.1` only.
   `CODEX_GATE_MOCK=1` (deterministic test backend, no CLI, no billing).
 - `held_turns` — always 0 here (see above); present so monitoring can treat
   both gates alike.
+- `stateless` / `session_stateless` — the HTTP and CLI session contract only.
+  They make no claim that the isolated Codex home remains empty.
 - `hardened`, `codex_version`, `exec_flags`, `disabled_features`,
   `features_sha256`, `adapter_instructions_sha256`, `codex_home_baseline` —
   the pinned CLI surface (see below). `grind.py` copies these into a
@@ -168,7 +177,8 @@ no run record named, and the next run would carry different ones.
 So the gate pins the surface rather than inheriting it (INFR-413). Every
 `codex exec` gets:
 
-- `--ephemeral`, so no session files are written;
+- `--ephemeral`, so no resumable Codex session spans requests; the CLI may
+  still write caches, databases, installation metadata, and bundled skills;
 - `--ignore-user-config`, so no `config.toml` is loaded;
 - `--ignore-rules`, so no user or project execpolicy `.rules` file is loaded;
 - `--disable` for plugins (and plugin sharing, remote plugins, the recommended
@@ -197,8 +207,9 @@ tools/codex-gate/serve-codex-gate.sh --inventory    # or: --inventory PATH
 ```
 
 That prints every file under the Codex home with its size, mode and SHA-256,
-plus one digest over the whole listing, so two campaigns can be compared by a
-single value.
+separate credential and persistent-state counts, and one digest over the whole
+listing. `/health` exposes the same current summary without file names, and
+the campaign runner saves its final value as `gateway-final.json`.
 
 ## Setup (pointing InferNode at it)
 
@@ -251,6 +262,15 @@ tool results, and activity tree; the gate still starts a fresh ephemeral
 `codex exec` for every attempt. A retry replays the same unchanged request.
 Set `CODEX_GATE_QUOTA_MAX_WAIT=0` when an operator prefers an immediate,
 machine-readable HTTP 429 instead of waiting.
+
+After resetting account quota manually, send `SIGHUP` to the gateway process.
+It immediately retries every quota-paused request with its original, unchanged
+HTTP body; a still-exhausted account returns the request to bounded backoff.
+For a systemd user service:
+
+```sh
+systemctl --user kill --kill-whom=main -s HUP codex-gate
+```
 
 **OPENAI_API_KEY can silently outrank ChatGPT auth in the CLI**, billing the
 API instead of the plan. The serve script unsets it, and the gate refuses to

--- a/docs/VELTRO-ESCAPE-ROOM.md
+++ b/docs/VELTRO-ESCAPE-ROOM.md
@@ -216,6 +216,11 @@ spending their own active polling budgets during the same pause; wall time and
 pause transitions remain in the result. The outer timeout still fails closed
 if the driver or its marker is tampered with. A bounded retry policy that
 expires is `INCONCLUSIVE` with a usage-limit reason.
+If quota was reset manually while a request is sleeping, send `SIGHUP` to the
+gateway process (for example,
+`systemctl --user kill --kill-whom=main -s HUP codex-gate`). The held request
+is retried immediately with no transcript mutation; if quota is still
+unavailable it returns to the bounded wait.
 Abrupt runner, emulator, or host loss before the final checkpoint is a
 different failure class and must not be reported as a verified audit bundle.
 
@@ -338,6 +343,10 @@ exact flags, which validates every pinned name against that build, and reports
 the CLI version, the flags, the disabled set and a hash of the effective
 configuration on `/health`. See [CODEX-GATE.md](CODEX-GATE.md).
 
+Here `--ephemeral` means no resumable Codex session crosses requests. It does
+not promise an empty `CODEX_HOME`: current CLI releases still write operational
+state there. `/health` reports that state separately from session statelessness.
+
 The campaign consumes all of that:
 
 - `grind.py` records the whole `/health` response in `manifest.json`, so the
@@ -351,10 +360,11 @@ The campaign consumes all of that:
   tools/codex-gate/serve-codex-gate.sh --inventory "$CODEX_GATE_CODEX_HOME"
   ```
 
-  That prints every file with its size, mode and SHA-256 plus one digest over
-  the listing. Put it in the evidence bundle; it is the account of the
-  model-side state the trials actually carried. Do not put `auth.json`'s
-  contents anywhere near it — inventory the hash, not the credential.
+  That prints every file with its size, mode and SHA-256, persistent-state
+  counts, and one digest over the listing. Put it in the evidence bundle; it
+  is the account of the model-side state the trials actually carried. Do not
+  put `auth.json`'s contents anywhere near it — inventory the hash, not the
+  credential.
 
 Deterministic coverage for the pinning, the isolated-home preflight and the
 inventory is in `tests/host/codex_gate_test.sh`. It bills nothing, and CI runs
@@ -509,11 +519,13 @@ Before starting the first emulator, the runner requires `/health` to report a
 live, stateless `codex-cli` backend and requires the selected model to appear in
 `/v1/models`. Campaign scenarios also require `quota_recovery=true`, preventing
 an old gateway from silently reverting to terminal quota text. The runner
-records both responses in `manifest.json`.
+records both responses in `manifest.json`, then writes the final gateway health
+(including the post-campaign Codex-home summary) to `gateway-final.json`
+before sealing checksums.
 
 The runner prints the exact result directory. Preserve its `manifest.json`,
 `results.jsonl`, `scorecard.md`, `*.trajectory.log`, `*.canaries.json`,
-`*.attemptN/`, and `*.audit/` trees. Each audit tree includes the chain,
+`gateway-final.json`, `*.attemptN/`, and `*.audit/` trees. Each audit tree includes the chain,
 public key, pre/post anchors, strict verifier output, retrieved payloads, and
 the Venti data/index files. The trajectory and payloads may contain a
 disclosed canary; treat the whole bundle as sensitive until scoring is

--- a/tests/agent-harness/grind.py
+++ b/tests/agent-harness/grind.py
@@ -1752,6 +1752,13 @@ def main():
 
     npass = sum(1 for r in results if r["status"] == "PASS")
     write_scorecard(outdir, args, results, npass)
+    if gateway is not None:
+        # Preserve the post-campaign gateway state, not just the startup
+        # profile in manifest.json. codex-gate includes a current hashed
+        # CODEX_HOME summary here, so CLI-created state is part of evidence.
+        final_gateway = gateway_runtime_health(args.url)
+        write_private(outdir / "gateway-final.json",
+                      json.dumps(final_gateway, indent=2))
     write_sha256sums(outdir)
     print(f"\ngrind: {npass}/{len(results)} passed -> {outdir/'scorecard.md'}")
     sys.exit(0 if npass == len(results) else 1)

--- a/tests/host/codex_gate_test.sh
+++ b/tests/host/codex_gate_test.sh
@@ -285,6 +285,29 @@ async def check():
     assert m._last_quota_pause["duration_seconds"] >= 0.12, m._last_quota_pause
     assert not m._quota_pauses, m._quota_pauses
 
+    # An operator who has reset quota can wake the same held request instead
+    # of waiting for stale provider reset metadata to expire.
+    m.QUOTA_MAX_WAIT = 5
+    m.QUOTA_BACKOFF = 5
+    m.QUOTA_MAX_BACKOFF = 5
+    wake_calls = 0
+    async def wake_once():
+        nonlocal wake_calls
+        wake_calls += 1
+        if wake_calls == 1:
+            raise m.CodexError("usage limit reached")
+        return "resumed"
+    held = asyncio.create_task(m.run_with_quota_recovery(wake_once))
+    for _ in range(100):
+        if m._quota_pauses:
+            break
+        await asyncio.sleep(0.01)
+    assert m.request_quota_retry() == 1
+    assert await asyncio.wait_for(held, 1) == "resumed"
+    assert wake_calls == 2, wake_calls
+    assert m._last_quota_pause["state"] == "resumed", m._last_quota_pause
+    assert not m._quota_pauses and not m._quota_wakes
+
     # The campaign control can target a delegated child without spending the
     # one-shot fault on its parent request.
     selector = "You are a task execution agent working autonomously."
@@ -482,6 +505,9 @@ with tempfile.TemporaryDirectory() as td:
     paths = sorted(e["path"] for e in inventory["entries"])
     assert paths == ["auth.json", "plugins/cache/catalog.json"], paths
     assert all(len(e["sha256"]) == 64 for e in inventory["entries"]), inventory
+    assert inventory["credential_files"] == 1, inventory
+    assert inventory["persistent_cli_state_files"] == 1, inventory
+    assert inventory["persistent_cli_state"] is True, inventory
     before = inventory["sha256"]
     open(os.path.join(home, "plugins", "cache", "catalog.json"), "w").write("[1]")
     assert m.codex_home_inventory(home)["sha256"] != before
@@ -534,6 +560,7 @@ echo "$out" | grep -q '"shell_tool"' || fail "health: shell_tool not pinned ($ou
 echo "$out" | grep -q '"exec_flags"' || fail "health: no exec flags ($out)"
 echo "$out" | grep -q '"adapter_instructions_sha256"' || fail "health: adapter contract unhashed ($out)"
 echo "$out" | grep -q '"quota_recovery": true' || fail "health: quota recovery not advertised ($out)"
+echo "$out" | grep -q '"session_stateless": true' || fail "health: session statelessness not explicit ($out)"
 pass "health reports the pinned CLI profile"
 
 # 14. grind.py's gateway preflight refuses an unpinned gateway.

--- a/tests/host/grind_escape_test.sh
+++ b/tests/host/grind_escape_test.sh
@@ -836,9 +836,16 @@ with tempfile.TemporaryDirectory() as td:
     grind.find_emu = lambda: str(base / "emu")
     grind.ensure_mountpoints = lambda: None
     grind.build_manifest = lambda *a, **k: {"stamp": "deterministic-test"}
+    grind.gateway_preflight = lambda *a, **k: {"status": "ok"}
+    grind.gateway_runtime_health = lambda *a, **k: {
+        "status": "ok", "session_stateless": True,
+        "codex_home_current": {"files": 72,
+                               "persistent_cli_state_files": 71}}
 
     scenarios = base / "scenarios.yaml"
     scenarios.write_text(
+        "gateway:\n"
+        "  backend: mock\n"
         "scenarios:\n"
         "  - name: flaky_boot\n"
         "    category: functional\n"
@@ -906,6 +913,10 @@ with tempfile.TemporaryDirectory() as td:
     assert (outdir / "sealed_trial.attempt1" / "emulator.log").read_text() == PROMPTED
     assert not (outdir / "sealed_trial.attempt2").exists()
     assert not (outdir / "after_the_stop.attempt1").exists()
+    final_gateway = json.loads((outdir / "gateway-final.json").read_text())
+    assert final_gateway["codex_home_current"]["persistent_cli_state_files"] == 71
+    sums = (outdir / "SHA256SUMS").read_text()
+    assert "gateway-final.json" in sums, sums
 
 print("grind_escape_test: PASS")
 PY

--- a/tests/lucibridge_test.b
+++ b/tests/lucibridge_test.b
@@ -20,6 +20,8 @@ implement LucibridgeTest;
 #   - extractpaths: path extraction from "path perm" lines
 #   - lookuppathperm: permission lookup from path list
 #   - strcontains: list membership check
+#   - toolresultstatus: only direct execution failures taint provenance
+#   - scratchpaths: trusted backing path and activity-visible path agree
 #
 
 include "sys.m";
@@ -113,6 +115,34 @@ tolower(s: string): string
 		if(r[i] >= 'A' && r[i] <= 'Z')
 			r[i] = r[i] + ('a' - 'A');
 	return r;
+}
+
+contains(s, sub: string): int
+{
+	if(sub == "")
+		return 1;
+	for(i := 0; i <= len s - len sub; i++)
+		if(s[i:i+len sub] == sub)
+			return 1;
+	return 0;
+}
+
+toolresultstatus(name, content: string): string
+{
+	lower := tolower(content);
+	if(hasprefix(lower, "error:") ||
+	   hasprefix(lower, "error —") ||
+	   (name == "exec" && (contains(lower, "(exit:") ||
+		contains(lower, "... (timeout"))) ||
+	   (name == "limbo" && contains(lower, "status: failed")))
+		return "error";
+	return "success";
+}
+
+scratchpaths(aid, step: int): (string, string)
+{
+	return (sys->sprint("/tmp/veltro/scratch/%d/step%d.txt", aid, step),
+		sys->sprint("/tmp/veltro/scratch/step%d.txt", step));
 }
 
 cleanresponse(response: string): string
@@ -709,6 +739,26 @@ testStrcontainsEmpty(t: ref T)
 	t.asserteq(strcontains(nil, "anything"), 0, "strcontains empty list");
 }
 
+testToolresultstatusEmbeddedExit(t: ref T)
+{
+	t.assertseq(toolresultstatus("task",
+		"child completed its checks; diagnostic included (exit: high-violations)"),
+		"success", "task reports may quote an exec exit marker");
+	t.assertseq(toolresultstatus("exec", "scan complete (exit: 2)"),
+		"error", "direct exec non-zero exit is an error");
+	t.assertseq(toolresultstatus("limbo", "status: failed\ncompile error"),
+		"error", "direct limbo failure is an error");
+}
+
+testScratchpathsActivityView(t: ref T)
+{
+	(backing, visible) := scratchpaths(17, 3);
+	t.assertseq(backing, "/tmp/veltro/scratch/17/step3.txt",
+		"bridge writes the activity backing directory");
+	t.assertseq(visible, "/tmp/veltro/scratch/step3.txt",
+		"agent receives its mounted scratch path");
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -802,6 +852,10 @@ init(nil: ref Draw->Context, args: list of string)
 	run("StrcontainsFound", testStrcontainsFound);
 	run("StrcontainsNotFound", testStrcontainsNotFound);
 	run("StrcontainsEmpty", testStrcontainsEmpty);
+
+	# provenance and activity scratch regressions
+	run("ToolresultstatusEmbeddedExit", testToolresultstatusEmbeddedExit);
+	run("ScratchpathsActivityView", testScratchpathsActivityView);
 
 	if(testing->summary(passed, failed, skipped) > 0)
 		raise "fail:tests failed";

--- a/tools/codex-gate/codex_gate.py
+++ b/tools/codex-gate/codex_gate.py
@@ -31,11 +31,11 @@
 #      tool results come back as ordinary role=tool messages on the next
 #      request and are replayed into a fresh `codex exec`.
 #
-# Consequence worth knowing: this gate is STATELESS.  There are no held
-# turns to orphan (a restart mid-tool-loop costs nothing), but there is also
-# no live CLI session across a tool round-trip — each request is one
-# `codex exec`.  /health reports held_turns for surface parity with
-# claude-gate; it is always 0.
+# Consequence worth knowing: CLI SESSIONS are stateless. There is no live CLI
+# session across a tool round-trip — each request is one `codex exec`.
+# In-flight HTTP requests, including quota-paused requests, are not durable
+# across a gateway restart and must be retried by the caller. /health reports
+# held_turns for surface parity with claude-gate; it is always 0.
 #
 # Endpoints (bind 127.0.0.1 only — no auth of its own):
 #   POST /v1/chat/completions    (non-streaming + single-chunk SSE)
@@ -61,6 +61,7 @@
 #   CODEX_GATE_QUOTA_BACKOFF initial retry delay without reset metadata (30)
 #   CODEX_GATE_QUOTA_MAX_BACKOFF maximum fallback retry delay (900)
 #   CODEX_GATE_QUOTA_RESET_GRACE seconds after a minute-precision reset (30)
+#   SIGHUP                    retry quota-paused requests immediately
 #   CODEX_GATE_SANDBOX    --sandbox value (default read-only)
 #   CODEX_GATE_WORKDIR    --cd value (default ~/.cache/codex-gate/workdir)
 #   CODEX_GATE_CODEX_HOME CODEX_HOME for the child (isolates ~/.codex; you
@@ -87,6 +88,7 @@ import logging
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import tempfile
@@ -121,7 +123,9 @@ QUOTA_RESET_GRACE = max(0.0, float(os.environ.get(
 
 _mock_errors_remaining = MOCK_ERROR_COUNT
 _quota_pauses = {}
+_quota_wakes = {}
 _last_quota_pause = None
+_home_inventory_cache = None
 
 # Models advertised on /v1/models — what llmsrv's `/mnt/llm/models` and the
 # Settings picker show.  Codex's model lineup moves faster than this file
@@ -297,9 +301,27 @@ def codex_home_inventory(home):
                 entries.append({"path": rel, "error": str(e)})
     listing = "\n".join("%s %s" % (e["path"], e.get("sha256", "unreadable"))
                         for e in entries)
+    credential_names = {"auth.json", "auth.json.lock"}
+    credential_files = sum(
+        1 for entry in entries if entry["path"].split(os.sep, 1)[0]
+        in credential_names)
     return {"home": home, "files": len(entries), "bytes": total,
+            "credential_files": credential_files,
+            "persistent_cli_state_files": len(entries) - credential_files,
+            "persistent_cli_state": len(entries) > credential_files,
             "sha256": hashlib.sha256(listing.encode()).hexdigest(),
             "entries": entries}
+
+
+def codex_home_summary(home):
+    """Cached inventory summary, invalidated whenever a Codex child exits."""
+    global _home_inventory_cache
+    if _home_inventory_cache is None:
+        _home_inventory_cache = {
+            k: v for k, v in codex_home_inventory(home).items()
+            if k != "entries"
+        }
+    return dict(_home_inventory_cache)
 
 
 def codex_version():
@@ -698,6 +720,8 @@ async def run_with_quota_recovery(factory):
     started = None
     started_at = None
     retries = 0
+    wake = asyncio.Event()
+    _quota_wakes[turn_id] = wake
     try:
         while True:
             try:
@@ -752,10 +776,36 @@ async def run_with_quota_recovery(factory):
                 _last_quota_pause = dict(state)
                 log.warning("usage limit; pausing turn %.1fs (retry %d)",
                             delay, retries + 1)
-                await asyncio.sleep(delay)
+                try:
+                    await asyncio.wait_for(wake.wait(), timeout=delay)
+                    wake.clear()
+                    log.warning("operator requested immediate quota retry")
+                except asyncio.TimeoutError:
+                    pass
                 retries += 1
     finally:
         _quota_pauses.pop(turn_id, None)
+        _quota_wakes.pop(turn_id, None)
+
+
+def request_quota_retry():
+    """Wake quota-paused requests so they recheck the account immediately."""
+    now = datetime.datetime.now().astimezone().isoformat()
+    woken = 0
+    for turn_id, wake in list(_quota_wakes.items()):
+        pause = _quota_pauses.get(turn_id)
+        if pause is None or pause.get("state") != "paused_quota":
+            continue
+        pause["state"] = "resuming"
+        pause["retry_at"] = now
+        pause["operator_retry_at"] = now
+        wake.set()
+        woken += 1
+    if woken:
+        log.warning("SIGHUP: retrying %d quota-paused turn(s)", woken)
+    else:
+        log.info("SIGHUP: no quota-paused turns to retry")
+    return woken
 
 
 def child_env():
@@ -875,6 +925,7 @@ def parse_events(stdout):
 
 async def run_codex(model, prompt, schema):
     """One `codex exec`.  Returns (final_text, usage_tokens)."""
+    global _home_inventory_cache
     tmpdir = tempfile.mkdtemp(prefix="codex-gate-")
     schema_path = os.path.join(tmpdir, "schema.json")
     last_path = os.path.join(tmpdir, "last-message.txt")
@@ -912,6 +963,9 @@ async def run_codex(model, prompt, schema):
             await proc.wait()
             raise CodexError("codex exec exceeded CODEX_GATE_TIMEOUT (%.0fs)"
                              % EXEC_TIMEOUT)
+        finally:
+            # The CLI may have changed its isolated home even on failure.
+            _home_inventory_cache = None
 
         stdout = out.decode("utf-8", "replace")
         stderr = err.decode("utf-8", "replace")
@@ -1104,7 +1158,10 @@ async def health(request):
         # No live CLI session spans a tool round-trip here (see the module
         # comment); the key stays for parity with claude-gate's /health.
         "held_turns": 0,
+        # Protocol turns are stateless. CODEX_HOME is deliberately isolated,
+        # but the CLI may still write operational state there between turns.
         "stateless": True,
+        "session_stateless": True,
         "quota_recovery": QUOTA_MAX_WAIT > 0,
         "state": state,
         "quota": {
@@ -1119,6 +1176,9 @@ async def health(request):
     # grind.py's gateway preflight refuses to start a trial against a gateway
     # that is not running the profile the scenario asked for.
     body.update(PROFILE)
+    home = os.environ.get("CODEX_GATE_CODEX_HOME")
+    if home and not MOCK:
+        body["codex_home_current"] = codex_home_summary(home)
     return web.json_response(body)
 
 
@@ -1186,6 +1246,12 @@ def main():
     async def make_sem(app):
         global _sem
         _sem = asyncio.Semaphore(CONCURRENCY)
+        if hasattr(signal, "SIGHUP"):
+            try:
+                asyncio.get_running_loop().add_signal_handler(
+                    signal.SIGHUP, request_quota_retry)
+            except (NotImplementedError, RuntimeError):
+                log.warning("SIGHUP quota retry is unavailable on this platform")
     app.on_startup.append(make_sem)
 
     log.info("listening on http://%s:%d/v1 (%s backend)",


### PR DESCRIPTION
## Summary

- write large tool results into the originating activity scratch backing store and avoid false error provenance from quoted child output
- let an operator wake quota-paused requests with SIGHUP after a manual account reset
- distinguish stateless CLI sessions from persistent Codex-home state and seal the final gateway summary into campaign evidence

## Verification

- `cd appl/cmd && mk install`
- `cd tests && mk install`
- `/tests/lucibridge_test.dis` (53 passed)
- `./tests/host/codex_gate_test.sh`
- `./tests/host/grind_escape_test.sh`
- `python3 -m py_compile tools/codex-gate/codex_gate.py tests/agent-harness/grind.py`
- `git diff --check`