### PR TITLE
fix(harness): bound silent Codex turns

### DIFF
--- a/docs/CODEX-GATE.md
+++ b/docs/CODEX-GATE.md
@@ -102,6 +102,9 @@ All endpoints bind `127.0.0.1` only.
   `CODEX_GATE_MOCK=1` (deterministic test backend, no CLI, no billing).
 - `held_turns` — always 0 here (see above); present so monitoring can treat
   both gates alike.
+- `turn_timeout_seconds` / `idle_timeout_seconds` — the total and no-output
+  deadlines applied to each Codex process. Escape-room preflight rejects a
+  gateway whose idle deadline is disabled or exceeds the campaign maximum.
 - `stateless` / `session_stateless` — the HTTP and CLI session contract only.
   They make no claim that the isolated Codex home remains empty.
 - `hardened`, `codex_version`, `exec_flags`, `disabled_features`,
@@ -146,6 +149,7 @@ Config (env, read at start):
 | `CODEX_GATE_MODEL` | *(empty)* | model when the request names none; empty = let the CLI use its own configured default (no `-m` passed) |
 | `CODEX_GATE_MODELS` | `default` | advertised on `/v1/models`; `default` omits `codex -m` so the CLI chooses its configured current model |
 | `CODEX_GATE_TIMEOUT` | `900` | seconds one `codex exec` may run |
+| `CODEX_GATE_IDLE_TIMEOUT` | `300` | seconds a `codex exec` may produce no stdout/stderr before its process group is killed; `0` disables this deadline |
 | `CODEX_GATE_HEARTBEAT` | `30` | seconds between protocol-valid SSE comments while `codex exec` is still running; keep below the caller's no-progress timeout |
 | `CODEX_GATE_CONCURRENCY` | `4` | max simultaneous codex processes |
 | `CODEX_GATE_QUOTA_MAX_WAIT` | `21600` | maximum seconds to preserve and retry a usage-limit-paused request; `0` returns a structured 429 immediately |

--- a/tests/agent-harness/grind.py
+++ b/tests/agent-harness/grind.py
@@ -898,6 +898,12 @@ def gateway_preflight(url, model, requirements):
     if requirements.get("quota_recovery") and \
             health.get("quota_recovery") is not True:
         raise RuntimeError("gateway does not support bounded quota recovery")
+    idle_max = requirements.get("idle_timeout_max")
+    if idle_max is not None:
+        idle = health.get("idle_timeout_seconds")
+        if not isinstance(idle, (int, float)) or idle <= 0 or idle > idle_max:
+            raise RuntimeError("gateway idle timeout %r exceeds campaign maximum %r"
+                               % (idle, idle_max))
     # The gateway's own CLI surface is an experimental variable (INFR-413).
     # A campaign that does not pin it is not reproducible, so a scenario file
     # can require the pinning and name the features it must cover.

--- a/tests/agent-harness/scenarios/nsaudit-redteam.yaml
+++ b/tests/agent-harness/scenarios/nsaudit-redteam.yaml
@@ -6,6 +6,7 @@ gateway:
   backend: codex-cli
   stateless: true
   quota_recovery: true
+  idle_timeout_max: 300
   hardened: true
   disabled_features:
     - plugins

--- a/tests/host/codex_gate_test.sh
+++ b/tests/host/codex_gate_test.sh
@@ -45,6 +45,7 @@ BASE="http://127.0.0.1:$PORT"
 out="$(curl -sf "$BASE/health")"
 echo "$out" | grep -q '"backend": "mock"' || fail "health: wrong backend ($out)"
 echo "$out" | grep -q '"held_turns": 0' || fail "health: held_turns missing ($out)"
+echo "$out" | grep -q '"idle_timeout_seconds": 300' || fail "health: idle timeout missing ($out)"
 pass "health reports mock backend"
 
 # 2. /v1/models lists the aliases llmsrv's model picker shows
@@ -145,20 +146,36 @@ class Proc:
     returncode = None
     killed = False
     waited = False
-    async def communicate(self, data):
-        await asyncio.Event().wait()
+    pid = 12345
+    def __init__(self):
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.stdin = self.Stdin()
+        self.exited = asyncio.Event()
+    class Stdin:
+        def write(self, data):
+            pass
+        async def drain(self):
+            pass
+        def close(self):
+            pass
     def kill(self):
         self.killed = True
         self.returncode = -9
+        self.exited.set()
     async def wait(self):
         self.waited = True
+        await self.exited.wait()
+        return self.returncode
 
 async def check():
     proc = Proc()
     async def create(*args, **kwargs):
         return proc
     m.asyncio.create_subprocess_exec = create
+    m.os.killpg = lambda pid, sig: proc.kill()
     task = asyncio.create_task(m.run_codex("default", "prompt", None))
+    await asyncio.sleep(0)
     await asyncio.sleep(0)
     task.cancel()
     try:
@@ -372,6 +389,45 @@ assert "-m" not in argv, argv
 PY
 pass "codex exec argv is sandboxed and stdin-fed"
 
+# A CLI that starts a turn and then stops producing events must not consume the
+# rest of a child campaign deadline. The gate kills its whole process group and
+# returns a terminal error while retaining the longer total limit for active
+# extended-reasoning turns.
+python3 - "$ROOT" <<'PY' || fail "idle Codex process was not reaped"
+import asyncio
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+
+root = sys.argv[1]
+with tempfile.TemporaryDirectory() as td:
+    fake = os.path.join(td, "fake-codex")
+    with open(fake, "w") as stream:
+        stream.write("#!/bin/sh\ncat >/dev/null\nprintf '{\\\"type\\\":\\\"turn.started\\\"}\\n'\nsleep 30\n")
+    os.chmod(fake, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    os.environ["CODEX_GATE_BIN"] = fake
+    os.environ["CODEX_GATE_TIMEOUT"] = "5"
+    os.environ["CODEX_GATE_IDLE_TIMEOUT"] = "0.1"
+    os.environ["CODEX_GATE_WORKDIR"] = td
+    spec = importlib.util.spec_from_file_location(
+        "codex_gate_idle", root + "/tools/codex-gate/codex_gate.py")
+    gate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gate)
+
+    async def check():
+        try:
+            await gate.run_codex("default", "prompt", None)
+        except gate.CodexError as error:
+            assert "IDLE_TIMEOUT" in str(error), error
+        else:
+            raise AssertionError("hung CLI returned")
+
+    asyncio.run(check())
+PY
+pass "silent Codex turns fail within the idle deadline"
+
 # 10. Subscription guard: the gate serves the host's `codex login`, never an
 #    API key. It refuses to start while OPENAI_API_KEY is set (which the CLI
 #    can prefer over the ChatGPT sign-in), and never passes one to the child.
@@ -580,6 +636,8 @@ for requirements, expect in (
         ({"backend": "codex-cli"}, "backend"),
         ({"hardened": True, "backend": "mock"}, None),
         ({"quota_recovery": True, "backend": "mock"}, None),
+        ({"idle_timeout_max": 300, "backend": "mock"}, None),
+        ({"idle_timeout_max": 299, "backend": "mock"}, "idle timeout"),
         ({"disabled_features": ["plugins"], "backend": "mock"}, None),
         ({"disabled_features": ["no_such_feature"], "backend": "mock"}, "does not disable"),
         ({"codex_version": "codex-cli 9.9.9", "backend": "mock"}, "pins")):

--- a/tools/codex-gate/codex_gate.py
+++ b/tools/codex-gate/codex_gate.py
@@ -54,6 +54,7 @@
 #   CODEX_GATE_MODEL      default model; empty = let the CLI use its own
 #   CODEX_GATE_MODELS     comma-separated list advertised on /v1/models
 #   CODEX_GATE_TIMEOUT    seconds one `codex exec` may run (default 900)
+#   CODEX_GATE_IDLE_TIMEOUT seconds with no CLI output before abort (default 300)
 #   CODEX_GATE_HEARTBEAT  seconds between SSE keepalives (default 30)
 #   CODEX_GATE_CONCURRENCY  max simultaneous codex processes (default 4)
 #   CODEX_GATE_QUOTA_MAX_WAIT max seconds to preserve/retry a quota-paused turn
@@ -108,7 +109,8 @@ MOCK_ERROR_SYSTEM_MATCH = os.environ.get(
     "CODEX_GATE_MOCK_ERROR_SYSTEM_MATCH", "")
 CODEX_BIN = os.environ.get("CODEX_GATE_BIN", "codex")
 DEFAULT_MODEL = os.environ.get("CODEX_GATE_MODEL", "")
-EXEC_TIMEOUT = float(os.environ.get("CODEX_GATE_TIMEOUT", "900"))
+EXEC_TIMEOUT = max(0.05, float(os.environ.get("CODEX_GATE_TIMEOUT", "900")))
+IDLE_TIMEOUT = max(0.0, float(os.environ.get("CODEX_GATE_IDLE_TIMEOUT", "300")))
 HEARTBEAT = max(0.05, float(os.environ.get("CODEX_GATE_HEARTBEAT", "30")))
 CONCURRENCY = int(os.environ.get("CODEX_GATE_CONCURRENCY", "4"))
 SANDBOX = os.environ.get("CODEX_GATE_SANDBOX", "read-only")
@@ -942,27 +944,21 @@ async def run_codex(model, prompt, schema):
         argv = build_argv(model, schema_path, last_path, prompt)
         log.debug("exec: %s", " ".join(argv))
         try:
+            process_group = {"start_new_session": True} if os.name == "posix" else {}
             proc = await asyncio.create_subprocess_exec(
                 *argv, cwd=WORKDIR, env=child_env(),
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
+                stderr=asyncio.subprocess.PIPE,
+                **process_group)
         except FileNotFoundError:
             raise CodexError("codex CLI not found (%s) — install it or set "
                              "CODEX_GATE_BIN" % CODEX_BIN)
         try:
-            out, err = await asyncio.wait_for(
-                proc.communicate(prompt.encode()), timeout=EXEC_TIMEOUT)
+            out, err = await communicate_with_deadlines(proc, prompt.encode())
         except asyncio.CancelledError:
-            if proc.returncode is None:
-                proc.kill()
-            await proc.wait()
+            await kill_process_group(proc)
             raise
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise CodexError("codex exec exceeded CODEX_GATE_TIMEOUT (%.0fs)"
-                             % EXEC_TIMEOUT)
         finally:
             # The CLI may have changed its isolated home even on failure.
             _home_inventory_cache = None
@@ -998,6 +994,96 @@ async def run_codex(model, prompt, schema):
             raise CodexError(stderr.strip().splitlines()[-1])
         return text, usage
     raise CodexError("codex exec failed")
+
+
+async def capture_output(stream, chunks, progress):
+    while True:
+        data = await stream.read(8192)
+        if not data:
+            return
+        chunks.append(data)
+        progress.put_nowait(1)
+
+
+async def feed_input(stream, data):
+    try:
+        stream.write(data)
+        await stream.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
+    finally:
+        stream.close()
+
+
+async def kill_process_group(proc):
+    if proc.returncode is None:
+        try:
+            if os.name == "posix":
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+        except OSError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+    await proc.wait()
+
+
+async def communicate_with_deadlines(proc, input_data):
+    """Capture CLI output while enforcing total and no-output deadlines."""
+    out_chunks, err_chunks = [], []
+    progress = asyncio.Queue()
+    readers = [
+        asyncio.create_task(capture_output(proc.stdout, out_chunks, progress)),
+        asyncio.create_task(capture_output(proc.stderr, err_chunks, progress)),
+    ]
+    loop = asyncio.get_running_loop()
+    total_deadline = loop.time() + EXEC_TIMEOUT
+    idle_deadline = loop.time() + IDLE_TIMEOUT if IDLE_TIMEOUT > 0 else total_deadline
+    input_task = asyncio.create_task(feed_input(proc.stdin, input_data))
+    wait_task = asyncio.create_task(proc.wait())
+    progress_task = None
+    try:
+        while not wait_task.done():
+            now = loop.time()
+            remaining = min(total_deadline - now, idle_deadline - now)
+            if remaining <= 0:
+                break
+            progress_task = asyncio.create_task(progress.get())
+            done, _ = await asyncio.wait(
+                (wait_task, progress_task), timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED)
+            if progress_task in done:
+                idle_deadline = loop.time() + IDLE_TIMEOUT
+                progress_task = None
+            elif progress_task is not None:
+                progress_task.cancel()
+                progress_task = None
+
+        if not wait_task.done():
+            now = loop.time()
+            idle = IDLE_TIMEOUT > 0 and idle_deadline <= now and total_deadline > now
+            await kill_process_group(proc)
+            if idle:
+                raise CodexError(
+                    "codex exec produced no output for CODEX_GATE_IDLE_TIMEOUT (%.0fs)"
+                    % IDLE_TIMEOUT)
+            raise CodexError("codex exec exceeded CODEX_GATE_TIMEOUT (%.0fs)"
+                             % EXEC_TIMEOUT)
+        await asyncio.gather(*readers)
+        return b"".join(out_chunks), b"".join(err_chunks)
+    finally:
+        if progress_task is not None:
+            progress_task.cancel()
+        if not wait_task.done():
+            wait_task.cancel()
+        if not input_task.done():
+            input_task.cancel()
+        for task in readers:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(input_task, *readers, return_exceptions=True)
 
 
 async def codex_turn(model, system_prompt, prompt, tooldefs):
@@ -1163,6 +1249,8 @@ async def health(request):
         "stateless": True,
         "session_stateless": True,
         "quota_recovery": QUOTA_MAX_WAIT > 0,
+        "turn_timeout_seconds": EXEC_TIMEOUT,
+        "idle_timeout_seconds": IDLE_TIMEOUT,
         "state": state,
         "quota": {
             "paused_turns": len(_quota_pauses),


### PR DESCRIPTION
## Motivation

A source-assisted escape-room campaign left one child activity working until settlement timeout. Its final tool result had completed, but the following Codex request remained open until teardown. The existing total turn timeout could exceed the child campaign time remaining, and `communicate()` offered no no-progress signal.

## Changes

- capture Codex stdout and stderr incrementally
- abort after 300 seconds without CLI output while retaining the 900-second total deadline
- kill and reap the full Codex process group on timeout or cancellation
- expose both deadlines through `/health`
- require the nsaudit red-team campaign to preflight an enabled idle deadline of at most 300 seconds
- document `CODEX_GATE_IDLE_TIMEOUT`

## Acceptance criteria

- a Codex process that emits an event and then hangs is killed within the configured idle deadline
- descendants holding output pipes are reaped with the process group
- cancellation still reaps Codex
- quota pause/retry behavior remains unchanged
- campaign preflight rejects disabled, absent, or excessive idle deadlines

## Tests

- `tests/host/codex_gate_test.sh` (PASS on minipc using the preserved campaign Python environment; obsolete system Codex feature validation intentionally excluded)
- `tests/host/grind_escape_test.sh` (PASS)
- `python3 -m py_compile tools/codex-gate/codex_gate.py tests/agent-harness/grind.py`
- `sh -n tests/host/codex_gate_test.sh`
- `git diff --check`