### PR TITLE
Bare-metal Pi 3B+ boots to desktop with Tk login, USB, Ethernet, SD card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,19 @@ jobs:
         chmod +x tests/host/llmsrv_session_capability_test.sh
         ROOT=. tests/host/llmsrv_session_capability_test.sh
 
+    - name: Run dossrv badent alias check
+      run: |
+        # dossrv must decide "damaged entry" from the on-disk name, not
+        # the badent- alias it hands out: a healthy file named badent-1
+        # has to have its clusters freed by rm. The same fixture runs
+        # under QEMU in baremetal_test.sh, which no workflow runs; this
+        # is the hosted copy, against the emu built above. 77 = skip
+        # (no emu or python3).
+        chmod +x tests/host/dossrv_badent_test.sh
+        rc=0
+        ROOT=. bash tests/host/dossrv_badent_test.sh || rc=$?
+        [ "$rc" = 0 ] || [ "$rc" = 77 ] || exit "$rc"
+
     - name: Run test suite
       run: |
         # Create /tmp inside Inferno root for tmp_writable test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,11 @@ infernode/
 │   ├── wm/              #   Window manager
 │   └── svc/             #   Services (httpd, etc.)
 ├── module/              # Limbo module interfaces (.m files)
+├── os/                  # NATIVE (bare-metal) kernel: os/arm64 shared AArch64,
+│                        #   os/bcm2837 Raspberry Pi 3B+, os/port portable kernel,
+│                        #   os/ip TCP/IP, os/init the Dis that boots it.
+│                        #   Built and tested ONLY via tests/host/baremetal_test.sh;
+│                        #   status and roadmap in os/bcm2837/README.md.
 ├── tests/               # Unit tests (Limbo + shell)
 │   ├── host/            #   Host-side shell tests
 │   ├── inferno/         #   Inferno-side shell tests

--- a/appl/cmd/dossrv.b
+++ b/appl/cmd/dossrv.b
@@ -762,9 +762,16 @@ rremove(t: ref Tmsg.Remove): ref Rmsg
 	# entry may once have owned are deliberately leaked for an
 	# offline fsck to sweep.
 	#
+	# Damaged is decided from the name ON THE DISK, not the name
+	# handed out. This used to match the prefix of the presented
+	# name, and a perfectly healthy file that happened to be called
+	# badent-1 -- a legal name, and one a person cleaning up after
+	# this very code might well type -- was removed by this path,
+	# with its cluster chain left allocated and unreachable.
+	#
 	if(getfile(f) >= 0){
-		bd := dostat(f);
-		if(len bd.name >= 7 && bd.name[0:7] == "badent-"){
+		bd := rawstat(f);
+		if(badname(bd.name)){
 			doremove(f.xf, f.ptr);
 			putfile(f);
 			xfile(t.fid, Clunk);
@@ -854,7 +861,14 @@ rstat(t: ref Tmsg.Stat): ref Rmsg
 	return ref Rmsg.Stat(t.tag, *dir);
 }
 
-dostat(f: ref Xfile): ref Sys->Dir
+#
+# The entry as it is on the disk: the name is the real one, however
+# damaged. dostat() below is this plus the badent alias, and is what
+# every reply to a client goes through. rremove needs this one, because
+# "is the name an alias?" cannot be answered from the aliased name -- a
+# real file is free to be CALLED badent-anything.
+#
+rawstat(f: ref Xfile): ref Sys->Dir
 {
 	islong :=0;
 	prevdo: int;
@@ -899,6 +913,12 @@ dostat(f: ref Xfile): ref Sys->Dir
 	}
 	if(islong)
 		dir.name = longnamebuf;
+	return dir;
+}
+
+dostat(f: ref Xfile): ref Sys->Dir
+{
+	dir := rawstat(f);
 	fixname(dir);
 	return dir;
 }
@@ -923,20 +943,27 @@ badentname(qp: big): string
 	return sys->sprint("badent-%bux", qp);
 }
 
-fixname(dir: ref Sys->Dir)
+#
+# Is this on-disk name one the kernel would refuse at dirread? The
+# single definition of "damaged", shared by the alias on the way out
+# and by rremove deciding whether it is looking at damage.
+#
+badname(name: string): int
 {
-	name := dir.name;
-	if(name == "" || name == "." || name == ".."){
-		dir.name = badentname(dir.qid.path);
-		return;
-	}
+	if(name == "" || name == "." || name == "..")
+		return 1;
 	for(i := 0; i < len name; i++){
 		c := name[i];
-		if(c < 16r20 || c == 16r7f || c == '/'){
-			dir.name = badentname(dir.qid.path);
-			return;
-		}
+		if(c < 16r20 || c == 16r7f || c == '/')
+			return 1;
 	}
+	return 0;
+}
+
+fixname(dir: ref Sys->Dir)
+{
+	if(badname(dir.name))
+		dir.name = badentname(dir.qid.path);
 }
 
 nameok(elem: string): int

--- a/appl/cmd/mkfile
+++ b/appl/cmd/mkfile
@@ -62,6 +62,7 @@ TARG=\
 	diff.dis\
 	disdep.dis\
 	disdump.dis\
+	dossrv.dis\
 	du.dis\
 	echo.dis\
 	ed.dis\

--- a/appl/wm/logon.b
+++ b/appl/wm/logon.b
@@ -23,7 +23,25 @@ implement WmLogon;
 # First boot: prompts for new password + confirmation, creates secstore account.
 # Subsequent boots: prompts for password, unlocks secstore, loads keys.
 #
-# For headless: profile detects no display and falls back to console prompt.
+# The exit status is the contract with the boot script, and there are
+# three outcomes it has to tell apart. Inferno sh treats a command
+# that returns as success and one that raises "fail:<reason>" as a
+# failure with $status set to <reason>, so:
+#
+#	logged in	init returns; factotum holds the keys
+#	skipped		raise "fail:skipped" -- the user chose to go
+#			on without secstore (Escape twice, or Escape
+#			after a failed unlock). Deliberate, and the
+#			desktop may start, but not silently: it has
+#			no factotum and the script must say so.
+#	anything else	raise "fail:<why>" -- no display, no keyboard,
+#			the form would not build, the keyboard closed.
+#			Nothing was authenticated and nothing was
+#			chosen; a crash is not a login.
+#
+# Before this, every one of those returned normally, and the bare-metal
+# boot script -- which starts the desktop on success -- could not tell
+# a login from a login screen that had died before it drew.
 #
 
 include "sys.m";
@@ -93,6 +111,13 @@ statusmsg: string;
 state: int;
 escpending: int;
 
+# How this screen ended, for the exit status described at the top:
+# nil means logged in; anything else is raised as "fail:<outcome>"
+# once the input readers are dead. The handlers set it when they
+# return 1 to leave the loop.
+outcome: string;
+SKIPPED: con "skipped";
+
 stderr: ref Sys->FD;
 
 init(ctxt: ref Draw->Context, nil: list of string)
@@ -112,11 +137,8 @@ init(ctxt: ref Draw->Context, nil: list of string)
 		display_g = ctxt.display;
 	if(display_g == nil) {
 		display_g = Display.allocate(nil);
-		if(display_g == nil) {
-			# No display — headless fallback
-			headlessprompt();
-			return;
-		}
+		if(display_g == nil)
+			giveup(sys->sprint("no display: %r"));
 	}
 
 	# If factotum was already started with secstore backing (e.g. headless
@@ -130,6 +152,7 @@ init(ctxt: ref Draw->Context, nil: list of string)
 	confirmbuf = "";
 	savedpass = "";
 	escpending = 0;
+	outcome = nil;
 
 	# Load brand image once (reloading per-redraw can fail under resource pressure)
 	logo_g = loadpng(IMGPATH);
@@ -146,22 +169,16 @@ init(ctxt: ref Draw->Context, nil: list of string)
 		statusmsg = "Enter password to unlock";
 	}
 
-	if(tk == nil || !buildform()) {
-		sys->fprint(stderr, "logon: cannot build the login form: %r\n");
-		headlessprompt();
-		return;
-	}
+	if(tk == nil || !buildform())
+		giveup(sys->sprint("cannot build the login form: %r"));
 	redraw();
 
 	# Input straight from the devices: there is no window manager to
 	# route it yet. Enter and Escape drive the state machine here;
 	# everything else is the field's business and goes to Tk.
 	kbdfd := sys->open("/dev/keyboard", Sys->OREAD);
-	if(kbdfd == nil) {
-		sys->fprint(stderr, "logon: cannot open /dev/keyboard: %r\n");
-		headlessprompt();
-		return;
-	}
+	if(kbdfd == nil)
+		giveup(sys->sprint("cannot open /dev/keyboard: %r"));
 	ptrfd := sys->open("/dev/pointer", Sys->OREAD);
 
 	kbdch := chan of int;
@@ -183,9 +200,12 @@ init(ctxt: ref Draw->Context, nil: list of string)
 	done := 0;
 	while(!done) alt {
 	k := <-kbdch =>
-		if(k < 0)
+		if(k < 0){
+			# The keyboard went away under us. Nobody typed a
+			# password and nobody chose to skip.
+			outcome = "keyboard closed";
 			done = 1;
-		else case k {
+		}else case k {
 		'\n' or '\r' =>
 			escpending = 0;
 			passbuf = fieldtext();
@@ -205,9 +225,24 @@ init(ctxt: ref Draw->Context, nil: list of string)
 
 	# The readers are blocked in read; left alone they would go on
 	# eating the desktop's keystrokes after this screen is gone.
+	# Killed BEFORE the raise below, on every path: a raise leaves
+	# init at once and would otherwise leave them running.
 	kill(kbdpid);
 	if(ptrpid >= 0)
 		kill(ptrpid);
+
+	if(outcome != nil)
+		raise "fail:" + outcome;
+}
+
+# Fail before the input loop ever ran: nothing to kill, nothing on
+# screen worth a delay, and the reason goes to stderr as well as to
+# the shell -- on a bare-metal boot stderr is the serial console and
+# the only place the reason can be read.
+giveup(why: string)
+{
+	sys->fprint(stderr, "logon: %s\n", why);
+	raise "fail:" + why;
 }
 
 kbdreader(fd: ref Sys->FD, out: chan of int, pids: chan of int)
@@ -285,10 +320,21 @@ handleenter(): int
 			return 0;
 		}
 		# Passwords match — create account and unlock
-		dosetupandunlock(passbuf);
+		err := dosetupandunlock(passbuf);
 		passbuf = "";
 		savedpass = "";
-		return 1;
+		if(err == nil)
+			return 1;
+		# It used to exit here whatever dosetupandunlock had done,
+		# which on a first boot with no secstored running meant a
+		# desktop with no factotum and no account, two seconds after
+		# an error nobody had time to read. Offer the same two ways
+		# out a failed unlock gets; Enter goes back to setup, since
+		# there is still no account.
+		state = STATE_LOGIN_FAILED;
+		statusmsg = err + "\nEnter: try again  |  Escape: continue without secstore";
+		redraw();
+		return 0;
 
 	STATE_LOGIN =>
 		r := dounlock();
@@ -305,10 +351,16 @@ handleenter(): int
 		return 0;
 
 	STATE_LOGIN_FAILED =>
-		# Enter from failed state — go back to password entry
+		# Enter from failed state — go back to password entry, or
+		# to account setup if the failure was there and left none.
 		passbuf = "";
-		state = STATE_LOGIN;
-		statusmsg = "Enter password to unlock";
+		if(secstoreacctexists()){
+			state = STATE_LOGIN;
+			statusmsg = "Enter password to unlock";
+		}else{
+			state = STATE_SETUP_PASS;
+			statusmsg = "First boot — choose a secstore password";
+		}
 		redraw();
 		return 0;
 
@@ -383,6 +435,7 @@ handleescape(): int
 		statusmsg = "Continuing without secstore";
 		redraw();
 		sys->sleep(500);
+		outcome = SKIPPED;
 		return 1;
 
 	* =>
@@ -391,6 +444,7 @@ handleescape(): int
 			statusmsg = "Skipped";
 			redraw();
 			sys->sleep(300);
+			outcome = SKIPPED;
 			return 1;
 		}
 		escpending = 1;
@@ -560,18 +614,15 @@ redraw()
 	tk->cmd(top, "update");
 }
 
-# First boot: create secstore account, then unlock
-dosetupandunlock(pass: string)
+# First boot: create secstore account, then unlock.
+# Returns nil on success, else what went wrong, for the caller to show.
+dosetupandunlock(pass: string): string
 {
 	statusmsg = "Creating secstore account...";
 	redraw();
 	err := createsecstoreacct(pass);
-	if(err != nil) {
-		statusmsg = "Setup failed: " + err;
-		redraw();
-		sys->sleep(2000);
-		return;
-	}
+	if(err != nil)
+		return "Setup failed: " + err;
 
 	statusmsg = "Unlocking (this may take a moment)...";
 	redraw();
@@ -584,14 +635,11 @@ dosetupandunlock(pass: string)
 
 	pass = "";
 
-	if(err != nil) {
-		statusmsg = err;
-		redraw();
-		sys->sleep(2000);
-		return;
-	}
+	if(err != nil)
+		return err;
 
 	finishunlock();
+	return nil;
 }
 
 # Normal boot: unlock secstore and load keys.
@@ -973,15 +1021,6 @@ secstoreacctexists(): int
 		user = "inferno";
 	(ok, nil) := sys->stat("/usr/inferno/secstore/" + user + "/PAK");
 	return ok >= 0;
-}
-
-headlessprompt()
-{
-	# Fallback for headless: use factotum's built-in console prompt
-	sys->fprint(stderr, "logon: no display, using console\n");
-	# Nothing to do — factotum -S will prompt on its own if needed,
-	# or the user can manually run:
-	#   auth/factotum -S tcp!localhost!5356
 }
 
 loadpng(path: string): ref Image

--- a/docs/JIT.md
+++ b/docs/JIT.md
@@ -148,6 +148,25 @@ command line to a ticket and remove the entry.
   AArch64 side was affected: `comp-arm64.c`'s `macfrp` fix was proven
   under QEMU by the bare-metal harness, not by this test.
 
+  *Later the same day, reproduced and attributed.* The full hosted
+  runner (`emu -c1 /dis/tests/runner.dis`) hits it deterministically:
+  all fifteen cases of `tests/asyncio_test.b` die with
+  `sys: segmentation violation addr=0xffffffffd8ab86a0` (and nearby),
+  PC in `altrdy` at `alt.c:98`, the `c = ac->c` load. The same runner
+  against an emulator built from `origin/master` passes `asyncio`. The
+  only commit on `feat/baremetal-pi` that touches `comp-amd64.c` or
+  `xec.c` is fb64f77 ("dis: a Limbo int is 32 bits on a 64-bit word"),
+  and the faulting address is exactly a 32-bit value sign-extended into
+  a 64-bit pointer -- so a `w`-typed store the JIT now sign-extends is
+  carrying a pointer-sized value somewhere on the `alt` path (the `Alt`
+  block's channel slots, or the count/index words next to them). That
+  commit's own tests (`intsem_test`, `jit_test`) pass; the runner is
+  the only thing that covers it. **This blocks merging the branch to
+  `master`**; see os/bcm2837/README.md, tier 2 item 8. Two unrelated
+  pre-existing `-c1` failures (`Aes256Sha256`, `cipher_matrix`, SEGV in
+  JIT-generated code) also appear with master's own emulator on a Linux
+  amd64 host and are not this branch's.
+
 ## When to leave JIT off
 
 - **Tiny scripts / shell pipelines.** JIT compilation has a one-time per-module cost; a script that runs for 2 ms gains nothing and pays the compile.

--- a/docs/JIT.md
+++ b/docs/JIT.md
@@ -126,6 +126,28 @@ These are the values the [Lucia launch scripts](LUCIA.md#launching) use. Lower v
 
 For deep debug stories — what worked, what didn't, every blind alley — the [arm64-jit/](arm64-jit/) directory has 27 session logs.
 
+### Open faults
+
+Known, unreproduced, and not yet ticketed — recorded here so they are
+not lost. Anyone who hits one should attach the module and the exact
+command line to a ticket and remove the entry.
+
+- **amd64 `-c1`: SEGV in `altrdy()` (`libinterp/alt.c`) on an `alt`
+  over two unbuffered channels inside a helper function.** Seen
+  2026-09-05 while writing `tests/fdclose_test.b`: the first draft had a
+  helper that spawned a reader and a timer, each with its own unbuffered
+  `chan of int`, and `alt`ed on both; it faulted in `altrdy` under
+  `-c1` in every test case, and passed under `-c0`. The `Testing` module
+  was loaded and a `ref T` was live in the caller's frame at the time.
+  Five later probes with the same channel shape, and eight runs of a
+  bare module with the identical helper and no `Testing`, did not
+  reproduce it, so the `alt` alone is not the trigger; something in the
+  surrounding frame is, and it has not been isolated. The draft that
+  faulted was not kept. The shipped test avoids `alt` entirely
+  (one buffered channel; comment in the test explains). Nothing on the
+  AArch64 side was affected: `comp-arm64.c`'s `macfrp` fix was proven
+  under QEMU by the bare-metal harness, not by this test.
+
 ## When to leave JIT off
 
 - **Tiny scripts / shell pipelines.** JIT compilation has a one-time per-module cost; a script that runs for 2 ms gains nothing and pays the compile.

--- a/lib/lucifer/boot-baremetal.sh
+++ b/lib/lucifer/boot-baremetal.sh
@@ -17,34 +17,121 @@
 
 load std
 
+#
+# The desktop's namespace, narrowed.
+#
+# Every process on this machine runs as the host owner
+# (os/arm64/main.c), so no identity check refuses a desktop program
+# anything. The only thing between an agent tool and the raw SD card
+# is what the tool's namespace does not contain -- which is how the
+# rest of InferNode draws its boundaries (docs/DESIGN-PRINCIPLES.md),
+# and it is drawn here, before anything of the desktop's starts, so
+# that logon, luciuisrv, lucifer and everything they spawn inherit it.
+#
+# What the desktop gets is /dev as the kernel built it, less this:
+#
+#	#S	/dev/sdcard, /dev/sdctl	the raw card and its partition
+#					table (sdaddpart checks nothing)
+#	#G	/dev/gpio/N/{ctl,level}	the pins
+#	/dev/sysctl			reboot, tryboot, halt, panic
+#	/dev/hostowner			renames the owner of every process
+#
+# and keeps: #c (cons, keyboard, random, time, user, null, drivers --
+# what a program expects of /dev), #m the pointer, #B the running
+# kernel image (read-only) and #b the microsecond timer. #i, the draw
+# device, is not bound by the kernel (main.c: attaching it takes the
+# panel from the text console) and not bound here either: libdraw's
+# initdisplay binds it the first time a program opens a display, so
+# it lands in THIS namespace when logon starts, and the panel stays a
+# console until then. /n, /usr, /dis, /lib, /fonts, /net, /prog, /env
+# and /chan are inherited as they are.
+#
+# #S and #G are whole devices unioned onto /dev, so they come out with
+# unmount. /dev/sysctl and /dev/hostowner are two files of #c, and #c
+# is also the console and the keyboard, so they cannot be unmounted;
+# /dev/null is bound over each instead. A write lands in null, a read
+# is empty, and the version line logon shows falls back to the brand
+# name. (Verified: Inferno's cmount takes a file over a file with
+# MREPL, and pgrpcpy gives this process its own mount table.)
+#
+# pctl forkns first. sh forks its namespace as it starts, so this
+# script already has its own copy -- but that is a property of how the
+# profile happens to invoke it, and the boundary must not depend on
+# that. The serial console shell is another process group and is not
+# touched by any of this: it keeps the card, the pins and sysctl,
+# because it is the management plane.
+#
+pctl forkns
+unmount '#S' /dev
+unmount '#G' /dev
+bind /dev/null /dev/sysctl
+bind /dev/null /dev/hostowner
+
+#
+# And check that it took, because this is a boundary: a desktop
+# started over a namespace that still holds the card is exactly what
+# the lines above exist to prevent, and an unmount that failed prints
+# one line on a console nobody is watching.
+#
+narrowed=1
+if {ftest -e /dev/sdcard} {narrowed=0}
+if {ftest -e /dev/sdctl} {narrowed=0}
+if {ftest -e /dev/gpio} {narrowed=0}
+v=`{cat /dev/sysctl}
+if {! ~ $#v 0} {narrowed=0}
+if {~ $narrowed 0} {
+	echo 'boot: the desktop namespace still holds the card, the pins or sysctl; NOT starting the desktop.'
+	exit
+}
+
 # Let the boot settle: this races USB enumeration and service
 # startup, and logon's first act is to attach the draw device.
 sleep 3
 
 skip=0
 if {ftest -f /n/dos/skiplogon} {skip=1}
-if {! ~ $#skiplogon 0} {skip=1}
+if {~ $skiplogon 1} {skip=1}
 
+#
+# wm/logon has three outcomes and the shell must tell them apart (the
+# contract is at the top of appl/wm/logon.b):
+#
+#	it returns	logged in; factotum holds the keys
+#	skipped		the user chose to go on without secstore, twice.
+#			Deliberate, so the desktop starts -- but said
+#			so here, because from the panel it looks the
+#			same as a login and it is not one.
+#	anything else	it died: no display, no keyboard, no form. Retry,
+#			and after three tries say so and STOP. A crash
+#			is not a login, and the serial console is still
+#			a shell; skiplogon exists for the deliberate
+#			no-auth posture.
+#
+# The first version of this loop tested the exit status alone, which
+# was success on every one of those paths.
+#
+# $status is copied at once: `if` sets it from every condition it
+# runs, so by the time the reason is printed the `~` test has replaced
+# it with "no match".
+#
 ok=0
 if {~ $skip 1} {
 	echo 'boot: skiplogon -- desktop without factotum/secstore'
 	ok=1
 }{
-	#
-	# Retried, and FAIL-CLOSED. A login screen that dies must not
-	# quietly fall through to an authenticated-looking desktop with
-	# no factotum behind it -- a crash is not a login. If logon
-	# cannot run after three tries, say so and stop; the serial
-	# console is still a shell, and skiplogon exists for the
-	# deliberate no-auth posture.
-	#
 	for i in 1 2 3 {
 		if {~ $ok 0} {
 			if {wm/logon} {
 				ok=1
 			}{
-				echo 'boot: wm/logon failed (try' $i 'of 3)'
-				sleep 2
+				why=$status
+				if {~ $why skipped} {
+					echo 'boot: login skipped at the screen -- desktop WITHOUT factotum/secstore; keys will not persist'
+					ok=1
+				}{
+					echo 'boot: wm/logon failed:' $why '(try' $i 'of 3)'
+					sleep 2
+				}
 			}
 		}
 	}
@@ -56,6 +143,6 @@ if {~ $ok 1} {
 	echo activity create Main > /mnt/ui/ctl
 	lucifer
 }{
-	echo 'boot: logon would not start; NOT starting the desktop.'
+	echo 'boot: logon would not run; NOT starting the desktop.'
 	echo 'boot: fix logon, or create /n/dos/skiplogon for a no-auth desktop.'
 }

--- a/lib/lucifer/boot-baremetal.sh
+++ b/lib/lucifer/boot-baremetal.sh
@@ -44,7 +44,13 @@ load std
 # initdisplay binds it the first time a program opens a display, so
 # it lands in THIS namespace when logon starts, and the panel stays a
 # console until then. /n, /usr, /dis, /lib, /fonts, /net, /prog, /env
-# and /chan are inherited as they are.
+# and /chan are inherited as they are -- and "as they are" includes
+# /n/dos read-write: the FAT boot partition, holding config.txt and
+# the kernel image the firmware loads. A desktop program can no longer
+# write the raw card, but it can still overwrite the kernel it booted
+# from through the filesystem. Inferno has no read-only bind, so that
+# is not closed here; it belongs with the second half of this item
+# (a non-eve user for the desktop, and a /n it does not own).
 #
 # #S and #G are whole devices unioned onto /dev, so they come out with
 # unmount. /dev/sysctl and /dev/hostowner are two files of #c, and #c
@@ -53,6 +59,16 @@ load std
 # is empty, and the version line logon shows falls back to the brand
 # name. (Verified: Inferno's cmount takes a file over a file with
 # MREPL, and pgrpcpy gives this process its own mount table.)
+#
+# One consequence is deliberate and must be known: lucifer's Quit
+# (shutdown() in appl/cmd/lucifer.b) and xenith's killwins() write
+# "halt" to /dev/sysctl before they exit. Here that write lands in
+# null and succeeds, so Quit ends the desktop and the board stays up
+# with the serial console alive -- which is the point: a desktop
+# program, or anything it spawned, must not be able to stop the
+# machine. Halting is the management plane's, and the line printed
+# when lucifer returns (bottom of this script) says so on the console
+# so that a dead panel is not mistaken for a hung board.
 #
 # pctl forkns first. sh forks its namespace as it starts, so this
 # script already has its own copy -- but that is a property of how the
@@ -142,6 +158,13 @@ if {~ $ok 1} {
 	sleep 1
 	echo activity create Main > /mnt/ui/ctl
 	lucifer
+	#
+	# The desktop's own Quit wrote "halt" into the null bound over
+	# its /dev/sysctl (see the namespace comment above), so the board
+	# is still running, with a dead panel. Say so where it can be
+	# read; halt or reboot from the serial console.
+	#
+	echo 'boot: the desktop has exited. The machine is still up: a Quit from the panel cannot halt the board (its /dev/sysctl is null). Halt or reboot from the serial console.'
 }{
 	echo 'boot: logon would not run; NOT starting the desktop.'
 	echo 'boot: fix logon, or create /n/dos/skiplogon for a no-auth desktop.'

--- a/lib/lucifer/boot.sh
+++ b/lib/lucifer/boot.sh
@@ -20,8 +20,28 @@ if {! ~ $user ''} {
 # logon runs). When $skiplogon is 1, secstore stays locked and
 # factotum starts empty; downstream code that needs keys (LLM
 # keyring mounts, etc.) will fail in expected ways.
+#
+# wm/logon returns when the user logged in, fails with status
+# "skipped" when they chose to go on without secstore, and fails with
+# the reason otherwise (no display, no keyboard -- see the top of
+# appl/wm/logon.b). The hosted boot goes on to the desktop in every
+# case, as it always has: the host's own login already stands between
+# the world and this screen, and a developer running without a
+# display wants the desktop, not a refusal. But it says which of the
+# three it was, because a desktop with no factotum looks exactly like
+# one with. ($status is copied first: `if` resets it from every
+# condition it evaluates, the `~` included.)
 if {! ~ $skiplogon 1} {
-	wm/logon
+	if {wm/logon} {
+		echo 'boot: logged in — secstore keys are in factotum'
+	}{
+		why=$status
+		if {~ $why skipped} {
+			echo 'boot: login skipped at the screen — no factotum, no secstore; keys will not persist'
+		}{
+			echo 'boot: wm/logon failed:' $why '— continuing without factotum/secstore'
+		}
+	}
 }{
 	echo 'boot: skiplogon=1 — wm/logon bypassed (dev mode; no factotum, no secstore)'
 }

--- a/libinterp/comp-arm64.c
+++ b/libinterp/comp-arm64.c
@@ -2240,22 +2240,44 @@ preamble(void)
 /*
  * Macro implementations.
  */
+/*
+ * Free-pointer macro: drop one reference to the heap cell in RA0.
+ *
+ * The shape is comp-amd64.c's, and the two things it gets right are
+ * both load-bearing. The test is "ref == 1" BEFORE any decrement, and
+ * the last-reference path does not store one: destroy() in heap.c
+ * does its own --ref, so a macro that stored ref-1 first would hand
+ * it a zero, the unsigned decrement would wrap, and the cell would
+ * read as referenced for ever. And the flags the branch consumes are
+ * set by the compare on the refcount, not left over from the nil
+ * check. The previous version did SUB_IMM (which sets no flags) and
+ * then BCOND(NE) on the nil check's flags, always NE for a non-nil
+ * pointer, so rdestroy was unreachable and no compiled code ever ran
+ * a destructor: a dropped fd stayed open until the collector found
+ * it. Found by reading; confirmed by etherusb's #l handoff, whose
+ * endpoint stayed "inuse" after fd = nil.
+ */
 static void
 macfrp(void)
 {
-	u32int *nilcheck, *notzero;
+	u32int *nilcheck, *lastref;
 
-	CMN_IMM(RA0, 1);
+	CMN_IMM(RA0, 1);		/* H is (void*)-1: nothing to count */
 	nilcheck = code;
 	BCOND(EQ, 0);
 
 	mem(Ldw, O(Heap, ref) - sizeof(Heap), RA0, RA2);
+	CMP_IMM(RA2, 1);
+	lastref = code;
+	BCOND(EQ, 0);
+
+	/* ref > 1: one fewer, and done */
 	SUB_IMM(RA2, RA2, 1);
 	mem(Stw, O(Heap, ref) - sizeof(Heap), RA0, RA2);
-	notzero = code;
-	BCOND(NE, 0);
+	RET_X30();
 
-	/* ref == 0: save state, call rdestroy */
+	/* ref == 1: save state, let rdestroy take the last one */
+	PATCH_BCOND(lastref);
 	mem(Stw, O(REG, FP), RREG, RFP);
 	mem(Stw, O(REG, s), RREG, RA0);
 	mem(Stw, O(REG, st), RREG, 30);
@@ -2267,7 +2289,6 @@ macfrp(void)
 	mem(Ldw, O(REG, MP), RREG, RMP);
 
 	PATCH_BCOND(nilcheck);
-	PATCH_BCOND(notzero);
 	RET_X30();
 }
 

--- a/os/arm64/arch.S
+++ b/os/arm64/arch.S
@@ -61,6 +61,33 @@ coherence:
 	ret
 
 /*
+ * ulong ainc(ulong *addr)
+ *
+ * Atomic increment; returns the NEW value, as Plan 9's ainc does.
+ *
+ * For counters that several cores bump without a lock: nspurious and the
+ * profiler's buckets are written from every core's interrupt path, and a
+ * plain ++ there is a load, an add and a store that another core's ++ can
+ * land between -- a lost count, not a crash, which is exactly the kind
+ * of wrongness that survives for months. A lock would be heavier than the
+ * counter it guards; a load/store-exclusive loop is the right size.
+ *
+ * ldxr/stxr rather than ldadd: the Cortex-A53 is ARMv8.0 and has no LSE
+ * atomics, and the kernel is compiled for the base architecture. No
+ * acquire/release ordering is asked for -- these are statistics, and
+ * nothing is published through them.
+ */
+	.global	ainc
+ainc:
+1:
+	ldxr	x1, [x0]
+	add	x1, x1, #1
+	stxr	w2, x1, [x0]
+	cbnz	w2, 1b			/* store lost the race; retry */
+	mov	x0, x1
+	ret
+
+/*
  * Cache maintenance for instructions written as data.
  *
  * void cacheiflush(void *addr, ulong len)

--- a/os/arm64/devboot.c
+++ b/os/arm64/devboot.c
@@ -10,10 +10,27 @@
  * So publish it. Installing the running kernel then needs no new
  * mechanism and no transfer at all -- it is
  *
- *	cp /dev/bootimage /n/dos/infernode8.img
+ *	cp /dev/bootimage /n/dos/tryboot.img
+ *	echo tryboot > /dev/sysctl
  *
  * with the ordinary cp, through the ordinary filesystem, and anything
- * that can copy a file can do it.
+ * that can copy a file can do it. To a CANDIDATE name, never over the
+ * file config.txt boots: infernode8.img is the kernel known to work,
+ * and the only thing allowed to replace it is a candidate that has
+ * booted --
+ *
+ *	mv /n/dos/tryboot.img /n/dos/infernode8.img
+ *
+ * typed at the candidate's own shell. The reset with the tryboot flag
+ * boots the candidate once, under a watchdog; a candidate that hangs
+ * or panics resets back to the incumbent. The card recipe is in
+ * os/bcm2837/README.md.
+ *
+ * #B/bootargs is the other half: the command line the firmware
+ * handed this boot, which is how osinit knows it is the candidate
+ * (the tryboot configuration puts the word "tryboot" on it) and so
+ * whether to print the promotion step. Board code reads it from the
+ * firmware; see os/bcm2837/board.c.
  *
  * A SNAPSHOT is served rather than the live memory, and that is the
  * whole subtlety here. The image runs from where it was loaded, so its
@@ -34,6 +51,7 @@
 enum{
 	Qdir,
 	Qimage,
+	Qargs,
 };
 
 /*
@@ -51,6 +69,7 @@ extern char _start[], __data_start[], edata[], __datastash[];
 static Dirtab boottab[]={
 	".",		{Qdir, 0, QTDIR},	0,	0555,
 	"bootimage",	{Qimage},		0,	0444,
+	"bootargs",	{Qargs},		0,	0444,
 };
 
 static Chan*
@@ -90,6 +109,12 @@ bootread(Chan *c, void *a, long n, vlong off)
 {
 	if(c->qid.type & QTDIR)
 		return devdirread(c, a, n, boottab, nelem(boottab), devgen);
+	if((ulong)c->qid.path == Qargs){
+		char buf[1024+2];
+
+		snprint(buf, sizeof buf, "%s\n", boardcmdline());
+		return readstr(off, a, n, buf);
+	}
 	if((ulong)c->qid.path != Qimage)
 		error(Ebadusefd);
 

--- a/os/arm64/fns.h
+++ b/os/arm64/fns.h
@@ -212,5 +212,6 @@ void	tryboot(void);
 void	booted(void);
 void	boardbooted(void);
 void	boardbootwatchdog(void);
+void	boardwatchdogpoll(void);
 int	boardcandidate(void);
 char*	boardcmdline(void);

--- a/os/arm64/fns.h
+++ b/os/arm64/fns.h
@@ -203,3 +203,14 @@ void	kprocchild(Proc*, void(*)(void*), void*);
 void	boardreboot(void);
 void	boardtryboot(void);
 void	tryboot(void);
+
+/*
+ * The boot watchdog and the command line that controls it -- see
+ * os/bcm2837/board.c. booted() is devcons's "booted" sysctl word;
+ * boardbooted() is what it means to the hardware.
+ */
+void	booted(void);
+void	boardbooted(void);
+void	boardbootwatchdog(void);
+int	boardcandidate(void);
+char*	boardcmdline(void);

--- a/os/arm64/fns.h
+++ b/os/arm64/fns.h
@@ -10,6 +10,8 @@ void	serialrecover(void);
 int	hwrandom(uchar*, int);
 void	uartputstr(char*);
 void	uartlockon(void);
+int	uartlock(void);
+void	uartunlock(int);
 void	uartputx(u64int);
 void	uartputd(u64int);
 
@@ -88,12 +90,13 @@ u64int	clockticks(void);
 void	microdelay(int);
 int	clockintr(Ureg*);
 int	irqdispatch(Ureg*);
-extern int irqorphan;
+extern int irqorphan[];
 void	intrdump(void);
 int	intrpending(void);
 int	getmacaddr(uchar*);
 void	mmunormalnc(uintptr, usize);
 extern ulong nspurious;
+ulong	ainc(ulong*);
 /*
  * intr.c -- the board's interrupt controller.
  *

--- a/os/arm64/main.c
+++ b/os/arm64/main.c
@@ -2258,6 +2258,15 @@ kmain(void)
 	serialrecover();
 
 	boardprobe();
+
+	/*
+	 * Read the command line and, if this is a tryboot candidate, arm
+	 * the boot watchdog -- here, before the MMU, the allocators or
+	 * any driver, so that nothing a candidate can get wrong runs
+	 * unguarded. Released by osinit's "booted"; see board.c.
+	 */
+	boardbootwatchdog();
+
 	startmmu();
 
 	/*

--- a/os/arm64/main.c
+++ b/os/arm64/main.c
@@ -265,6 +265,7 @@ probeuartin(void)
 	n = 0;
 	deadline = clockcount() + 3*clockfreq();
 	while(clockcount() < deadline){
+		boardwatchdogpoll();	/* interrupts are masked: no tick reloads it */
 		c = uartgetc();
 		if(c >= 0){
 			n++;

--- a/os/arm64/main.c
+++ b/os/arm64/main.c
@@ -2074,11 +2074,18 @@ squidboy(void)
 	m->proc = nil;
 
 	/*
-	 * A clock of its own, or tsleep() on this core would insert into
-	 * a per-core timer queue that nothing ever services -- a sleep
-	 * with a timeout that cannot fire, which is a hang wearing a
-	 * timeout's clothes. This also gives the core hzclock preemption
-	 * for free.
+	 * A clock of its own. portclock.c keeps a Timer queue per core
+	 * and services it only from that core's clock interrupt, so this
+	 * core must take ticks or its queue is dead. secclockinit() also
+	 * puts this core's hzclock Timer on that queue -- the entry with
+	 * no callback that timerintr() turns into hzclock() -- which is
+	 * what makes the tick a clock here: m->ticks advances,
+	 * active.exiting is honoured, and a process that will not yield
+	 * is preempted at HZ. Without that entry the interrupt arrived a
+	 * thousand times a second and did nothing, which is how cores 1-3
+	 * ran for the first months of SMP. (tsleep() was never the
+	 * casualty it looked like: it uses the global talarm list, which
+	 * whichever core ticks first services.)
 	 */
 	secclockinit();
 	{
@@ -2107,15 +2114,163 @@ squidboy(void)
 	iprint("cpu%d: up\n", m->machno);	/* iprint: no up, no qlock */
 
 	/*
-	 * Straight into the scheduler. No devices are routed here, no
-	 * clock ticks here; this core exists to run whatever processes
-	 * core0's interrupts make ready. Preemption on this core is
-	 * voluntary for now -- every kernel process sleeps or yields,
-	 * and the one CPU-bound process this system has (the Dis VM)
-	 * yields through its own scheduler. A per-core timer can come
-	 * later if a workload appears that needs it.
+	 * Straight into the scheduler. No devices are routed here -- every
+	 * GPU interrupt goes to core 0 -- so this core runs whatever
+	 * processes core 0's interrupts make ready, plus its own clock:
+	 * the tick set up above preempts here exactly as on core 0, and
+	 * smpcheck() proves that on every boot rather than asserting it
+	 * in a comment, which is what the previous version of this
+	 * paragraph did, wrongly, for months.
 	 */
 	schedinit();
+}
+
+/*
+ * Prove the secondaries preempt, once, at every boot.
+ *
+ * The claim "cores 1-3 tick" lived in comments for months while it was
+ * false: each secondary's clock interrupt ran, found an empty Timer
+ * queue and returned, so a process that did not yield owned its core
+ * until it chose to stop. Nothing noticed, because every kproc this
+ * system runs sleeps or yields, and the one CPU-bound one -- the Dis VM
+ * -- yields through its own scheduler. A comment cannot be regression
+ * tested. This can.
+ *
+ * The proof, per secondary: wire a kproc to the core and have it spin
+ * without yielding for Spinms; once it reports it is spinning, wire a
+ * second kproc to the same core and time how long that one waits to run
+ * there. With hzclock preempting on the core the wait is a tick or two;
+ * without it the probe runs only when the hog exits, Spinms later. The
+ * budget between those is wide, and the two outcomes are two hundred
+ * times apart, so this cannot pass by timing luck on a slow emulator.
+ *
+ * Wiring is what makes the test exact: runproc() honours p->wired, so
+ * neither kproc can be picked up by another core and the only way the
+ * probe runs is the hog being taken off its core by the tick. It costs
+ * three quarters of a second of one core each at boot, while the Dis
+ * boot proceeds on the others.
+ */
+enum
+{
+	Spinms	= 250,		/* the hog's run if nothing preempts it */
+	Preemptbudget	= 25000,	/* µs: 25 ticks at HZ=1000; a tick or two is normal */
+};
+
+typedef struct Preempt Preempt;
+struct Preempt
+{
+	int	core;
+	int	hogging;	/* the hog is on its core and spinning */
+	int	done;		/* the probe has run on its core */
+	uvlong	waited;		/* fastticks from the probe wiring itself to running there */
+};
+
+static Preempt preempt[MAXMACH];	/* static: the kprocs outlive a timed-out wait */
+
+/*
+ * Restrict the calling process to one core and go there. sched() puts
+ * us back on the run queue, from which only the named core will take
+ * us; when it returns we are running on that core.
+ *
+ * mp is set as well as wired, as Plan 9's procwired() does, and the
+ * first version of this did not: runproc() passes over a process whose
+ * last core was a different one until its movetime (HZ/10 after the
+ * move) has expired, preferring one that ran here -- and the hog ran
+ * here. So the probe, freshly arrived from wherever kproc() first ran
+ * it, was skipped at every tick for a hundred milliseconds in favour of
+ * the very process it was meant to displace, and the proof read
+ * 150-220ms: preemption working, affinity hiding it. Claiming the core
+ * as the last one run on is what "wired here" means to runproc.
+ */
+static void
+wireto(int core)
+{
+	up->wired = MACHP(core);
+	up->mp = MACHP(core);
+	sched();
+}
+
+static void
+preempthog(void *a)
+{
+	Preempt *pp;
+	uvlong end, hz;
+
+	pp = a;
+	wireto(pp->core);
+	fastticks(&hz);
+	end = fastticks(nil) + hz*Spinms/1000;
+	pp->hogging = 1;
+	coherence();
+	/*
+	 * No yield, no lock, no sleep: the point is a process that
+	 * gives the scheduler no opening but the clock interrupt.
+	 */
+	while(fastticks(nil) < end)
+		;
+	pexit("", 0);
+}
+
+static void
+preemptprobe(void *a)
+{
+	Preempt *pp;
+	uvlong t0;
+
+	pp = a;
+	t0 = fastticks(nil);
+	wireto(pp->core);
+	pp->waited = fastticks(nil) - t0;
+	coherence();
+	pp->done = 1;
+	pexit("", 0);
+}
+
+static void
+smpcheck(void *)
+{
+	Preempt *pp;
+	int core, i, ok;
+	uvlong hz, us;
+	char buf[128], *p, *e;
+
+	fastticks(&hz);
+	ok = 1;
+	p = buf;
+	e = buf + sizeof buf;
+	for(core = 1; core < conf.nmach; core++){
+		if((active.machs & (1<<core)) == 0){
+			p = seprint(p, e, " cpu%d absent", core);
+			ok = 0;
+			continue;
+		}
+		pp = &preempt[core];
+		pp->core = core;
+		kproc("preempthog", preempthog, pp, 0);
+		for(i = 0; i < 100 && !pp->hogging; i++)
+			tsleep(&up->sleep, return0, nil, 10);
+		if(!pp->hogging){
+			p = seprint(p, e, " cpu%d hog never ran", core);
+			ok = 0;
+			continue;
+		}
+		kproc("preemptprobe", preemptprobe, pp, 0);
+		for(i = 0; i < 100 && !pp->done; i++)
+			tsleep(&up->sleep, return0, nil, 10);
+		if(!pp->done){
+			p = seprint(p, e, " cpu%d probe never ran", core);
+			ok = 0;
+			continue;
+		}
+		us = pp->waited * 1000000 / hz;
+		p = seprint(p, e, " cpu%d %lludus", core, us);
+		if(us > Preemptbudget)
+			ok = 0;
+	}
+	USED(p);
+	print("smp:  preempt%s %s\n", buf,
+		ok ? "OK" : "BROKEN (a kproc wired to a busy core did not run within the tick budget)");
+	pexit("", 0);
 }
 
 static void
@@ -2467,6 +2622,13 @@ kmain(void)
 	 * re-queue or reap it.
 	 */
 	launchsmp();
+
+	/*
+	 * After launchsmp, so active.machs says which cores answered;
+	 * before schedinit, because kproc() wants a current process to
+	 * copy from and mainproc is the last one there is.
+	 */
+	kproc("smpcheck", smpcheck, nil, 0);
 
 	up = nil;
 	spllo();

--- a/os/arm64/notyet.c
+++ b/os/arm64/notyet.c
@@ -227,6 +227,18 @@ tryboot(void)
 	exit(0);
 }
 
+/*
+ * "booted" on /dev/sysctl: osinit's word that the shell is loaded and
+ * about to run. What that means to the hardware is the board's
+ * business -- on the BCM2837 it releases the boot watchdog a tryboot
+ * candidate armed in kmain; see boardbooted().
+ */
+void
+booted(void)
+{
+	boardbooted();
+}
+
 void
 halt(void)
 {

--- a/os/arm64/notyet.c
+++ b/os/arm64/notyet.c
@@ -239,11 +239,12 @@ halt(void)
  *
  * Upstream uses it to notice that the clock interrupt has been masked
  * for too long while spinning, and to run the timer callbacks that
- * would otherwise be starved. This port drives its tick from clock.c
- * rather than portclock.c's Timer machinery, and runs on one core where
- * a contended ilock means a deadlock rather than a wait -- so there is
- * nothing useful to do here yet, and taslock.c's spin limit is what
- * actually catches the deadlock.
+ * would otherwise be starved. Here every core's tick goes through
+ * portclock.c's timerintr() (clock.c hands it over; each core owns a
+ * periodic hzclock Timer on its own queue), and a contended ilock is a
+ * wait for another core rather than a deadlock -- so there is nothing
+ * to rescue here, and taslock.c's spin limit is what catches the case
+ * where the holder never comes back.
  */
 void
 clockcheck(void)

--- a/os/arm64/trap.c
+++ b/os/arm64/trap.c
@@ -72,11 +72,23 @@ slotname(u64int t)
 	return from[(t >> 2) & 3];
 }
 
+/*
+ * Held under the console lock for the whole dump, on purpose. This is
+ * the report a panic leaves behind, and with four cores it is the one
+ * most likely to be written while another core is also talking -- the
+ * first SMP panic on the board was three cores' dumps shuffled together
+ * line by line, and none of them could be read. uartlock() is
+ * re-entrant for the calling core, so the uartputstr/uartputx calls
+ * inside write straight through; a core that cannot get the lock within
+ * the bound prints anyway, so a dump is delayed, never lost. It does not
+ * bypass the lock: bypassing was the old behaviour, by accident.
+ */
 void
 dumpureg(Ureg *u)
 {
-	int i;
+	int i, held;
 
+	held = uartlock();
 	uartputstr("\n  vector:  ");
 	uartputstr(slotname(u->type));
 	uartputstr("\n  esr:     ");
@@ -157,6 +169,7 @@ dumpureg(Ureg *u)
 		}
 	}
 	uartputstr("\n");
+	uartunlock(held);
 }
 
 /* kernel image bounds, from the linker script */

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1725,6 +1725,14 @@ also changes hosted behaviour — Limbo `int` semantics in both JITs and
 the interpreter, `runt.c` print bounds, `draw.h`'s `BGLONG` — and those
 need the hosted suite on both architectures before the merge.
 
+*Blocker found 2026-09-05:* the hosted runner under `-c1` on Linux
+amd64 crashes every `asyncio_test` case in `altrdy` (`alt.c:98`) with
+this branch's emulator and passes with `master`'s. The only suspect is
+fb64f77, the Limbo-`int` sign-extension change to `comp-amd64.c`: the
+fault address is a 32-bit value sign-extended into a pointer. Details
+under "Open faults" in `docs/JIT.md`. Fix and prove it with the full
+runner before merging; `intsem_test` and `jit_test` do not cover it.
+
 **9. Network device lifecycle.** `#l` binds once, ever (`devether.c`);
 its reader and writer kprocs exit on error without closing their
 endpoints; `etherusb.b` has no detach handling although `#u` now

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1109,11 +1109,19 @@ Hunting lessons written in blood, for the next person here:
   server always did.
 - Limbo `fd = nil` did NOT close the endpoint before the kernel tried
   to take it -- the FD destructor provably did not run at the
-  assignment (the ep stayed inuse until process exit). The handoff
-  closes by sys->dup of #c/null over the descriptor, which replaces
-  the chan inline. WHY the destructor is late is an OPEN QUESTION that
-  implies every dropped fd on this kernel leaks until its process
-  exits.
+  assignment (the ep stayed inuse until process exit). For a while the
+  handoff closed by sys->dup of #c/null over the descriptor instead.
+  RESOLVED 2026-09-05: it was the JIT. `comp-arm64.c` `macfrp()`
+  decremented the refcount with `SUB_IMM`, which sets no flags, then
+  `BCOND(NE)`'d on the flags the nil check had left -- always NE for
+  a non-nil pointer -- so `rdestroy` was unreachable and compiled code
+  never ran any destructor; every dropped fd waited for the
+  collector. The macro now has comp-amd64.c's shape (compare with 1,
+  branch to rdestroy on equal, else decrement and store), the dup is
+  gone, and the handoff is a plain `fd = nil`. Pinned by
+  `tests/fdclose_test.b` (hosted, both -c0 and -c1), by osinit's
+  `init: fd:` self-checks, and by the harness asserting the "(kernel
+  data path)" handoff line.
 
 ### Single-shot bulk transfers, and the two bugs that forbade them
 
@@ -1279,6 +1287,21 @@ in compiled code and checks `#u`'s endpoint `inuse` (or a pipe's other
 end seeing EOF) *without* the dup workaround; then remove the
 workaround. Run the hosted runner on macOS with `-c1` in CI. Half a day
 of code; the test is the point.
+
+**DONE 2026-09-05.** `macfrp()` now compares the refcount with 1 and
+branches to `rdestroy` on equal without storing a decrement, else
+decrements and stores; an audit of every other `BCOND` in the file
+found each one directly preceded by its own compare. `tests/fdclose_test.b`
+drops a pipe's write end by assignment, by frame return, through a ref
+adt and through `tl` on a list cell, and reads EOF from the other end
+within a bound; it also proves a second reference keeps the file open.
+It passes on hosted Linux under both `-c0` and `-c1` (amd64 JIT). On
+AArch64 the fixed macro is exercised by osinit's `init: fd:` self-checks
+(assignment and return drops, each read to EOF) which the harness
+asserts with the JIT on, and by the `#l` handoff in `etherusb.b`, which
+is now a plain `fd = nil` -- the `#c/null` dup is gone and the harness
+asserts the "(kernel data path)" line. The macOS `-c1` CI run is still
+to do.
 
 **2. Cores 1–3 have no clock tick.** `timersinit()`
 (`os/port/portclock.c`) creates the one periodic Timer whose purpose is

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1298,6 +1298,21 @@ harness asserts `cpu1..3: up`, and a busy Limbo loop pinned by chance to
 a secondary is preempted by a second one. Nothing in the harness
 currently asserts that SMP came up at all.
 
+**DONE 2026-09-05.** `secclockinit` now calls `timersinitmach()`
+(`portclock.c`), which puts a periodic nil-`tf` Timer on the calling
+core's own queue without re-running `todinit`; `checkalarms` already
+tolerates concurrent callers (`canlock`) and the runq path is the one
+the secondaries' schedulers already used. Observable as `/dev/sysstat`
+(one `cpuN ticks T intrs I timers F` line per running core), asserted
+by `osinit` ("init: clock ticks on 4 of 4 cores") and by a boot-time
+preemption proof in `main.c` (`smpcheck`: a kproc wired to a spinning
+core runs there within a tick budget, ~1ms with preemption, 250ms
+without). The harness now checks `cpu1..3: up`, both lines, and the
+shell's `cat /dev/sysstat`. Verified with the full harness under QEMU
+raspi3b (159 checks, up from 152, all passing) plus five further boots
+of the same image, each showing all four cores ticking, preemption
+latencies of a few milliseconds and no fault.
+
 **3. Every process is the host owner.** `main.c` sets the user to
 `inferno`, which is `eve`, for every process, so `iseve()` is always
 true, and `#S`, `#G` and `/dev/sysctl` are bound into the `/dev` the
@@ -1344,13 +1359,19 @@ logged-in / skipped / failed, and the script honours them. Hours.
 - `irqorphan` (`intr.c`) is reset by *every* core's timer interrupt
   (`clock.c`), so a genuinely unhandled GPU interrupt on core 0 can be
   reported "spurious" by a tick on core 1 and storm silently.
+  DONE 2026-09-05: per-core (`irqorphan[MAXMACH]`).
 - `devusb.c` `CMdetach` releases every endpoint on every write; a
   second "detach" double-frees. `osinit` writes once today.
 - `uart.c` zeroes the console mutex after a bounded spin even when it
   never acquired it; `uartputx`/`uartputd` and `dumpureg` bypass it.
+  DONE 2026-09-05: `uartlock()`/`uartunlock()` release only what the
+  caller took, are re-entrant per core, and `uartputx`/`uartputd`,
+  `dumpureg` and `intrdump` emit under it as whole pieces.
 - Unlocked multi-core writers: `ticks++` and the profiler buckets in
   `clock.c`, `nspurious` and `irqenabled |=` in `intr.c`. Lossy at
   best; `irqenabled` from a kproc on another core is the one to fix.
+  DONE 2026-09-05: `irqenabled` under an `ilock`; `nspurious` and the
+  buckets through `ainc` (`arch.S`, ldxr/stxr); `ticks` is core 0's.
 - `lock()` has two different spin bounds (1M with `up == nil`, 100M
   otherwise) and `schedinit`/interrupt-time wakeups use the short one
   against locks that are held across a memset.

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -982,6 +982,36 @@ unattended board wants), `nowatchdog` (never arm — for a kernel being
 stepped under a debugger) and `wdogtest` (arm, and ignore the release,
 so the reset at the budget can be watched on the board).
 
+The hardware count is 15 seconds at most (20 bits at 65536Hz), so the
+90-second budget is kept by reloading it, and the boot path has two
+halves to reload it in. After `kmain`'s final `spllo` the clock tick on
+core 0 does it every 64 ticks. Before that — the allocators, the
+probes, the SMP launch, the card, everything up to `schedinit` —
+interrupts are masked and the tick cannot run, and that half is not
+short: `probeuartin` waits three seconds on purpose, `launchsmp` up to
+five for cores that never answer, `emmcinit` two for a card to power
+up plus its command timeouts. So `microdelay()`, which every one of
+those waits loops around, and `probeuartin`'s own loop poll the same
+reload whenever five seconds have passed since the last one. In code
+that is waiting on purpose the count never falls below ten seconds;
+it reaches zero only when nothing has polled for fifteen — a hang, or
+a spin that does not go through `microdelay` (the mailbox spin is the
+one that matters). QEMU cannot show the reload at all, since its model
+resets on the arming write; the interval is a board result.
+
+A boot whose command line *cannot be read* — `GET_COMMAND_LINE`
+unanswered, or a line longer than the kernel's 1024-byte buffer, which
+the protocol answers by copying nothing and reporting the length —
+arms. The kernel cannot tell which boot it is, and a boot that reaches
+the shell releases the watchdog and has lost nothing but the line
+`boot: command line: (UNREAD: the firmware reports N bytes, ...)`
+saying why, while a candidate left unarmed because its line was
+1100 bytes would have cost the power switch. `nowatchdog` cannot be
+honoured on such a boot, because it cannot be seen; the fix is a
+shorter `cmdline.txt` or a bigger buffer (`Mboxcmdlinemax` in
+`board.h`). A real Pi's line, with the firmware's additions, runs to
+a few hundred bytes.
+
 The one `config.txt`, with `init_uart_clock` pinned because uart.c
 divides for 115200 assuming 48MHz and the firmware, not the kernel,
 decides what that reference is:
@@ -1006,20 +1036,50 @@ For a card with no kernel yet, `kernel=serialboot.img` in place of the
 `kernel=infernode8.img` line, and the first candidate is installed from
 a serial-fed kernel exactly as above.
 
+Be clear about what the guard on a candidate rests on: **two** firmware
+behaviours, stacked, and neither yet seen on a Pi 3. First, that
+`SET_REBOOT_FLAGS` from this kernel makes the next boot take the
+`[tryboot]` section at all. Second, that the section's `cmdline=` is
+what the firmware then hands `GET_COMMAND_LINE`, so the word reaches
+the kernel. The second is the same conditional-filter machinery that
+applies the section's `kernel=` — the firmware documentation lists
+`cmdline` as an ordinary `config.txt` property and `[tryboot]` as an
+ordinary conditional filter, restricting neither to a model — so a
+firmware that boots `tryboot.img` from
+the section but serves the other file's line would be a firmware bug
+rather than a documented gap; but it is untested, and the failure is
+quiet. If the first behaviour fails the candidate never boots and the
+known-good kernel does, which is safe. If the second fails the
+candidate boots *unguarded* and the only tell is its own `wdog: not
+armed (not a tryboot candidate)` line on a boot that should have said
+`armed`. Watch for that line on the first candidate boot; and if it
+appears, `bootwatchdog` in the **known-good** `cmdline.txt` puts the
+guard on every boot regardless of which section the firmware applied,
+since that file is read whenever the section does not override it.
+
 *Status, 2026-09-05.* Everything on this path that emulation can prove
 is in the harness: the command line reaching the kernel and `osinit`
 through `#B/bootargs`, the candidate announcement and promotion text,
 the arming write reaching the PM block, the `booted` release
 handshake, and `echo tryboot > /dev/sysctl` resetting the machine.
-What only the board can prove, and has not yet: that the firmware
-honours `SET_REBOOT_FLAGS` from this kernel and boots the `[tryboot]`
-section (the candidate's `boot: command line:` line is the evidence;
-`tryboot: firmware acknowledged ...` on the way out is the firmware's
-own word, meaningless under QEMU); that `PM_WDOG` counts down and the
-tick's reloads hold it off for 90 seconds (`bootwatchdog wdogtest` on
-`cmdline.txt`, and the board should reset at 90 s and come back with
-`pm:   rsts` showing the watchdog-reset bit 0x20); that the
-`PM_RSTC` disarm write leaves the machine up. The earlier
+Sixteen checks were added (152 → 168), and the count should be read
+honestly: fourteen fail on the code before the change, and two — the
+`tryboot: resetting` line and the reboot after it — passed before it
+too, because `notyet.c`'s print and the `PM_RSTC` full reset predate
+the mailbox handshake; they pin that path against regression and are
+labelled so in the script. What only the board can prove, and has not
+yet: that the firmware honours `SET_REBOOT_FLAGS` from this kernel and
+boots the `[tryboot]` section, and that the section's `cmdline=` is
+what reaches the kernel (the candidate's `boot: command line:` line is
+the evidence for both; `tryboot: firmware acknowledged ...` on the way
+out is the firmware's own word, meaningless under QEMU); that `PM_WDOG`
+counts down and the reloads — the tick's after `spllo`, `microdelay`'s
+poll before it — hold it off for 90 seconds (`bootwatchdog wdogtest`
+on `cmdline.txt`, and the board should reset at 90 s and come back
+with `pm:   rsts` showing the watchdog-reset bit 0x20); that the
+`PM_RSTC` disarm write leaves the machine up; and the real length of
+the firmware's command line against the 1024-byte buffer, which the
+`boot: command line:` line now reports if it does not fit. The earlier
 `boardtryboot` set bit 5 of `PM_RSTS` and called it the tryboot bit;
 the downstream Linux tree shows the flag is a mailbox tag and bit 5 is
 the watchdog reset-cause bit, and the code now does what Linux does.
@@ -1420,6 +1480,31 @@ checks the arming line, the release line, the candidate announcement,
 resets QEMU; it cannot check the countdown or the firmware's answer,
 because QEMU models neither — the recipe and the remaining board proof
 are under "Working on the board without moving the card".
+
+*Review follow-up, 2026-09-05.* Two reviewers read the change. The
+budget analysis had a hole: the 64-tick reload cannot run until
+`kmain`'s final `spllo`, so the whole pre-scheduler boot — the
+three-second UART probe, up to five seconds waiting for secondary
+cores, the card's two-second power-up — ran on the 15-second hardware
+count alone, and the comments called that "a hang with interrupts
+off". `microdelay()` and `probeuartin`'s loop now poll the reload
+(`boardwatchdogpoll`, `board.c`) once five seconds have passed since
+the last one. `mboxreboot` read the tag response out of the shared
+mailbox buffer after the lock was dropped, so the "firmware
+acknowledged" line — the board evidence — could have been a
+framebuffer scroll's answer; `mboxprop1` now holds the lock through
+the copy-back and returns the tag word. A command line longer than the
+buffer was reported as "(empty)" and booted a candidate unarmed;
+`mboxcmdline` now returns the firmware's length unclamped, the kernel
+prints `UNREAD` with the length, and arms. The two shell-tryboot checks
+that pass on the old code are labelled as pins, above and in the
+script. Verification: the changed files compile under the harness's
+flags, and the harness run made after the change had passed 85 of its
+168 checks with no failure — the tryboot arming and reset checks among
+them — when the orchestrating session was closed before it finished;
+the full run should be confirmed at merge. None of the three fixes
+changes QEMU output: the reload interval, the unread-line arming and
+the lock's effect on the board line remain board results.
 
 **5. The login screen is bypassable in two ways, one deliberate.**
 `boot-baremetal.sh` treats `wm/logon` exiting 0 as a login. Escape

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -46,8 +46,6 @@ a Tk form; `luciuisrv` and `lucifer`.
 Not done, in one line each; the detail and the order are in "Next" at
 the end of this file:
 
-- a confirmed JIT bug means compiled code never runs a reference's
-  destructor, so dropped fds and heap cells wait for the collector
 - cores 1–3 have no clock tick, so nothing preempts on them
 - every process is the host owner, and the desktop namespace holds the
   raw card, the pins and `/dev/sysctl`
@@ -1301,7 +1299,11 @@ AArch64 the fixed macro is exercised by osinit's `init: fd:` self-checks
 asserts with the JIT on, and by the `#l` handoff in `etherusb.b`, which
 is now a plain `fd = nil` -- the `#c/null` dup is gone and the harness
 asserts the "(kernel data path)" line. The macOS `-c1` CI run is still
-to do.
+to do. Follow-up 2026-09-05: `dis/tests/fdclose_test.dis` added to
+`tools/dis-manifest.txt`, the stale "not done" bullet at the top of this
+file removed, and the hosted amd64 `-c1` `altrdy` SEGV that the first
+draft of the test hit (unreproduced since) is recorded under "Open
+faults" in `docs/JIT.md` so it gets its own ticket.
 
 **2. Cores 1–3 have no clock tick.** `timersinit()`
 (`os/port/portclock.c`) creates the one periodic Timer whose purpose is

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1314,6 +1314,20 @@ mechanism — `bind`, `newns` — already exists), then a non-eve user for
 the desktop and agents. A week for the second; an afternoon for the
 first.
 
+*First half DONE 2026-09-05.* `boot-baremetal.sh` now forks its
+namespace before anything of the desktop's starts, unmounts `#S` and
+`#G` from `/dev`, binds `/dev/null` over `/dev/sysctl` and
+`/dev/hostowner`, and refuses to start the desktop if `/dev/sdcard`,
+`/dev/gpio` or a readable `sysctl` is still there afterwards; the
+comment in the script is the record of what the desktop's `/dev`
+holds (`#i` arrives there through libdraw's own bind when logon opens
+the display, as before). Verified by a new harness session that types
+the same sequence into a child shell over the serial line with the
+FAT16 card attached: inside, the card, the pins and sysctl are gone
+and `echo halt > /dev/sysctl` does not stop the machine; back in the
+console shell all three are still there (seven checks). The second
+half — a non-eve user — is untouched.
+
 **4. tryboot is a one-shot flag, not yet an A/B path.**
 `cp /dev/bootimage /n/dos/infernode8.img` (`devboot.c`) overwrites the
 file `config.txt` names — the known-good kernel. A/B exists only if the
@@ -1338,6 +1352,24 @@ the display or `/dev/keyboard` cannot be opened, which is precisely the
 Also `if {! ~ $#skiplogon 0}` enables the skip for `skiplogon=0`, unlike
 the hosted `~ $skiplogon 1`. Fix: distinct exit statuses for
 logged-in / skipped / failed, and the script honours them. Hours.
+
+*DONE 2026-09-05.* `logon.b` returns only on a login, raises
+`fail:skipped` for the deliberate skip (Escape twice, or Escape after
+a failed unlock or a failed first-boot setup, which now offers that
+choice instead of exiting), and `fail:<reason>` when there is no
+display, no form or no keyboard or the keyboard closes; the input
+readers are killed before the raise on every path. `boot-baremetal.sh`
+copies `$status` (an `if` resets it from every condition it runs,
+`~` included), starts the desktop on a login, starts it on a skip with
+a console line saying there is no factotum, and after three failures
+refuses; the skiplogon test is `~ $skiplogon 1`. The hosted
+`boot.sh` prints which of the three it was and goes on as before.
+Verified on the hosted emulator with the boot-script logic run
+against child shells raising the three statuses, and by reading
+`builtin_if`; the display and keyboard paths of `logon.b` itself
+could not be driven here — the Linux emulator on the build host has
+no display backend and faults on the draw attach — so those are
+compile-checked only.
 
 **6. Smaller confirmed defects, each a line or two:**
 

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1366,7 +1366,13 @@ logged-in / skipped / failed, and the script honours them. Hours.
   never acquired it; `uartputx`/`uartputd` and `dumpureg` bypass it.
   DONE 2026-09-05: `uartlock()`/`uartunlock()` release only what the
   caller took, are re-entrant per core, and `uartputx`/`uartputd`,
-  `dumpureg` and `intrdump` emit under it as whole pieces.
+  `dumpureg` and `intrdump` emit under it as whole pieces. Review of
+  that change found the owner-by-core rule unsound at spllo once every
+  core preempts (the holding process could migrate mid-line and the
+  old core would then write through unlocked), so the lock is now held
+  at splhi, ilock-style: the holder cannot be preempted, so the core
+  is the holder. Verified by the full harness under QEMU raspi3b (159
+  checks passing, console output unshredded through four-core boot).
 - Unlocked multi-core writers: `ticks++` and the profiler buckets in
   `clock.c`, `nspurious` and `irqenabled |=` in `intr.c`. Lossy at
   best; `irqenabled` from a kproc on another core is the one to fix.

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -49,22 +49,25 @@ a Tk form; `luciuisrv` and `lucifer`.
 Not done, in one line each; the detail and the order are in "Next" at
 the end of this file:
 
-- cores 1–3 have no clock tick, so nothing preempts on them
-- every process is the host owner, and the desktop namespace holds the
-  raw card, the pins and `/dev/sysctl`
+- every process is still the host owner. The desktop's namespace no
+  longer holds the raw card, the pins or `/dev/sysctl`, but a non-eve
+  user for the desktop and agents is not done
 - the tryboot firmware handshake and the watchdog countdown are proved
   against QEMU's model only, which has neither; the board has not yet
   run them
-- the login screen can be bypassed by design and by failure
-- the harness tests none of logon, secstore, rootpath or the
-  dossrv fixes, and no CI job runs the harness at all
+- the harness types the boot script's namespace lines into a shell
+  and tests dossrv on the host, but does not boot a populated card
+  through rootpath, logon and secstore under QEMU, and no CI job runs
+  the bare-metal harness at all
+- the fixes of 2026-09-05 (below) have run under QEMU only; none has
+  been on the board
 - WiFi, touch, USB storage, audio; the Pi 4
 
 Regression-tested by `tests/host/baremetal_test.sh`, which builds the
 port, boots it under QEMU's `raspi3b`, and asserts on the result —
 pulling the framebuffer back through QMP, hot-plugging USB devices,
 round-tripping TCP through the emulated network, and comparing the
-served kernel image with the file it booted. ~150 checks. A second
+served kernel image with the file it booted. 194 checks. A second
 QEMU machine (`virt`) once shared this kernel and forced the
 `os/arm64` split; it is not in the tree today.
 
@@ -1398,7 +1401,16 @@ and no workflow in `.github/workflows` runs the harness. Until tier 2
 is done, "it works" means "it worked on one board and one developer's
 QEMU".
 
-### Tier 1 — defects the review found; fix before anything new
+*Later the same day:* tier 1 was worked through, one branch per item,
+each reviewed adversarially and re-run through the harness before it
+was merged. Items 1, 2, 5 and the four non-SMP bullets of 6 are done;
+4 is done except for the board; 3 is half done (the namespace, not the
+user). Each carries a harness check that fails on the unfixed tree.
+The merged tree passes 194 checks against 152 before, and the hosted
+suite still passes with the JIT on. Every "DONE" note below says what
+was verified and what was not; the board has run none of it yet.
+
+### Tier 1 — defects the review found; worked through 2026-09-05
 
 **1. The AArch64 JIT never runs a reference's destructor.**
 `libinterp/comp-arm64.c` `macfrp()`: after the nil check, the refcount

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -4,42 +4,66 @@ Tracked as **INFR-404**. This is InferNode running *native* — as the
 firmware on the board, with no host OS underneath — rather than *hosted*,
 which is what everything under `emu/` does.
 
-Status: **there is a shell, networking, and a JIT.** The system boots to
-an interactive prompt, runs pipelines and command substitution as
-JIT-compiled AArch64, answers pings and completes TCP connections over
-its own IP stack, and enumerates the USB bus end to end.
+Status, 2026-09-05: **it is a machine.** A Pi 3B+ boots this kernel from
+its SD card to a Tk login screen on HDMI, with a USB keyboard and
+mouse, wired Ethernet configured by DHCP, a writable `/usr` on the
+card, secstore-backed keys, and the Lucifer desktop — and a shell on
+the serial console the whole time. All four cores schedule. The Dis JIT
+runs on the A53 at 27× the interpreter with bit-identical results.
+Everything below has been exercised on the board, not only in QEMU,
+except where a section says otherwise.
 
-Working:
+Working, in the kernel (`os/arm64/notyet.c` holds the device table):
 
-- boot, secondary-core parking, EL2 → EL1, PL011 console
-- AArch64 exception vectors, ESR decoding, register dump on fault
-- MMU with an identity map, caches on, correct memory attributes
-- VideoCore mailbox; framebuffer, verified pixel-exact; GPIO
-- ARM generic timer at 100Hz; device interrupts through the VideoCore
-  controller, asserted at boot rather than assumed
-- `xalloc`, the pool allocator (`malloc`/`free`), Blocks
-- the scheduler: process table, context switch, blocking locks
-- namespace: channels, path composition, process groups, the root
-  device, `kopen`/`kread`/`kwrite`/`kbind`
-- a console on `/dev/cons`, `#p` (processes), `#|` (pipes)
-- the Dis VM, and the **JIT**: 27× the interpreter, bit-identical results
-- an interactive shell: pipelines, command substitution, `for` loops
-- **`os/ip`**: ICMP and TCP over loopback, route table, `ptclbsum`
-- **USB**: `#u`, the DWC OTG host stack, and enumeration through a hub
-  to the CDC Ethernet device behind it
+- boot, EL2 → EL1, MMU with caches on, all four cores up, exception
+  vectors with a register dump on fault, the ARM generic timer, device
+  interrupts through the VideoCore controller
+- `xalloc`, the pool allocator, Blocks; the scheduler with per-process
+  preemption guards; the namespace, channels, mounts (`#M`), process
+  groups, `#p`, `#|`, `#e`, `#s`
+- the Dis VM and the **JIT**; a sign-extension fix that makes a Limbo
+  `int` 32 bits on a 64-bit word (both JITs and the interpreter)
+- **`os/ip`** (`#I`): the full stack, ARP, ICMP, TCP, UDP, routing
+- **USB**: `#u`, the DWC OTG host stack with split transactions,
+  single-shot bulk transfers, hot-plug and unplug
+- **`#l`**: the Ethernet data path in the kernel (~2.6 MB/s in, ~4 MB/s
+  out), bound to endpoints a Limbo driver has set up
+- the SD card as a file (`#S`), the running kernel image as a file
+  (`#B/bootimage`), microsecond timing (`#b`), GPIO pins as files
+  (`#G`), the framebuffer console (`fbcons`), the draw device (`#i`),
+  the pointer (`#m`), the keyboard on `/dev/keyboard`, SSL (`#D`), a
+  hardware-fed entropy pool, a tick-driven sampling profiler
+- **tryboot**: the firmware's one-shot flag for A/B kernels (but see
+  "Next" — it is not yet a safe A/B path)
 
-Not done: no packet has yet been sent or received on a real network —
-that needs the class driver described under "Decision: device protocols
-live outside the kernel, mechanism inside". And **nothing here has run
-on real hardware**; everything above is QEMU. The JIT in particular is
-not accepted until it has, because TCG does not model split I/D caches,
-so missing icache maintenance is invisible in emulation.
+Working, in Limbo on top (`os/init/`, plus the card): `osinit` — the USB
+bus walk, the hub watcher, the SD mount, the rootpath policy, `/usr`;
+`etherusb` (RNDIS for QEMU, LAN78xx with PHY autonegotiation for the
+board, DHCP, and the `#l` handoff); `kbdusb`, `mouseusb`; `dossrv` on
+FAT32 with the fixes the card demanded; `auth/secstored`; `wm/logon` as
+a Tk form; `luciuisrv` and `lucifer`.
+
+Not done, in one line each; the detail and the order are in "Next" at
+the end of this file:
+
+- a confirmed JIT bug means compiled code never runs a reference's
+  destructor, so dropped fds and heap cells wait for the collector
+- cores 1–3 have no clock tick, so nothing preempts on them
+- every process is the host owner, and the desktop namespace holds the
+  raw card, the pins and `/dev/sysctl`
+- tryboot installs over the known-good kernel, not beside it
+- the login screen can be bypassed by design and by failure
+- the harness tests none of tryboot, logon, secstore, rootpath or the
+  dossrv fixes, and no CI job runs the harness at all
+- WiFi, touch, USB storage, audio; the Pi 4
 
 Regression-tested by `tests/host/baremetal_test.sh`, which builds the
-port, boots it under QEMU, and asserts on the result — including pulling
-the framebuffer back out via QMP and checking pixel values. That harness
-runs **both** boards: see [os/virt](../virt/README.md), the QEMU `virt`
-port that shares this kernel.
+port, boots it under QEMU's `raspi3b`, and asserts on the result —
+pulling the framebuffer back through QMP, hot-plugging USB devices,
+round-tripping TCP through the emulated network, and comparing the
+served kernel image with the file it booted. ~150 checks. A second
+QEMU machine (`virt`) once shared this kernel and forced the
+`os/arm64` split; it is not in the tree today.
 
 ## Why `os/` and not `emu/<Platform>`
 
@@ -64,12 +88,16 @@ genuinely this SoC — the memory map, PL011 wiring, VideoCore mailbox,
 GPIO, framebuffer, the system timer and the MMU map — plus `board.c`,
 the five hooks `../arm64/fns.h` declares.
 
-That split was forced by [os/virt](../virt/README.md) and is the honest
-place for the line: with one board, "shared" and "BCM2837" were
-indistinguishable, and `main.c` had grown to 1700 lines of mostly
-board-independent bring-up checks. A sixth board hook should be read as
-an argument for moving code into `os/arm64`, not for widening the
-interface.
+That split was forced by a second QEMU machine (`virt`) that shared the
+kernel for a while, and it is the honest place for the line: with one
+board, "shared" and "BCM2837" were indistinguishable, and `main.c` had
+grown to 1700 lines of mostly board-independent bring-up checks. The
+`virt` port is not in the tree today; the line it drew held. Since then
+`os/bcm2837` has also grown the drivers that are this SoC's — `usbdwc`,
+`emmc`/`devsd`, `devgpio`, `fbcons`/`screen`, `random`, `serialboot` —
+which is the right side of the line for them. A further board hook
+should be read as an argument for moving code into `os/arm64`, not for
+widening the interface.
 
 ## Why the Pi 3B+
 
@@ -182,8 +210,9 @@ QEMU is the fast loop, but it is not the truth. Known divergences:
 - **Peripherals.** SD/EMMC timing, USB and the VideoCore mailbox
   framebuffer are modelled loosely or not at all.
 
-Real-hardware bring-up needs a USB-serial cable on GPIO 14/15 (there is no
-video output until the framebuffer works) and a FAT32 SD card carrying the
+Real-hardware bring-up needs a USB-serial cable on GPIO 14/15 (the
+console is mirrored to the display once `fbcons` is up, but that is
+some way into boot) and a FAT32 SD card carrying the
 Broadcom firmware blobs (`bootcode.bin`, `start.elf`, `fixup.dat`) plus
 `kernel8.img` and a `config.txt` setting `arm_64bit=1`.
 
@@ -250,8 +279,10 @@ mechanism inside" below. `usbdwc.c` and `devusb.c` were imported;
 `etherusb.c` will not be, because it is an in-kernel `Ether` driver and
 that layer is now a program.
 
-None of this reduces the other hard dependency: **this tree has no
-TCP/IP stack at all**, so `os/ip` is required for any networking path.
+None of this reduced the other hard dependency at the time: the tree
+had no TCP/IP stack at all. `os/ip` has since been imported, ported to
+LP64 and is in the build (`#I`); see "The Ethernet data path is in the
+kernel" for how it attaches.
 
 ## Lessons that cost time
 
@@ -548,8 +579,28 @@ ordering was chosen.
   needed**: `ip.h` declares it, but `ethermedium` reaches its device
   with `kdial()` and `kopen()`, which this tree already has.
 - **Already imported and unaffected:** `usbdwc.c`, `devusb.c`.
-- **To write:** a Dis program speaking CDC (for QEMU's `usb-net`) and
-  LAN78xx (for the board), serving the ether interface sketched above.
+- **Written:** `os/init/etherusb.b`, speaking RNDIS (QEMU's `usb-net`)
+  and LAN78xx (the board), with DHCP.
+
+### Where the line was redrawn, and why it still holds
+
+The data path did not stay in Limbo. Once the whole system worked, the
+per-frame cost of crossing the interpreter and a 9P transaction was
+measured and was the ceiling (see "Network throughput" and "The
+Ethernet data path is in the kernel"), so `os/port/devether.c` (`#l`)
+now shuttles frames between USB endpoints and `os/ip` as kernel
+processes. What stays outside is everything that is one device's
+*protocol*: enumeration, RNDIS negotiation, the LAN78xx register and
+PHY bring-up. `etherusb.b` does that and then hands the two open
+endpoints to `#l` with one ctl write.
+
+That is the rule above applied, not abandoned: moving bytes between a
+bus endpoint and the IP stack is mechanism, shared by every user of the
+network; knowing what a LAN7800's registers mean is policy, and it is
+still a program. The USB keyboard and mouse drivers are still programs
+too. A storage or audio class driver should expect the same shape —
+setup in Limbo, and a kernel data path only when a measurement says
+so.
 
 ## VM bring-up: the four bugs that were in the way
 
@@ -721,7 +772,14 @@ Raising `KSTACK` from 16K to 64K did **not** help -- 5 of 8 boots still
 overflowed -- and that is what proved it recursion rather than depth.
 `KSTACK` is back at upstream's 16K.
 
-### Networking works, intermittently (open)
+### Networking works, intermittently (RESOLVED)
+
+*Resolved after this was written: the consumed 64 bytes were a NAK wake
+that re-baselined the DMA pointer and abandoned a live channel
+(c911449), on top of a late IN completing into freed memory (d7a7e20,
+the persistent bounce buffers). The harness has been clean since. The
+account is kept because the wrong hypothesis it records is the one the
+next person will reach for.*
 
 The whole path works. os/ip resolves an address by ARP, sends an ICMP
 echo through an interface bound to a driver that is not in the kernel,
@@ -1106,7 +1164,8 @@ per-stream window.
 
 Levers from here, in order of expected value: a kernel-side sink for
 measuring the wire path alone (the ~30MB/s USB2 budget is otherwise
-unobservable through a Limbo endpoint); genrandom's appetite; the
+unobservable through a Limbo endpoint); genrandom's appetite (since
+pulled: `random.c` feeds the pool from the hardware generator); the
 per-packet first-halt in singleshot transfers (2 channel ops per
 transfer could be 1 if the fresh-channel Chhltd|Ack halt has a
 register cause); and the GC/scheduler costs that INFR-404's earlier
@@ -1133,7 +1192,10 @@ core, and the cycle is their SUM because the reader parses before it
 reposts. The levers, in order: overlap read with processing (a second
 buffer and the parse moved off the repost path -- approaches the
 12MB/s wire ceiling for kernel consumers), then SMP so the VM runs
-beside the network instead of inside its cycle.
+beside the network instead of inside its cycle. SMP has since landed
+(all four cores schedule); the throughput with it has not been
+measured, and the review recorded in "Next" found that the secondary
+cores do not yet tick, so the number is not worth taking until they do.
 
 Two tools this bought, both permanent: `blackhole` on any ether ctl
 toggles a surgical sink (IPv4/UDP/port-9 counted and dropped, control
@@ -1169,157 +1231,239 @@ probe in devether.c's used<0 branch, never with theories.
 
 ### Smaller things still open
 
-`sprint()` in `devcons.c` assumes every caller's buffer is `PRINTSIZE`,
-and `os/port/dev.c:105` hands it a `smalloc(4+strlen(spec)+1)`. It fits
-today and will not survive the first caller that formats something
-longer.
+The `sprint()`/`PRINTSIZE` hazard once recorded here is fixed:
+`os/port/dev.c` uses `snprint` with the buffer's real size. What is
+still small and open is gathered under "Next", tier 1, item 6.
 
 ## Next
 
-Done: exception vectors, EL2→EL1, MMU, timer and IRQ, the `os/port`
-import and 64-bit port, the Dis VM, and an interactive shell. What
-follows is ordered by dependency, with the reasoning kept where a later
-reader needs it.
+Revised 2026-09-05 from a review of the branch's 49 commits against the
+tree, file by file, rather than from the commit messages. The previous
+version of this list was written before the board arrived and had
+drifted badly: it still called the JIT, LAN78xx and `os/ip` outstanding.
+All three are done. What the review found instead is below, and the
+ordering principle is: **make what exists correct and tested before
+adding hardware.** Every item names the code so it can be checked
+rather than believed.
 
-**1. The JIT — done in emulation, hardware validation outstanding.**
+The port lives on `feat/baremetal-pi`. `master` has no `os/` directory,
+and no workflow in `.github/workflows` runs the harness. Until tier 2
+is done, "it works" means "it worked on one board and one developer's
+QEMU".
 
-Dis is compiled to AArch64 rather than interpreted. Measured on the
-same kernel, differing only by `-DCFLAG=0`:
+### Tier 1 — defects the review found; fix before anything new
 
-    JIT:    2000000 iterations in   80 ms (acc=1048429888)
-    no JIT: 2000000 iterations in 2160 ms (acc=1048429888)
+**1. The AArch64 JIT never runs a reference's destructor.**
+`libinterp/comp-arm64.c` `macfrp()`: after the nil check, the refcount
+is loaded, decremented with `SUB_IMM` — which does not set flags — and
+stored, and then `BCOND(NE)` branches on the flags the *nil check* left,
+which are always NE for a non-nil pointer. `rdestroy` is unreachable.
+And if the branch were fixed alone it would still be wrong: `destroy()`
+in `heap.c` decrements again, `Heap.ref` is unsigned, and the wrapped
+value reads as "still referenced". `comp-386.c` and `comp-amd64.c` get
+this right by branching at `ref == 1` *without* decrementing.
 
-**27×**, against 10× measured for the same code generator in the hosted
-emulator on an M-series Mac. That direction was predicted and the
-reason holds: `xec`'s inner loop costs two indirect calls per Dis
-instruction, and an in-order Cortex-A53 cannot hide them the way an
-out-of-order core does. 12/12 clean boots; the shell, pipelines and
-command substitution all run as compiled code.
+The consequence is exactly the "OPEN QUESTION" recorded under "The
+Ethernet data path is in the kernel": a Limbo `fd = nil` did not close
+the endpoint, and etherusb.b still carries the `sys->dup` of `#c/null`
+workaround. Every last-reference drop in compiled code — `movp`,
+`headp`, `tail`, frame destructors — leaks until a GC sweep. The
+interpreter path in `xec.c` is correct, so a `-DCFLAG=0` kernel hides
+it. **This is not a bare-metal bug: hosted macOS on Apple Silicon runs
+the same macro under `-c1`,** and the macOS CI job runs the suite
+without `-c1` — interpreter only — so nothing there would have caught it.
 
-The suite checks two things that are not the same: that compiled code
-computes the **same answer** as the interpreter, bit for bit, and that
-it is faster. A JIT that is merely fast is a miscompilation waiting to
-be found. The interpreter stays the reference, so any disagreement is
-bisectable against it.
+Fix: mirror the amd64 shape (compare with 1, branch to `rdestroy` on
+equal, else decrement and return). Test: a Limbo test that drops an fd
+in compiled code and checks `#u`'s endpoint `inuse` (or a pipe's other
+end seeing EOF) *without* the dup workaround; then remove the
+workaround. Run the hosted runner on macOS with `-c1` in CI. Half a day
+of code; the test is the point.
 
-`comp-arm64.c` gained an `INFERNO_NATIVE` arm beside the `APPLE_JIT`
-one it already had. Its only host dependencies were `mmap(PROT_EXEC)`
-and an icache flush; this kernel maps all RAM without PXN/UXN so
-`malloc()` returns executable memory, and `cacheiflush()` is
-CTR_EL0-driven.
+**2. Cores 1–3 have no clock tick.** `timersinit()`
+(`os/port/portclock.c`) creates the one periodic Timer whose purpose is
+to call `hzclock()`, and `timeradd()` puts it on `timers[m->machno]` —
+core 0, where `clockinit()` ran. A secondary's `clockintr` calls
+`timerintr`, which walks its own queue, which is empty. So on cores 1–3
+there is no preemption, `m->ticks` never advances and `active.exiting`
+is never checked; the comment in `secclockinit` (`clock.c`) claiming
+otherwise is wrong, and the one in `squidboy` (`main.c`, "voluntary for
+now") is right. With `lock()` never yielding when `nmach > 1`
+(`taslock.c`), a process spinning at spllo on a lock whose holder was
+preempted holds its core until the holder runs elsewhere.
 
-**Still gated on hardware.** QEMU's TCG does not model split I/D
-caches, so a JIT that skips its icache maintenance works perfectly in
-emulation and executes stale instructions on a Cortex-A53. Acceptance
-is not complete until JIT-generated code has run on the board.
+Fix: each secondary adds its own periodic Timer in `secclockinit`, or
+`clockintr` calls `hzclock` directly when `m->machno != 0`. Test: the
+harness asserts `cpu1..3: up`, and a busy Limbo loop pinned by chance to
+a secondary is preempted by a second one. Nothing in the harness
+currently asserts that SMP came up at all.
 
-*Two harness bugs it exposed, both stale build state:* libinterp ships
-ten `comp-*.c` files each defining `compile()`, and excluding only
-`comp-amd64.c` left the linker free to pick `comp-68020.c` — so the
-first time `cflag` went above zero, the kernel compiled a Dis module
-with a 68020 code generator and branched into it. Then, after
-narrowing the build, it *still* did: `ar r` replaces and adds members
-but never removes one, so the stale object was still in `libkern.a`.
-That is the third time on this branch that stale build state has
-produced confident wrong behaviour.
+**3. Every process is the host owner.** `main.c` sets the user to
+`inferno`, which is `eve`, for every process, so `iseve()` is always
+true, and `#S`, `#G` and `/dev/sysctl` are bound into the `/dev` the
+desktop shares. Any desktop program — any agent tool — can `echo
+tryboot > /dev/sysctl`, write `/dev/sdcard` raw, repartition through
+`/dev/sdctl` (`sdaddpart` in `devsd.c` has no overlap check), or
+rewrite `/dev/hostowner`. This is the opposite of the namespace
+discipline the rest of InferNode is built on
+(`docs/DESIGN-PRINCIPLES.md`).
 
-*And a real kernel bug,* found stress-testing the JIT through the
-shell: a backquote substitution killed the machine with
-`panic: devno | 0x7c`. `kpipe()` reached `devtab` through
-`devno('|', 0)`, and `devno` panics on a miss when `user == 0` — so any
-Limbo program calling `sys->pipe()` on a kernel without `#|` took the
-system down. Both halves fixed: `#|` imported, and a missing device is
-now an error to the caller rather than a panic.
+Fix, smallest first: build the desktop's namespace in
+`boot-baremetal.sh` without `#S`, `#G` and the console ctl (the
+mechanism — `bind`, `newns` — already exists), then a non-eve user for
+the desktop and agents. A week for the second; an afternoon for the
+first.
 
-**2. Hardware bring-up.** The card needs a FAT32 partition holding the
-Broadcom blobs (`bootcode.bin`, `start.elf`, `fixup.dat` from
-raspberrypi/firmware), a `config.txt`, and this kernel named
-`kernel8.img`:
+**4. tryboot is a one-shot flag, not yet an A/B path.**
+`cp /dev/bootimage /n/dos/infernode8.img` (`devboot.c`) overwrites the
+file `config.txt` names — the known-good kernel. A/B exists only if the
+operator hand-edits `tryboot.txt`. No watchdog is armed while a
+candidate boots, so a candidate that *hangs* (the classic JIT icache
+failure) needs the power switch; only a candidate that panics reboots
+itself. And `boardtryboot` (`board.c`) is a PM_RSTS write that has not
+been tested against the firmware; the harness has no tryboot check.
 
-    BAREMETAL_BUILD_DIR=/tmp/bm ./tests/host/baremetal_test.sh
-    cp /tmp/bm/bcm2837-kernel.img /Volumes/<card>/kernel8.img
+Fix: install to a candidate filename; arm the hardware watchdog in
+`kmain` and clear it from `osinit` once the shell answers; prove the
+PM_RSTS handshake on the board once, with the result written here; a
+harness check for the flag write. Two or three days.
 
-`config.txt` wants four lines:
+**5. The login screen is bypassable in two ways, one deliberate.**
+`boot-baremetal.sh` treats `wm/logon` exiting 0 as a login. Escape
+twice is a designed skip ("Keys won't persist") and exits 0 — fine,
+but the script's comment claims fail-closed and it is not. Worse,
+`headlessprompt()` in `logon.b` does nothing and returns normally when
+the display or `/dev/keyboard` cannot be opened, which is precisely the
+"logon died, desktop starts anyway" case the script says it blocks.
+Also `if {! ~ $#skiplogon 0}` enables the skip for `skiplogon=0`, unlike
+the hosted `~ $skiplogon 1`. Fix: distinct exit statuses for
+logged-in / skipped / failed, and the script honours them. Hours.
 
-    arm_64bit=1
-    enable_uart=1
-    dtoverlay=disable-bt
-    init_uart_clock=48000000
+**6. Smaller confirmed defects, each a line or two:**
 
-The last one is not optional here even though it is often described as
-a default. `uart.c` divides for 115200 assuming a 48MHz reference --
-IBRD 26, FBRD 3, which is 48000000/(16*115200) = 26.04 -- and the
-firmware, not the kernel, decides what that reference actually is. If
-it differs, the divisor is wrong by the same ratio and the console
-produces framing errors and garbage rather than nothing, which reads
-as a broken kernel rather than a misconfigured clock. Pinning it costs
-one line.
+- `irqorphan` (`intr.c`) is reset by *every* core's timer interrupt
+  (`clock.c`), so a genuinely unhandled GPU interrupt on core 0 can be
+  reported "spurious" by a tick on core 1 and storm silently.
+- `devusb.c` `CMdetach` releases every endpoint on every write; a
+  second "detach" double-frees. `osinit` writes once today.
+- `uart.c` zeroes the console mutex after a bounded spin even when it
+  never acquired it; `uartputx`/`uartputd` and `dumpureg` bypass it.
+- Unlocked multi-core writers: `ticks++` and the profiler buckets in
+  `clock.c`, `nspurious` and `irqenabled |=` in `intr.c`. Lossy at
+  best; `irqenabled` from a kproc on another core is the one to fix.
+- `lock()` has two different spin bounds (1M with `up == nil`, 100M
+  otherwise) and `schedinit`/interrupt-time wakeups use the short one
+  against locks that are held across a memset.
+- `etherusb.b`: `dhcpreader`, `pingreader` and `ntpreader` never exit;
+  the UDP conversation on port 68 is never closed.
+- `dossrv.b`: a real file whose name matches `badent-*` is removed
+  without `truncfile`, leaking its clusters.
+- `mailbox.c` says "single-threaded for now" over one shared request
+  buffer; `fbcons` now calls it from the console path while draw and
+  pointer run on other cores.
+- `notyet.c` `postnote` is a stub, so a blocked reader cannot be
+  kicked; the comment there already says it is "wrong to leave
+  permanently".
 
-The third is the one that costs an afternoon if it is missing. On a Pi
-3 the PL011 is wired to Bluetooth by default and the mini-UART is on
-the header instead -- so the console comes out of a different device at
-a different clock, and the symptom is a board that boots to silence.
-`kernel.ld` links at 0x80000, which is where the boot ROM loads
-`kernel8.img` in 64-bit mode, so no `kernel_address` is needed.
+### Tier 2 — make what exists trustworthy
 
-Console is a 3.3V USB-serial adapter on GPIO 14/15 (pins 8 and 10),
-ground to pin 6. **Not 5V**: the Pi's GPIO is not 5V tolerant.
+**7. Test what the board relies on.** The harness (`baremetal_test.sh`)
+covers the kernel well and the userspace not at all: no check for
+tryboot, `wm/logon`, `secstored`, the rootpath policy, `/usr`, or any
+of the five dossrv fixes (its two FAT fixtures are read-only plus one
+append). DHCP "passes" through the static fallback because QEMU's
+user network never answers. SMP is not asserted. Add: a populated
+FAT32 card image booting through rootpath to logon under QEMU; dossrv
+rename/growroot/badent fixtures; four cores up; a DHCP server on the
+QEMU side. Three or four days, and it is what makes tier 1 provable.
 
-Two things are known to be untested on hardware and are the first to
-watch. The JIT has never run on a real Cortex-A53, and QEMU's TCG does
-not model split I/D caches, so missing icache maintenance is invisible
-in emulation and would present as executing stale instructions. And
-every USB finding on this branch is against QEMU's DWC model; the
-board's controller is the real thing behind a real high-speed hub, so
-the split-transaction paths that never execute under emulation will
-execute there.
+**8. CI, then master.** Add a Linux job with clang (`--target
+aarch64-elf`), `ld.lld`, `llvm-objcopy`, `qemu-system-aarch64` with
+`raspi3b`, the native `limbo` and python3; the harness already skips
+when they are absent, so it is safe to add before it is green
+everywhere. Remove the hard-coded personal path the harness falls back
+to for `limbo`. Then merge `feat/baremetal-pi` to `master`. The branch
+also changes hosted behaviour — Limbo `int` semantics in both JITs and
+the interpreter, `runt.c` print bounds, `draw.h`'s `BGLONG` — and those
+need the hosted suite on both architectures before the merge.
 
-**3. USB — a class driver exists; LAN78xx is unvalidated.** The RNDIS
-family works end to end under QEMU. The LAN78xx family, which is what
-the 3B+'s LAN7515 actually speaks, is written but **has never been run
-against the silicon**, and its register map came from knowledge rather
-than from a datasheet on the desk. It is built to fail loudly rather
-than half-work: `lansetup()` reads ID_REV first and refuses a device
-that answers 0 or all-ones, and refuses again if the MAC reads back as
-all zeroes, because a NIC that is misprogrammed comes up and silently
-carries nothing.
+**9. Network device lifecycle.** `#l` binds once, ever (`devether.c`);
+its reader and writer kprocs exit on error without closing their
+endpoints; `etherusb.b` has no detach handling although `#u` now
+reports detach; `nif.link` is set to 1 at bind and never updated;
+`lanphy` returns success without link; DHCP has no renewal. A NIC
+unplugged is dead for the boot. Two or three days.
 
-The PHY is not done. Link needs the internal PHY brought up and
-auto-negotiation completed through MII_ACC and MII_DATA, which is more
-than a handful of writes; the driver says so on the console rather
-than leaving it to be inferred from a dead interface.
+**10. The DWC read path, hardware edition.** No cache *invalidate*
+after DMA completes (`usbdwc.c` cleans before, `memmove`s after) —
+speculative prefetch on an A53 across four cores can read stale lines,
+and QEMU is coherent so the harness cannot see it. The residual ~0.02%
+framing desync under burst is still open; resume with the byte-capture
+probe in `devether.c`, not with theories. Completion is polled through
+`tsleep` timeouts rather than interrupt-driven. Hubs are polled rather
+than read through their status-change endpoint. About a week, and it
+is where the next hardware-only bug lives.
 
-**3a. The old item, for reference —** The 3B+'s
-LAN7515 sits behind USB, so a DWC2 host stack gates wired Ethernet
-*and* WiFi. `usbdwc.c` and `devusb.c` are imported and the bus
-enumerates end to end under QEMU: root hub, a real hub addressed and
-interrogated over the wire, and the CDC Ethernet device behind it.
+**11. Kernel hygiene the review flagged:** the identity map ("for
+now" in `mmu.c`, and JIT text is RWX); secondary scheduler stacks are
+8K `malloc` with no guard word; `conf.nmach` is set before the cores
+have answered; `up->inpreempt`-style invariants have no SMP
+counterparts. Also `lastdev` in `osinit.b` is one global shared by
+every hub watcher, so two hubs enumerating at once can cross names.
 
-The design decision this item used to be waiting on is made and written
-up — see "Decision: device protocols live outside the kernel, mechanism
-inside". The class driver is a Dis program, not `etherusb.c`. Remaining:
-`ethermedium.c` and `chandial.c` into `os/ip`, then the program itself,
-speaking CDC against QEMU's `usb-net` and LAN78xx against the board.
+### Tier 3 — the machine as a product
 
-**4. `os/ip`.** No TCP/IP stack exists in this tree at all, so it is a
-hard dependency under every networking path. Write the route-table test
-*before* touching `iproute.c`: it is the one file with a silent
-wrong-answer failure mode, and `tcp.c`'s sequence comparisons survive
-LP64 by accident through `(int)` truncation — which is worse than
-breaking, because it passes a smoke test and stalls under real traffic.
+**12. The userspace on the card.** `boot-baremetal.sh` starts
+`secstored`, `logon`, `luciuisrv` and `lucifer`. Against the hosted
+`boot.sh` it lacks `ndb/cs` (no name resolution — which is why
+secstore is dialled by number), the plumber, `mntgen`, `llmsrv` (so
+`/mnt/llm` is an empty mount point), `tools9p` at `/tool` (so Veltro
+has no tools), `msg9p`, `wallet9p`, `lucibridge`. Order: `ndb/cs` and
+the plumber first, because everything else assumes them. The mount
+points already exist in the root skeleton.
 
-**5. FT5406 touch**, via mailbox tag `0x0004000F` — the firmware polls
-the controller into a buffer, so no I2C driver is needed. Note QEMU
-declares that tag but never handles it, so this is hardware-only.
+**13. Throughput.** The ledger stands: 12.4 MB/s through the wire path,
+2.6 MB/s through a Limbo TCP consumer. The levers are still the two
+named there — a second receive buffer so USB and parsing overlap, and
+the VM on another core — but the second waits on item 2, and the
+number should be re-taken once it lands.
 
-**6. WiFi** (CYW43455 over SDIO), which needs everything above plus an
-SDIO/EMMC driver and a firmware blob upload.
+**14. Hardware not started, smallest first.** FT5406 touch via mailbox
+tag `0x0004000F` (firmware polls the controller; hardware-only, QEMU
+declares the tag and ignores it). A USB storage class driver in Limbo
+over `#u`, the same shape as `etherusb.b`. WiFi: CYW43455 over SDIO on
+the second controller, plus a firmware blob upload — the large one; the
+EMMC driver exists for SD but SDIO is different. Audio (PWM or HDMI).
+Bluetooth is on the PL011 the console uses; it would mean the
+mini-UART for the console first.
 
-Smaller, and worth doing whenever they block something: `devtab` holds
-root, cons, prog and pipe, so there is still no `/env` (`#e`) and no
-`/fd` (`#d`). `sysfile.c:514` reaches the mount device through
-`devno('M', 0)` — the same panic-on-miss hazard `#|` had, harmless only
-while nothing mounts anything. `sprint()` in `devcons.c` still assumes
-every caller's buffer is `PRINTSIZE` while `os/port/dev.c:105` hands it
-a `smalloc(4+strlen(spec)+1)` — it fits today and will not survive the
-first longer format.
+**15. The next board.** BCM2711 (Pi 4) needs a GIC-400 interrupt
+controller, xHCI over PCIe (the VL805) and the GENET MAC. The `#u`
+boundary means `etherusb.b`, `kbdusb.b` and `mouseusb.b` carry over
+unchanged above a new host controller driver; XHCI is an open
+specification and should be smaller than `usbdwc.c`. The Zero 2 W and
+CM3+ are this SoC and should boot this kernel, minus the hub (USB OTG
+only) and plus WiFi. The Pi 5 is blocked on RP1 having no public
+register documentation.
+
+### Housekeeping the review also found
+
+Comments that now say the opposite of the code, to fix as the files are
+touched: `fns.h` says four board hooks and declares five; `dat.h` says
+exception entry restores x28 (it deliberately does not) and that nothing
+saves FPU state (`FPsave`/`FPrestore` exist); `main.c` "one core for
+now" and "not yet exercised: sched()"; `taslock.c` "secondary cores are
+parked"; `notyet.c` "tcp and udp are not here yet" and "nothing installs
+a screenputs"; `etherusb.b` "never run against the silicon" and "bulk
+endpoint assumed to be 2"; two conflicting `config.txt` recipes in this
+file (under "Working on the board" and the old bring-up item), neither
+mentioning `tryboot.txt`; `docs/TLS-ENTROPY.md` (the pool is
+hardware-fed now) and `docs/PERSISTENCE.md` (the `/usr` question is
+decided: on the card). The top-level `README.md` and `QUICKSTART.md`
+still describe the Pi only as a hosted Linux target.
+
+### What was on this list before, for the record
+
+The JIT (validated on the board), hardware bring-up, the LAN78xx driver
+and PHY, `os/ip`, `#e`. All done. `#d` (`/fd`) is still absent and
+nothing has needed it.

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -33,8 +33,11 @@ Working, in the kernel (`os/arm64/notyet.c` holds the device table):
   (`#G`), the framebuffer console (`fbcons`), the draw device (`#i`),
   the pointer (`#m`), the keyboard on `/dev/keyboard`, SSL (`#D`), a
   hardware-fed entropy pool, a tick-driven sampling profiler
-- **tryboot**: the firmware's one-shot flag for A/B kernels (but see
-  "Next" — it is not yet a safe A/B path)
+- **tryboot**: A/B kernels through the firmware's one-shot flag — a
+  candidate is installed under its own name, booted once under a boot
+  watchdog, and promoted from its own shell (see "Working on the board
+  without moving the card"; the firmware handshake itself is still to
+  be proved on the board)
 
 Working, in Limbo on top (`os/init/`, plus the card): `osinit` — the USB
 bus walk, the hub watcher, the SD mount, the rootpath policy, `/usr`;
@@ -51,9 +54,11 @@ the end of this file:
 - cores 1–3 have no clock tick, so nothing preempts on them
 - every process is the host owner, and the desktop namespace holds the
   raw card, the pins and `/dev/sysctl`
-- tryboot installs over the known-good kernel, not beside it
+- the tryboot firmware handshake and the watchdog countdown are proved
+  against QEMU's model only, which has neither; the board has not yet
+  run them
 - the login screen can be bypassed by design and by failure
-- the harness tests none of tryboot, logon, secstore, rootpath or the
+- the harness tests none of logon, secstore, rootpath or the
   dossrv fixes, and no CI job runs the harness at all
 - WiFi, touch, USB storage, audio; the Pi 4
 
@@ -209,12 +214,24 @@ QEMU is the fast loop, but it is not the truth. Known divergences:
   runtime — JIT bring-up must be validated on the board, not just here.
 - **Peripherals.** SD/EMMC timing, USB and the VideoCore mailbox
   framebuffer are modelled loosely or not at all.
+- **The watchdog.** QEMU's `hw/misc/bcm2835_powermgt.c` stores
+  `PM_WDOG` and never counts it down; a write to `PM_RSTC` with the
+  full-reset `WRCFG` resets the machine *immediately*, whatever the
+  count. So under QEMU, arming the boot watchdog is the reset — which
+  is how the harness proves the arming write reaches the block with
+  the right password and bits, and why the countdown, the reload from
+  the clock tick and the disarm can only be watched on the board. The
+  property mailbox likewise acknowledges every tag, known or not, so
+  the firmware's answer to `SET_REBOOT_FLAGS` means nothing here.
+  `PM_RSTS` reads its reset value `0x1000` after every QEMU reset; on
+  the board it carries the reset cause.
 
 Real-hardware bring-up needs a USB-serial cable on GPIO 14/15 (the
 console is mirrored to the display once `fbcons` is up, but that is
 some way into boot) and a FAT32 SD card carrying the
 Broadcom firmware blobs (`bootcode.bin`, `start.elf`, `fixup.dat`) plus
-`kernel8.img` and a `config.txt` setting `arm_64bit=1`.
+the kernel and the `config.txt` under "Working on the board without
+moving the card" below — the one recipe in this file.
 
 ## Prior art, and where the driver code will actually come from
 
@@ -925,23 +942,87 @@ investigation.
 
 ### Working on the board without moving the card
 
-`serialboot` lives on the card and pulls the kernel over the UART on
-every reset -- see the commit that added it. The loop is: build, send
-(about a minute for 618KB at 115200), watch. `reboot()` is implemented
-via the watchdog, since this SoC has no reset line, so once the
-console accepts input the loop needs nobody at the power switch.
+Two ways in, and the card never needs to come out for either.
 
-The `config.txt` recipe that works, with `init_uart_clock` pinned
-because uart.c divides for 115200 assuming 48MHz and the firmware, not
-the kernel, decides what that reference is:
+**Over the wire.** `serialboot` pulls a kernel over the UART: build,
+send (about a minute for 618KB at 115200), watch. It lives on the card
+as `serialboot.img` for a card with no kernel yet, and every installed
+kernel carries the same loader and offers it in a window at the start
+of each boot (`recover.c`), so a kernel that boots far enough to print
+can always be replaced by one fed from the host. `reboot` on
+`/dev/sysctl` resets through the watchdog, since this SoC has no reset
+line, so once the console accepts input the loop needs nobody at the
+power switch.
 
-    kernel=serialboot.img
+**From the card, as A/B.** The kernel `config.txt` names is the
+known-good one and nothing overwrites it in place. A new kernel is
+installed under a *candidate* name, booted exactly once under a boot
+watchdog, and promoted from its own shell:
+
+    cp /dev/bootimage /n/dos/tryboot.img       # the running kernel, or one serialboot fed in
+    echo tryboot > /dev/sysctl                 # reset; the next boot is the candidate
+
+The candidate comes up saying so — `boot: command line: tryboot`,
+`wdog: armed, 90 s boot budget`, and from osinit `CANDIDATE kernel`
+with the two commands below — and releases the watchdog when the shell
+is loaded (`wdog: released after N ms`). Then:
+
+    mv /n/dos/tryboot.img /n/dos/infernode8.img   # keep it
+    echo reboot > /dev/sysctl                     # or reject it: boots infernode8.img
+
+A candidate that panics resets through `exit()`; one that *hangs* is
+reset by the watchdog at the 90-second budget, or within 15 seconds if
+it hung with interrupts off. Either way the firmware's tryboot flag was
+spent on the way in, and the reset boots `infernode8.img`. The budget
+and the reasons for arming only candidate boots are in the comment
+above `boardbootwatchdog()` in `board.c`; the words the kernel reads
+from the command line are `tryboot` (candidate: arm and announce),
+`bootwatchdog` (arm any boot; a hang then loops, which is what an
+unattended board wants), `nowatchdog` (never arm — for a kernel being
+stepped under a debugger) and `wdogtest` (arm, and ignore the release,
+so the reset at the budget can be watched on the board).
+
+The one `config.txt`, with `init_uart_clock` pinned because uart.c
+divides for 115200 assuming 48MHz and the firmware, not the kernel,
+decides what that reference is:
+
     arm_64bit=1
     dtoverlay=disable-bt
     init_uart_clock=48000000
+    kernel=infernode8.img
+    cmdline=cmdline.txt
 
-`infernode8.img` is kept alongside as a fallback: swapping the
-`kernel=` line boots a kernel directly, without a host feeding one.
+    [tryboot]
+    kernel=tryboot.img
+    cmdline=tryboot.cmd
+
+`tryboot.cmd` holds the single word `tryboot`; `cmdline.txt` may be
+empty or absent. The `[tryboot]` section is the firmware's conditional
+filter for a boot made with the flag set; on firmware old enough not to
+know it, a `tryboot.txt` that is a copy of `config.txt` with the two
+`[tryboot]` lines in place of the two above it does the same job, and
+that is the file the firmware documentation historically described.
+For a card with no kernel yet, `kernel=serialboot.img` in place of the
+`kernel=infernode8.img` line, and the first candidate is installed from
+a serial-fed kernel exactly as above.
+
+*Status, 2026-09-05.* Everything on this path that emulation can prove
+is in the harness: the command line reaching the kernel and `osinit`
+through `#B/bootargs`, the candidate announcement and promotion text,
+the arming write reaching the PM block, the `booted` release
+handshake, and `echo tryboot > /dev/sysctl` resetting the machine.
+What only the board can prove, and has not yet: that the firmware
+honours `SET_REBOOT_FLAGS` from this kernel and boots the `[tryboot]`
+section (the candidate's `boot: command line:` line is the evidence;
+`tryboot: firmware acknowledged ...` on the way out is the firmware's
+own word, meaningless under QEMU); that `PM_WDOG` counts down and the
+tick's reloads hold it off for 90 seconds (`bootwatchdog wdogtest` on
+`cmdline.txt`, and the board should reset at 90 s and come back with
+`pm:   rsts` showing the watchdog-reset bit 0x20); that the
+`PM_RSTC` disarm write leaves the machine up. The earlier
+`boardtryboot` set bit 5 of `PM_RSTS` and called it the tryboot bit;
+the downstream Linux tree shows the flag is a mailbox tag and bit 5 is
+the watchdog reset-cause bit, and the code now does what Linux does.
 
 ### Network throughput: where the time actually went
 
@@ -1328,6 +1409,18 @@ Fix: install to a candidate filename; arm the hardware watchdog in
 PM_RSTS handshake on the board once, with the result written here; a
 harness check for the flag write. Two or three days.
 
+*DONE 2026-09-05, except the board.* The install is to `tryboot.img`,
+the boot watchdog is armed in `kmain` for a boot whose command line
+says `tryboot` and released by osinit's `booted` on `/dev/sysctl`, the
+firmware flag is requested through the mailbox tag Linux uses rather
+than a `PM_RSTS` bit (which turned out to be the watchdog reset-cause
+bit), and `#B/bootargs` tells osinit which boot it is. The harness
+checks the arming line, the release line, the candidate announcement,
+`-append`-driven command lines and that `tryboot` on `/dev/sysctl`
+resets QEMU; it cannot check the countdown or the firmware's answer,
+because QEMU models neither — the recipe and the remaining board proof
+are under "Working on the board without moving the card".
+
 **5. The login screen is bypassable in two ways, one deliberate.**
 `boot-baremetal.sh` treats `wm/logon` exiting 0 as a login. Escape
 twice is a designed skip ("Keys won't persist") and exits 0 — fine,
@@ -1457,7 +1550,7 @@ parked"; `notyet.c` "tcp and udp are not here yet" and "nothing installs
 a screenputs"; `etherusb.b` "never run against the silicon" and "bulk
 endpoint assumed to be 2"; two conflicting `config.txt` recipes in this
 file (under "Working on the board" and the old bring-up item), neither
-mentioning `tryboot.txt`; `docs/TLS-ENTROPY.md` (the pool is
+mentioning `tryboot.txt` (unified 2026-09-05); `docs/TLS-ENTROPY.md` (the pool is
 hardware-fed now) and `docs/PERSISTENCE.md` (the `/usr` question is
 decided: on the card). The top-level `README.md` and `QUICKSTART.md`
 still describe the Pi only as a hosted Linux target.

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1386,8 +1386,25 @@ with the interrupted holder on the same core, and `mboxfballoc` and
 `setpower` read the shared buffer after unlocking; the mutex is now a
 bounded `_tas` held with interrupts off across fill, post and copy-out,
 with a two-second wait that proceeds unlocked for a holder that cannot
-return. Verified by the harness under QEMU: @@COUNT@@ checks pass,
-including the five added for these.
+return. Verified by the harness under QEMU: 158 checks pass, 152
+before, six added for these (two for the DHCP reader, two for the
+double detach, two for `badent-1`).
+
+*What that verification does and does not show, 2026-09-05.* The
+`dossrv` fix is the one check that discriminates: the old code leaves
+one lost cluster, the new none, and the same fixture now runs hosted as
+`tests/host/dossrv_badent_test.sh` (also asserting that a genuinely
+damaged entry is still zapped with its cluster deliberately left),
+which CI runs. The DHCP-reader check is behavioural: the "exited" line
+is printed only after `/prog/N` has gone. The double-detach check does
+NOT reach the `epslck` compare-and-set -- two writes typed in sequence
+are serial, and the second was already refused by `ctlwrite`, so that
+check passes on the unfixed kernel; it pins the refusal and the
+driver-exits-once contract, and the race fix is correct by inspection
+only (one assignment of Ddetach in the tree, `epslck` taken in process
+context with nothing else held). The `mailbox.c` rewrite is likewise
+inspection-only; the harness shows the mailbox still works, not that
+the lock is right.
 
 ### Tier 2 — make what exists trustworthy
 
@@ -1438,7 +1455,12 @@ every hub watcher, so two hubs enumerating at once can cross names.
 name flows back through `portsetup`, and a device that failed to come
 up is detached on the spot by `portsetup` and `usbwalk` instead of
 holding its ep0 until unplugged -- or for ever, on the boot walk. The
-hotplug and keyboard harness checks pass unchanged.
+hotplug and keyboard harness checks pass unchanged, which shows the
+success path was not broken; the new detach-on-failure path is
+exercised by nothing -- no QEMU session makes enumeration fail (no
+descriptor timeout, no failed configure, no mid-walk unplug) -- and a
+device that never answered `newdev` returns no name, so there is
+nothing to detach and nothing is.
 
 ### Tier 3 — the machine as a product
 

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1365,6 +1365,30 @@ logged-in / skipped / failed, and the script honours them. Hours.
   kicked; the comment there already says it is "wrong to leave
   permanently".
 
+**DONE 2026-09-05 -- the four non-SMP bullets** (`irqorphan`, the uart
+mutex, the unlocked multi-core writers, the `lock()` bounds and
+`postnote` are not covered by this note). `devusb.c` `CMdetach` makes
+the Ddetach transition under `epslck`, so of two writers arriving
+together exactly one runs the release loop -- the serial second write
+was already refused by `ctlwrite`, which the review missed; the harness
+now detaches the keyboard twice down one shell fd and requires the
+driver to exit once and the shell to still answer. `etherusb.b`'s three
+readers hand their pid to the spawner, which kills them through `/prog`
+when the exchange is over (`killprog` finds them in Prelease and
+`swiproc` wakes the read with "interrupted"); the boot log says `dhcp
+reader N exited` and the harness checks for it. `dossrv.b` decides
+"damaged" from the on-disk name (`rawstat`, `badname`) rather than from
+the alias it hands out; the FAT32 fixture creates and removes a healthy
+`badent-1` and a host-side walk of the image asserts no lost clusters.
+`mailbox.c`'s "single-threaded" comment was stale -- a `lock()` had
+been added -- but `panic()` reaches the mailbox through `screenputs`
+with the interrupted holder on the same core, and `mboxfballoc` and
+`setpower` read the shared buffer after unlocking; the mutex is now a
+bounded `_tas` held with interrupts off across fill, post and copy-out,
+with a two-second wait that proceeds unlocked for a holder that cannot
+return. Verified by the harness under QEMU: @@COUNT@@ checks pass,
+including the five added for these.
+
 ### Tier 2 — make what exists trustworthy
 
 **7. Test what the board relies on.** The harness (`baremetal_test.sh`)
@@ -1410,6 +1434,11 @@ now" in `mmu.c`, and JIT text is RWX); secondary scheduler stacks are
 have answered; `up->inpreempt`-style invariants have no SMP
 counterparts. Also `lastdev` in `osinit.b` is one global shared by
 every hub watcher, so two hubs enumerating at once can cross names.
+*`lastdev` DONE 2026-09-05:* `enumerate` returns `(status, name)`, the
+name flows back through `portsetup`, and a device that failed to come
+up is detached on the spot by `portsetup` and `usbwalk` instead of
+holding its ep0 until unplugged -- or for ever, on the boot walk. The
+hotplug and keyboard harness checks pass unchanged.
 
 ### Tier 3 — the machine as a product
 

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1661,6 +1661,8 @@ compile-checked only.
   probed the leaf tripped over it. A leaf now lists its pin's entries
   as the pin's directory does, and the harness stats
   `/dev/gpio/21/level`.
+  DONE 2026-09-05 on the base (01f7324): `postnote` interrupts the
+  target's sleep, which is the one effect os/ip asks of it.
 
 **DONE 2026-09-05 -- the four non-SMP bullets** (`irqorphan`, the uart
 mutex, the unlocked multi-core writers, the `lock()` bounds and
@@ -1739,6 +1741,18 @@ endpoints; `etherusb.b` has no detach handling although `#u` now
 reports detach; `nif.link` is set to 1 at bind and never updated;
 `lanphy` returns success without link; DHCP has no renewal. A NIC
 unplugged is dead for the boot. Two or three days.
+
+*Mostly DONE 2026-09-05, on `feat/baremetal-pi` itself (01f7324, merged
+here):* `#l` unbinds when a data-path process dies or on an "unbind"
+verb and rebinds; `etherusb` confines its DHCP, ping and time readers
+to their descriptor and kills them when the exchange is over, closes
+the control endpoint when done, and clears a stale interface before
+making a new one; a replugged keyboard keeps its device; `postnote`
+is real, so an interface unbind can wake its readers. The harness
+releases the data path from the console and runs the driver again.
+Mouse unplug and replug verified on the board. Still open: link
+monitoring (`nif.link` is 1 for ever), `lanphy` returning success
+without link, DHCP renewal.
 
 **10. The DWC read path, hardware edition.** No cache *invalidate*
 after DMA completes (`usbdwc.c` cleans before, `memmove`s after) —

--- a/os/bcm2837/README.md
+++ b/os/bcm2837/README.md
@@ -1318,15 +1318,29 @@ first.
 namespace before anything of the desktop's starts, unmounts `#S` and
 `#G` from `/dev`, binds `/dev/null` over `/dev/sysctl` and
 `/dev/hostowner`, and refuses to start the desktop if `/dev/sdcard`,
-`/dev/gpio` or a readable `sysctl` is still there afterwards; the
+`/dev/gpio` or a readable `sysctl` is still there afterwards. The
 comment in the script is the record of what the desktop's `/dev`
-holds (`#i` arrives there through libdraw's own bind when logon opens
-the display, as before). Verified by a new harness session that types
-the same sequence into a child shell over the serial line with the
-FAT16 card attached: inside, the card, the pins and sysctl are gone
-and `echo halt > /dev/sysctl` does not stop the machine; back in the
-console shell all three are still there (seven checks). The second
-half — a non-eve user — is untouched.
+holds (`#i` arrives through libdraw's own bind when logon opens the
+display, as before) and of two things this does not close: the
+desktop's own Quit writes `halt` into the null over `/dev/sysctl`, so
+Quit now ends the desktop and leaves the board up — deliberate, and
+the script says so on the console when lucifer returns; halting is
+the serial console's — and `/n/dos`, config.txt and the kernel image,
+stays read-write (Inferno has no read-only bind). Verified by a
+harness session (`baremetal_test.sh`, "The desktop's namespace can be
+narrowed") that reads the narrowing lines and the fail-closed check
+out of the script — not a copy of them — and types them into a child
+shell over the serial line with the FAT16 card attached: inside, the
+card, the pins and sysctl are gone, the script's own check comes out
+`narrowed 1`, and `echo halt > /dev/sysctl` does not stop the machine;
+back in the console shell the card, `/dev/gpio/21/{ctl,level}` and the
+kernel's sysctl are all still there. Nine checks, run to a green
+summary (162 passed, 0 failed) on 2026-09-05. What the harness does
+not run is the script itself — the kernel image carries no card
+userspace — so its `$status` handling and retry loop are exercised
+only on the hosted emulator against child shells (item 5). The
+second half — a non-eve user, and a `/n` the desktop does not own —
+is untouched.
 
 **4. tryboot is a one-shot flag, not yet an A/B path.**
 `cp /dev/bootimage /n/dos/infernode8.img` (`devboot.c`) overwrites the
@@ -1396,6 +1410,15 @@ compile-checked only.
 - `notyet.c` `postnote` is a stub, so a blocked reader cannot be
   kicked; the comment there already says it is "wrong to leave
   permanently".
+- *DONE 2026-09-05.* `devgpio.c` `gpiogen` answered −1 for every
+  `s >= 0` when called on a leaf (`ctl`, `level`), so `stat(2)` on
+  `/dev/gpio/N/ctl` printed `devstat G <qid>` and failed "file does
+  not exist" while the directory listing showed the file and reads
+  worked (`devopen` takes gen's −1 as nothing to permission-check).
+  `ls` on the leaf, or `ftest -e`, showed it; a harness check that
+  probed the leaf tripped over it. A leaf now lists its pin's entries
+  as the pin's directory does, and the harness stats
+  `/dev/gpio/21/level`.
 
 ### Tier 2 — make what exists trustworthy
 

--- a/os/bcm2837/board.c
+++ b/os/bcm2837/board.c
@@ -331,17 +331,70 @@ boardfbprobe(void)
  * lets the harness drive this. The line is published as
  * #B/bootargs so osinit can read it too.
  *
+ * Because of that choice, the guard on a candidate rests on two
+ * firmware behaviours, neither yet seen on this board: that the
+ * SET_REBOOT_FLAGS tag makes the next boot take the [tryboot]
+ * section at all, and that the section's cmdline= line is what the
+ * firmware then hands GET_COMMAND_LINE. The second is the same
+ * conditional-filter machinery that applies the section's kernel=
+ * line, so a firmware that boots tryboot.img from the section but
+ * serves the other cmdline would be a firmware bug rather than a
+ * documented gap; but it is untested, and the failure would be
+ * quiet: the candidate boots, prints "wdog: not armed (not a tryboot
+ * candidate)", and runs unguarded. That line, on a boot that should
+ * have been marked, is the tell -- and "bootwatchdog" in the
+ * KNOWN-GOOD cmdline.txt is the way round it, since that file is
+ * read on every boot the section does not override.
+ *
+ * WHEN THE LINE CANNOT BE READ. An unanswered GET_COMMAND_LINE, or a
+ * line longer than the buffer (the protocol then copies nothing and
+ * reports the length), leaves the kernel unable to say which boot
+ * this is. It arms. A boot that reaches the shell releases the
+ * watchdog and has lost nothing but a line explaining why; a
+ * candidate that hangs unarmed because its line was 1100 bytes
+ * would have lost the machine to the power switch, which is the one
+ * outcome this whole mechanism exists to remove. "nowatchdog" cannot
+ * be honoured on such a boot, because it cannot be seen.
+ *
  * THE BUDGET. Ninety seconds, because a boot to the shell takes a few
  * seconds and the only things that legitimately take longer -- USB
  * enumeration behind a slow hub, a DHCP server that is not answering
  * -- are done in threads osinit spawns, so the shell is not behind
  * them. PM_WDOG cannot hold ninety seconds: it is a 20-bit count at
  * 65536Hz, sixteen seconds at most. So the hardware is loaded with
- * fifteen seconds and reloaded from the clock tick on core 0 for as
- * long as the budget has not run out, and then left to expire. A
- * kernel that hangs with interrupts still running is caught by the
- * budget; one that hangs with them off is caught by the fifteen
- * seconds. Both end in the same place.
+ * fifteen seconds and reloaded for as long as the budget has not run
+ * out, and then left to expire.
+ *
+ * Two things reload it, because the boot path has two halves. Once
+ * kmain's final spllo has let interrupts run, the clock tick on core 0
+ * reloads it every 64 ticks. Before that -- from the arming write
+ * through startmmu, the allocators, the probes, the SMP launch and
+ * the card, up to schedinit -- interrupts are masked except for the
+ * moments probeclock and probeintr open them, and the tick cannot
+ * help; and that half is not short. probeuartin waits a deliberate
+ * three seconds for a keypress, launchsmp waits up to five for cores
+ * that never answer, emmcinit two for a card to power up plus its
+ * command timeouts, and the sum on a bad day is past ten seconds
+ * against a count that started at fifteen. So the same reload is
+ * polled from microdelay(), which every one of those waits loops
+ * around, and from probeuartin's own loop, whenever five seconds have
+ * passed since the last reload. The count therefore never falls below
+ * ten seconds in code that is waiting on purpose, however long it
+ * waits, and reaches zero only when nothing has polled for fifteen
+ * seconds -- a hang, or a spin that does not go through microdelay,
+ * and the mailbox spin is the one of those worth knowing about. A
+ * kernel that hangs with interrupts running is caught at the budget;
+ * one that hangs with them off, or before they were ever on, within
+ * fifteen seconds. Both end in the same place.
+ *
+ * The poll takes the watchdog lock, and exclusives fault with the
+ * MMU off (see mboxlockon). It is safe because nothing between the
+ * arming write and mmuon calls microdelay -- startmmu is table
+ * building and register writes -- and because a poll returns before
+ * the lock unless five seconds have passed since arming, which the
+ * MMU set-up does not take. QEMU cannot show any of this: its PM
+ * model resets on the arming write, so no poll ever runs armed
+ * there; the reload interval is a board result.
  *
  * WHAT RELEASES IT. osinit writes "booted" to /dev/sysctl once the
  * shell is loaded and about to run; devcons calls booted(), which
@@ -356,13 +409,15 @@ enum
 	Bootbudgetms	= 90*1000,	/* see above */
 	Wdogmaxms	= 15*1000,	/* under the 16 s the 20-bit count can hold */
 	Wdogkickevery	= 64,		/* ticks between reloads; well inside 15 s */
+	Wdogpollms	= 5*1000,	/* microdelay reloads after this long without one */
 };
 
-static char cmdline[1024];
+static char cmdline[Mboxcmdlinemax];
 static Lock wdoglock;
 static int wdogarmed;		/* being kicked */
 static int wdogspent;		/* budget ran out; the reset is coming */
 static u64int wdogt0;		/* systimer() when armed */
+static u64int wdoglast;		/* systimer() at the last reload */
 
 char*
 boardcmdline(void)
@@ -419,6 +474,7 @@ pmwdogset(int ms)
 	*wdog = Pmpassword | t;
 	*rstc = Pmpassword | (*rstc & Pmwrcfgclr) | Pmwrcfgfull;
 	coherence();
+	wdoglast = systimer();
 }
 
 static void
@@ -459,34 +515,60 @@ pmdump(void)
 void
 boardbootwatchdog(void)
 {
-	int n;
+	int n, unread;
 
 	n = mboxcmdline(cmdline, sizeof cmdline);
+	unread = 0;
 	uartputstr("boot: command line: ");
-	if(n < 0)
-		uartputstr("(unavailable)");
-	else if(cmdline[0] == 0)
+	if(n < 0){
+		uartputstr("(UNREAD: the firmware did not answer GET_COMMAND_LINE)");
+		unread = 1;
+	}else if(n > Mboxcmdlinemax){
+		/*
+		 * The protocol copied nothing; see mboxcmdline. Say the
+		 * length, so that the fix -- a bigger buffer, or a
+		 * shorter cmdline.txt -- is obvious from the line.
+		 */
+		uartputstr("(UNREAD: the firmware reports ");
+		uartputd(n);
+		uartputstr(" bytes, more than the ");
+		uartputd(Mboxcmdlinemax);
+		uartputstr("-byte buffer)");
+		unread = 1;
+	}else if(cmdline[0] == 0)
 		uartputstr("(empty)");
 	else
 		uartputstr(cmdline);
 	uartputstr("\n");
 	pmdump();
 
-	if(cmdlineword("nowatchdog")){
-		uartputstr("wdog: not armed (nowatchdog on the command line)\n");
-		return;
-	}
-	if(!boardcandidate() && !cmdlineword("bootwatchdog") && !cmdlineword("wdogtest")){
-		uartputstr("wdog: not armed (not a tryboot candidate)\n");
-		return;
-	}
+	if(unread){
+		/*
+		 * Which boot this is cannot be known, so guard it as if
+		 * it were the candidate; see "WHEN THE LINE CANNOT BE
+		 * READ" above.
+		 */
+		uartputstr("wdog: armed, ");
+		uartputd(Bootbudgetms / 1000);
+		uartputstr(" s boot budget; the command line could not be read, "
+			"so this boot is guarded as a candidate would be\n");
+	}else{
+		if(cmdlineword("nowatchdog")){
+			uartputstr("wdog: not armed (nowatchdog on the command line)\n");
+			return;
+		}
+		if(!boardcandidate() && !cmdlineword("bootwatchdog") && !cmdlineword("wdogtest")){
+			uartputstr("wdog: not armed (not a tryboot candidate)\n");
+			return;
+		}
 
-	uartputstr("wdog: armed, ");
-	uartputd(Bootbudgetms / 1000);
-	uartputstr(" s boot budget; a hang resets");
-	if(boardcandidate())
-		uartputstr(" to config.txt's kernel");
-	uartputstr("\n");
+		uartputstr("wdog: armed, ");
+		uartputd(Bootbudgetms / 1000);
+		uartputstr(" s boot budget; a hang resets");
+		if(boardcandidate())
+			uartputstr(" to config.txt's kernel");
+		uartputstr("\n");
+	}
 
 	wdogt0 = systimer();
 	wdogarmed = 1;
@@ -495,21 +577,17 @@ boardbootwatchdog(void)
 }
 
 /*
- * From clockintr on core 0, every tick. canlock rather than lock: this
- * is interrupt context, and if boardbooted() holds the lock on this
- * core the kick can simply wait for the next tick.
+ * Reload the count from what is left of the budget, or stop when the
+ * budget is spent. canlock rather than lock, for both callers: the
+ * tick is interrupt context, the poll runs inside arbitrary drivers'
+ * delays, and if boardbooted() holds the lock the reload can simply
+ * wait for the next tick or the next delay.
  */
-void
-boardwatchdogtick(void)
+static void
+wdogkick(void)
 {
-	static int n;
 	u64int ms;
 
-	if(!wdogarmed)
-		return;
-	if(++n < Wdogkickevery)
-		return;
-	n = 0;
 	if(!canlock(&wdoglock))
 		return;
 	if(wdogarmed){
@@ -529,6 +607,38 @@ boardwatchdogtick(void)
 		}
 	}
 	unlock(&wdoglock);
+}
+
+/* from clockintr on core 0, every tick */
+void
+boardwatchdogtick(void)
+{
+	static int n;
+
+	if(!wdogarmed)
+		return;
+	if(++n < Wdogkickevery)
+		return;
+	n = 0;
+	wdogkick();
+}
+
+/*
+ * From microdelay(), and from the boot path's own busy-waits: the
+ * reload for the stretch of kmain that runs with interrupts masked.
+ * The first test is the whole cost on a boot that is not armed. The
+ * second keeps a tight loop of short delays from reloading the count
+ * on every pass; it also keeps the lock from being touched before the
+ * MMU is on, as the comment on the budget explains.
+ */
+void
+boardwatchdogpoll(void)
+{
+	if(!wdogarmed)
+		return;
+	if(systimer() - wdoglast < (u64int)Wdogpollms * 1000)
+		return;
+	wdogkick();
 }
 
 /*

--- a/os/bcm2837/board.c
+++ b/os/bcm2837/board.c
@@ -286,6 +286,305 @@ boardfbprobe(void)
 }
 
 /*
+ * The kernel command line, and the boot watchdog it controls.
+ *
+ * THE PROBLEM. A candidate kernel is one nobody has seen boot on this
+ * board. If it panics, exit() resets the machine and the firmware --
+ * its tryboot flag now spent -- loads the known-good kernel again; that
+ * path has always worked. If it HANGS, nothing happens at all: the
+ * classic failure of a JIT that forgot its instruction-cache
+ * maintenance is a machine that prints half a boot and stops, and the
+ * only way out was the power switch. A watchdog armed before the
+ * candidate has done anything, and disarmed only once it has proved it
+ * can run a shell, turns that hang into the same reset a panic gets.
+ *
+ * WHICH BOOTS ARM IT. Only the ones the command line says to: the word
+ * "tryboot" marks a candidate boot, and "bootwatchdog" asks for the
+ * guard without the candidate semantics; "nowatchdog" wins over both,
+ * for a boot that is legitimately slow -- a kernel being stepped under
+ * a debugger, say, whose budget would otherwise expire on a
+ * breakpoint. "wdogtest" arms and then IGNORES the release, so that the
+ * one thing emulation cannot show -- the count reaching zero and the
+ * chip resetting -- can be watched on the board with a stopwatch. The
+ * default is NOT to arm, for two reasons that were weighed against the
+ * obvious alternative of guarding every boot.
+ *
+ * One is emulation. QEMU's model of this block (hw/misc/
+ * bcm2835_powermgt.c) has no countdown: a write to PM_RSTC with the
+ * full-reset WRCFG resets the machine on the spot, whatever PM_WDOG
+ * holds. A kernel that armed unconditionally could not boot under
+ * QEMU at all, and QEMU is where every check in the harness runs.
+ * The other is that a known-good kernel which hangs has nowhere to
+ * fall back to: a watchdog there produces a machine that resets every
+ * ninety seconds and wipes its own console each time, which is a
+ * worse thing to find than a hang with the last line still on the
+ * screen. The candidate is the case a reset helps, and the operator
+ * who wants the reset regardless has a word for it.
+ *
+ * HOW THE WORD GETS HERE. The firmware assembles the command line
+ * from the cmdline file that the config in force names, and a
+ * [tryboot] section of config.txt -- or a tryboot.txt -- can name a
+ * different one from the known-good boot's. That is the whole channel:
+ * the same kernel image can be booted as a candidate or as the
+ * incumbent, and it learns which from the firmware rather than from
+ * the build. QEMU's -append lands in the same place, which is what
+ * lets the harness drive this. The line is published as
+ * #B/bootargs so osinit can read it too.
+ *
+ * THE BUDGET. Ninety seconds, because a boot to the shell takes a few
+ * seconds and the only things that legitimately take longer -- USB
+ * enumeration behind a slow hub, a DHCP server that is not answering
+ * -- are done in threads osinit spawns, so the shell is not behind
+ * them. PM_WDOG cannot hold ninety seconds: it is a 20-bit count at
+ * 65536Hz, sixteen seconds at most. So the hardware is loaded with
+ * fifteen seconds and reloaded from the clock tick on core 0 for as
+ * long as the budget has not run out, and then left to expire. A
+ * kernel that hangs with interrupts still running is caught by the
+ * budget; one that hangs with them off is caught by the fifteen
+ * seconds. Both end in the same place.
+ *
+ * WHAT RELEASES IT. osinit writes "booted" to /dev/sysctl once the
+ * shell is loaded and about to run; devcons calls booted(), which
+ * lands in boardbooted() below. The disarm is PM_RSTC's reset value
+ * written back with the password, which clears WRCFG -- the write
+ * every reference driver uses (see io.h). One line is printed when
+ * the watchdog is armed and one when it is released, so the harness
+ * can see both ends of the handshake.
+ */
+enum
+{
+	Bootbudgetms	= 90*1000,	/* see above */
+	Wdogmaxms	= 15*1000,	/* under the 16 s the 20-bit count can hold */
+	Wdogkickevery	= 64,		/* ticks between reloads; well inside 15 s */
+};
+
+static char cmdline[1024];
+static Lock wdoglock;
+static int wdogarmed;		/* being kicked */
+static int wdogspent;		/* budget ran out; the reset is coming */
+static u64int wdogt0;		/* systimer() when armed */
+
+char*
+boardcmdline(void)
+{
+	return cmdline;
+}
+
+/*
+ * A whole whitespace-delimited word, so that "tryboot" cannot be
+ * found inside "tryboot.img" or "notryboot".
+ */
+static int
+cmdlineword(char *w)
+{
+	char *p, *q;
+	int n;
+
+	n = strlen(w);
+	for(p = cmdline; *p != 0; p = q){
+		while(*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n')
+			p++;
+		for(q = p; *q != 0 && *q != ' ' && *q != '\t' && *q != '\r' && *q != '\n'; q++)
+			;
+		if(q - p == n && memcmp(p, w, n) == 0)
+			return 1;
+	}
+	return 0;
+}
+
+int
+boardcandidate(void)
+{
+	return cmdlineword("tryboot");
+}
+
+/*
+ * Load the count, then make its expiry a full reset. In that order:
+ * with WRCFG already set, a stale count could expire between the two
+ * writes.
+ */
+static void
+pmwdogset(int ms)
+{
+	volatile u32int *rstc, *wdog;
+	u32int t;
+
+	t = ((u64int)ms * Pmwdoghz) / 1000;
+	if(t > Pmwdogmask)
+		t = Pmwdogmask;
+	if(t == 0)
+		t = 1;
+	rstc = (u32int*)(uintptr)(PMREGS + Pmrstc);
+	wdog = (u32int*)(uintptr)(PMREGS + Pmwdog);
+	*wdog = Pmpassword | t;
+	*rstc = Pmpassword | (*rstc & Pmwrcfgclr) | Pmwrcfgfull;
+	coherence();
+}
+
+static void
+pmwdogoff(void)
+{
+	volatile u32int *rstc;
+
+	rstc = (u32int*)(uintptr)(PMREGS + Pmrstc);
+	*rstc = Pmpassword | Pmrstcreset;
+	coherence();
+}
+
+/*
+ * The block's three registers as the firmware left them. PM_RSTS is
+ * the interesting one on the board: it holds the reset cause, and
+ * after a tryboot it is where the firmware's own bookkeeping would
+ * show if it used the register. QEMU reports its reset values,
+ * 0x102/0x1000/0.
+ */
+static void
+pmdump(void)
+{
+	uartputstr("pm:   rsts ");
+	uartputx(*(volatile u32int*)(uintptr)(PMREGS + Pmrsts));
+	uartputstr(" rstc ");
+	uartputx(*(volatile u32int*)(uintptr)(PMREGS + Pmrstc));
+	uartputstr(" wdog ");
+	uartputx(*(volatile u32int*)(uintptr)(PMREGS + Pmwdog));
+	uartputstr("\n");
+}
+
+/*
+ * Called from kmain right after the mailbox has been proved to work
+ * and before anything slow. uartputstr throughout: this runs before
+ * print() has a queue, and the "armed" line must be out before the
+ * arming write, because under QEMU that write IS the reset.
+ */
+void
+boardbootwatchdog(void)
+{
+	int n;
+
+	n = mboxcmdline(cmdline, sizeof cmdline);
+	uartputstr("boot: command line: ");
+	if(n < 0)
+		uartputstr("(unavailable)");
+	else if(cmdline[0] == 0)
+		uartputstr("(empty)");
+	else
+		uartputstr(cmdline);
+	uartputstr("\n");
+	pmdump();
+
+	if(cmdlineword("nowatchdog")){
+		uartputstr("wdog: not armed (nowatchdog on the command line)\n");
+		return;
+	}
+	if(!boardcandidate() && !cmdlineword("bootwatchdog") && !cmdlineword("wdogtest")){
+		uartputstr("wdog: not armed (not a tryboot candidate)\n");
+		return;
+	}
+
+	uartputstr("wdog: armed, ");
+	uartputd(Bootbudgetms / 1000);
+	uartputstr(" s boot budget; a hang resets");
+	if(boardcandidate())
+		uartputstr(" to config.txt's kernel");
+	uartputstr("\n");
+
+	wdogt0 = systimer();
+	wdogarmed = 1;
+	coherence();
+	pmwdogset(Wdogmaxms);
+}
+
+/*
+ * From clockintr on core 0, every tick. canlock rather than lock: this
+ * is interrupt context, and if boardbooted() holds the lock on this
+ * core the kick can simply wait for the next tick.
+ */
+void
+boardwatchdogtick(void)
+{
+	static int n;
+	u64int ms;
+
+	if(!wdogarmed)
+		return;
+	if(++n < Wdogkickevery)
+		return;
+	n = 0;
+	if(!canlock(&wdoglock))
+		return;
+	if(wdogarmed){
+		ms = (systimer() - wdogt0) / 1000;
+		if(ms >= Bootbudgetms){
+			/*
+			 * Stop kicking. The last reload was for exactly the
+			 * time that was left, so the reset lands at the budget,
+			 * not fifteen seconds after it.
+			 */
+			wdogarmed = 0;
+			wdogspent = 1;
+			uartputstr("wdog: boot budget spent; the reset is coming\n");
+		}else{
+			ms = Bootbudgetms - ms;
+			pmwdogset(ms < Wdogmaxms ? (int)ms : Wdogmaxms);
+		}
+	}
+	unlock(&wdoglock);
+}
+
+/*
+ * "booted" on /dev/sysctl: the machine has a shell, so the boot is no
+ * longer the thing the watchdog is guarding. Prints in every case,
+ * because the release line is the harness's evidence that the write
+ * reached this far -- including on a boot that never armed.
+ */
+void
+boardbooted(void)
+{
+	int s, was;
+	u64int ms;
+
+	if(cmdlineword("wdogtest") && wdogarmed){
+		print("wdog: NOT released (wdogtest): the reset should come at %d s\n",
+			Bootbudgetms / 1000);
+		return;
+	}
+
+	ms = 0;
+	s = splhi();
+	lock(&wdoglock);
+	was = wdogarmed;
+	if(was){
+		wdogarmed = 0;
+		pmwdogoff();
+		ms = (systimer() - wdogt0) / 1000;
+	}
+	unlock(&wdoglock);
+	splx(s);
+
+	if(was)
+		print("wdog: released after %llud ms; boot complete\n", ms);
+	else if(wdogspent)
+		print("wdog: boot complete AFTER the budget; the reset is already coming\n");
+	else
+		print("wdog: boot complete; no watchdog was armed\n");
+}
+
+/*
+ * Before a deliberate reset: stop the tick from reloading PM_WDOG
+ * under it. The flag alone is not enough -- a kick on core 0 that has
+ * already passed its check would reload fifteen seconds over the
+ * sixteen ticks below -- so wait out more than one tick as well. No
+ * lock: this is called from exit(), where locks may be what broke.
+ */
+static void
+wdogquiet(void)
+{
+	wdogarmed = 0;
+	coherence();
+	microdelay(2000);
+}
+
+/*
  * Reset the machine.
  *
  * This SoC has no reset line to assert: rebooting means arming the
@@ -305,6 +604,8 @@ boardreboot(void)
 {
 	volatile u32int *rstc, *wdog;
 
+	wdogquiet();
+
 	rstc = (u32int*)(uintptr)(PMREGS + Pmrstc);
 	wdog = (u32int*)(uintptr)(PMREGS + Pmwdog);
 
@@ -317,37 +618,33 @@ boardreboot(void)
 }
 
 /*
- * Reset with the firmware's one-shot TRYBOOT flag raised.
+ * Reset with the firmware's one-shot tryboot flag raised, so that the
+ * next boot -- and only the next -- takes its configuration from the
+ * [tryboot] section of config.txt (or tryboot.txt). config.txt names
+ * the known-good kernel, the tryboot configuration names the candidate
+ * and marks its command line, and a candidate that crashes or hangs
+ * costs one reset back to known-good: no loader work, no card surgery,
+ * no serial rescue.
  *
- * The VideoCore reads PM_RSTS at boot; with this bit set it clears
- * the bit and loads tryboot.txt instead of config.txt, exactly once.
- * That is the whole A/B kernel mechanism on this platform: config.txt
- * names the known-good kernel, tryboot.txt names the candidate, and a
- * candidate that crashes costs one watchdog reset back to known-good
- * -- no loader work, no card surgery, no serial rescue. The bit is
- * survived by the reset on purpose; everything else about the reset
- * is boardreboot()'s.
- *
- * PM_RSTS also holds partition-select and reset-cause bits the
- * firmware owns, so read-modify-write rather than store: clobbering
- * them has no documented recovery.
+ * The flag is asked for through the mailbox, which is how Linux does
+ * it (SET_REBOOT_FLAGS then NOTIFY_REBOOT; see io.h). An earlier
+ * version of this function set bit 5 of PM_RSTS instead and called it
+ * the tryboot bit, with a comment saying the VideoCore reads it. That
+ * was never tested against the firmware, and reading the downstream
+ * Linux tree while writing the boot watchdog found that bit 5 is
+ * HADWRQ -- a reset-cause bit the firmware sets -- and that Linux
+ * never touches PM_RSTS for tryboot at all. Whether the firmware
+ * honours the tag from THIS kernel is still the one thing here that
+ * only the board can say: the line below records its answer.
  */
 void
 boardtryboot(void)
 {
-	volatile u32int *rstc, *rsts, *wdog;
-
-	rstc = (u32int*)(uintptr)(PMREGS + Pmrstc);
-	rsts = (u32int*)(uintptr)(PMREGS + Pmrsts);
-	wdog = (u32int*)(uintptr)(PMREGS + Pmwdog);
-
-	*rsts = Pmpassword | *rsts | Pmrststryboot;
-	*wdog = Pmpassword | 16;
-	*rstc = Pmpassword | (*rstc & Pmwrcfgclr) | Pmwrcfgfull;
-	coherence();
-
-	for(;;)
-		;
+	if(mboxreboot(1) < 0)
+		uartputstr("tryboot: firmware did NOT acknowledge the reboot flags; resetting anyway\n");
+	else
+		uartputstr("tryboot: firmware acknowledged reboot flags 0x1 (tryboot)\n");
+	boardreboot();
 }
 
 /*

--- a/os/bcm2837/board.h
+++ b/os/bcm2837/board.h
@@ -29,6 +29,11 @@ int	mboxfbnumdisplays(void);
 u32int	mboxclockrate(u32int);
 void	mboxlockon(void);
 int	mboxedid(u32int, uchar*);
+int	mboxcmdline(char*, int);
+int	mboxreboot(int);
+
+/* board.c: the boot watchdog's reload, called from clockintr on core 0 */
+void	boardwatchdogtick(void);
 
 int	emmcinit(void);
 int	emmcread(uvlong, void*);

--- a/os/bcm2837/board.h
+++ b/os/bcm2837/board.h
@@ -22,7 +22,12 @@ void	gpioclaim(int, char*);
 char*	gpioclaimed(int);
 
 /* mailbox.c */
+enum
+{
+	Mboxcmdlinemax	= 1024,	/* the GET_COMMAND_LINE value buffer, in bytes */
+};
 int	mboxprop(u32int, u32int*, int, int);
+int	mboxprop1(u32int, u32int*, int, int, u32int*);
 int	setpower(int, int);
 int	mboxfballoc(u32int, u32int, u32int, u32int, Fbinfo*);
 int	mboxfbnumdisplays(void);
@@ -32,8 +37,12 @@ int	mboxedid(u32int, uchar*);
 int	mboxcmdline(char*, int);
 int	mboxreboot(int);
 
-/* board.c: the boot watchdog's reload, called from clockintr on core 0 */
+/*
+ * board.c: the boot watchdog's reload. The tick is core 0's clockintr;
+ * the poll is microdelay's, for the boot path before interrupts run.
+ */
 void	boardwatchdogtick(void);
+void	boardwatchdogpoll(void);
 
 int	emmcinit(void);
 int	emmcread(uvlong, void*);

--- a/os/bcm2837/clock.c
+++ b/os/bcm2837/clock.c
@@ -40,7 +40,7 @@ enum
 
 static u64int cntfrq;		/* generic timer rate, from CNTFRQ_EL0 */
 static u64int tickinterval;	/* generic timer ticks between interrupts */
-static u64int ticks;		/* ticks since clockinit */
+static u64int ticks;		/* core 0's ticks since clockinit; see clockintr */
 
 static u64int
 rdcntfrq(void)
@@ -210,7 +210,15 @@ clockintr(Ureg *u)
 	if((ctl & (1<<2)) == 0)
 		return 0;
 
-	ticks++;
+	/*
+	 * Core 0's count only. This is the counter the boot-time rate
+	 * check reads through clockticks(), before any other core exists;
+	 * it has no per-core meaning, and four cores doing ++ on one word
+	 * without a lock lose increments. The per-core count that matters
+	 * is m->ticks, which hzclock() advances below.
+	 */
+	if(m->machno == 0)
+		ticks++;
 
 	/*
 	 * m->ticks is not bookkeeping -- os/port reads it directly.
@@ -269,13 +277,19 @@ clockintr(Ureg *u)
 	 * the answer (GC and scheduler, not the network path) is in the
 	 * README.
 	 */
+	/*
+	 * ainc, not ++: every core runs this on every tick, and two cores
+	 * sampling into the same bucket at once would otherwise lose one
+	 * of the samples -- a profiler that quietly under-reports the hot
+	 * spot is worse than one that is honestly noisy.
+	 */
 	{
 		extern ulong profbuck[24576];
 		ulong ix;
 
 		ix = (u->pc - 0x80000) >> 6;
 		if(ix < 24576)
-			profbuck[ix]++;
+			ainc(&profbuck[ix]);
 	}
 
 	armtick();
@@ -361,8 +375,16 @@ irqdispatch(Ureg *u)
 	 * intrrun could not place, and the decision below is about THIS
 	 * interrupt -- a stale value from an earlier one would condemn a
 	 * later spurious interrupt for something it did not do.
+	 *
+	 * And per core, not per machine. Every core's timer tick comes
+	 * through here, so with one shared word core 1's tick could clear
+	 * the orphan core 0 had just recorded, between intrrun setting it
+	 * and the test below reading it -- and a genuinely unhandled GPU
+	 * interrupt on core 0 would be counted spurious and left asserted,
+	 * storming silently. Each core's dispatch now has a word nobody
+	 * else writes.
 	 */
-	irqorphan = -1;
+	irqorphan[m->machno] = -1;
 
 	if(clockintr(u))
 		handled = 1;
@@ -419,8 +441,8 @@ irqdispatch(Ureg *u)
 	 * -1: nothing enabled and pending had been rejected, so there was
 	 * nothing to panic about.
 	 */
-	if(irqorphan < 0){
-		nspurious++;
+	if(irqorphan[m->machno] < 0){
+		ainc(&nspurious);
 		return 1;
 	}
 

--- a/os/bcm2837/clock.c
+++ b/os/bcm2837/clock.c
@@ -166,16 +166,33 @@ clockinit(void)
  * calibrated tickinterval against the fixed-frequency system timer;
  * the other cores reuse that number, route their own CNTPNSIRQ through
  * their own slot in the local interrupt block, and arm their first
- * tick. From then on clockintr() -- which reads only per-core
- * registers -- serves them exactly as it serves core 0, which is what
- * makes tsleep(), preemption and the portable timer chain work on
- * every core rather than only where the boot happened.
+ * tick.
+ *
+ * Routing and arming are not enough, and for a long time they were all
+ * this did. clockintr() hands every tick to portclock.c's timerintr(),
+ * which walks timers[m->machno] -- THIS core's queue -- and the only
+ * thing that makes a tick into a clock (m->ticks, checkalarms, the
+ * active.exiting check, preemption) is a periodic Timer with a nil tf
+ * sitting on that queue. timersinit() made exactly one, on core 0's
+ * queue, and so cores 1-3 took a thousand interrupts a second and did
+ * nothing with any of them: their m->ticks stayed at the 1 squidboy
+ * wrote, and a process spinning on one of them ran until it chose to
+ * stop. (tsleep() never noticed, because it goes through the global
+ * talarm list that core 0's checkalarms services.) An earlier version
+ * of this comment claimed the opposite, which is why the claim is now
+ * asserted at boot -- smpcheck() in main.c -- and readable afterwards
+ * in /dev/sysstat.
+ *
+ * timersinitmach() puts this core's hzclock Timer on this core's queue.
+ * It does not re-run todinit(): time of day is one machine-wide clock,
+ * initialised by core 0 before any secondary was released.
  */
 void
 secclockinit(void)
 {
 	LOCAL(Ltimerirq0 + 4*m->machno) = Cntpnsirq;
 	coherence();
+	timersinitmach();
 	armtick();
 }
 

--- a/os/bcm2837/clock.c
+++ b/os/bcm2837/clock.c
@@ -195,6 +195,10 @@ clockintr(Ureg *u)
 
 	ticks++;
 
+	/* the boot watchdog is core 0's to keep alive; see board.c */
+	if(m->machno == 0)
+		boardwatchdogtick();
+
 	/*
 	 * m->ticks is not bookkeeping -- os/port reads it directly.
 	 *

--- a/os/bcm2837/clock.c
+++ b/os/bcm2837/clock.c
@@ -100,12 +100,22 @@ systimer(void)
 /*
  * Busy-wait, timed off the system timer because its 1MHz rate is fixed
  * by the hardware rather than reported by firmware.
+ *
+ * The boot watchdog is polled from here, once per call. Until kmain's
+ * final spllo the clock interrupt that reloads the count is masked,
+ * and every wait the boot path makes in that window -- the SMP
+ * launch, the card's power-up, a command timeout -- is a loop around
+ * this function; so this is the one place a reload can be hung on
+ * that covers them all. It costs a load of one flag when nothing is
+ * armed, which is every call after osinit's "booted" and every call
+ * on a boot the command line did not mark. See board.c.
  */
 void
 microdelay(int us)
 {
 	u64int end;
 
+	boardwatchdogpoll();
 	end = systimer() + (u64int)(uint)us;
 	while(systimer() < end)
 		;

--- a/os/bcm2837/devgpio.c
+++ b/os/bcm2837/devgpio.c
@@ -108,10 +108,32 @@ gpiogen(Chan *c, char *name, Dirtab *tab, int ntab, int s, Dir *dp)
 		devdir(c, q, nm, 0, eve, DMDIR|0555, dp);
 		return 1;
 	case Qpin:
+	case Qctl:
+	case Qlevel:
+		/*
+		 * A pin's directory and the two files in it answer alike
+		 * for s >= 0: the entries of the pin's directory. That is
+		 * what devstat and devopen need of a gen called on a LEAF
+		 * -- they walk the leaf's siblings looking for its own qid
+		 * -- and this case used to answer -1 for every s >= 0 on a
+		 * leaf, so stat(2) on /dev/gpio/N/ctl printed "devstat G"
+		 * and failed with "file does not exist" while the
+		 * directory listing showed the file and reads worked (open
+		 * takes gen's -1 as "no entry to permission-check" and
+		 * carries on). ls on a leaf, and ftest -e, were the ways to
+		 * see it. Only ".." differs: the pin's parent is the gpio
+		 * directory, a file's is the pin.
+		 */
 		pin = QPIN(c->qid.path);
 		if(s == DEVDOTDOT){
-			mkqid(&q, Qgpio, 0, QTDIR);
-			devdir(c, q, "gpio", 0, eve, DMDIR|0555, dp);
+			if(QTYPE(c->qid.path) == Qpin){
+				mkqid(&q, Qgpio, 0, QTDIR);
+				devdir(c, q, "gpio", 0, eve, DMDIR|0555, dp);
+				return 1;
+			}
+			snprint(nm, sizeof nm, "%d", pin);
+			mkqid(&q, QPATH(pin, Qpin), 0, QTDIR);
+			devdir(c, q, nm, 0, eve, DMDIR|0555, dp);
 			return 1;
 		}
 		if(s == 0){
@@ -125,16 +147,8 @@ gpiogen(Chan *c, char *name, Dirtab *tab, int ntab, int s, Dir *dp)
 			return 1;
 		}
 		return -1;
-	default:
-		if(s == DEVDOTDOT){
-			pin = QPIN(c->qid.path);
-			snprint(nm, sizeof nm, "%d", pin);
-			mkqid(&q, QPATH(pin, Qpin), 0, QTDIR);
-			devdir(c, q, nm, 0, eve, DMDIR|0555, dp);
-			return 1;
-		}
-		return -1;
 	}
+	return -1;
 }
 
 static Chan*

--- a/os/bcm2837/intr.c
+++ b/os/bcm2837/intr.c
@@ -74,8 +74,30 @@ static Vctl vctl[Nirq];
  */
 static u32int irqenabled[3];
 
-/* the last source that arrived with no handler; -1 if none has */
-int irqorphan = -1;
+/*
+ * Guards irqenabled[] and the enable/disable registers behind it.
+ *
+ * intrenable() is called from kprocs, and a kproc runs on whichever core
+ * picks it up; two drivers enabling their sources at once from two
+ * cores would each read-modify-write the same word and one of the bits
+ * would be lost -- a driver whose interrupt is unmasked in hardware and
+ * masked in the software copy intrgpu() filters by, so it fires and is
+ * never dispatched. The reads in intrgpu() and intrpending() are single
+ * aligned words and need no lock; ilock because the writers may be
+ * called with interrupts already off.
+ */
+static Lock intrlock;
+
+/*
+ * The last source that arrived with no handler, per core; -1 if none.
+ *
+ * Per core because irqdispatch() clears it at the top of every dispatch
+ * and tests it at the bottom, and every core's clock tick is a dispatch.
+ * With one word, a tick on core 1 could wipe out what intrrun() on core
+ * 0 had just recorded, and the unhandled interrupt on core 0 would be
+ * counted as spurious -- and left asserted, to fire again, for ever.
+ */
+int irqorphan[MAXMACH];
 
 /* interrupts that had already gone away by the time we looked */
 ulong nspurious;
@@ -117,6 +139,7 @@ intrenable(int irq, void (*f)(Ureg*, void*), void *a, int tbdf, char *name)
 	if(f == nil)
 		panic("intrenable: nil handler for irq %d (%s)", irq, name);
 
+	ilock(&intrlock);
 	vctl[irq].f = f;
 	vctl[irq].a = a;
 	vctl[irq].name = name;
@@ -132,6 +155,7 @@ intrenable(int irq, void (*f)(Ureg*, void*), void *a, int tbdf, char *name)
 		irqenabled[2] |= 1 << (irq - 64);
 		INTREGS->ARMenable = 1 << (irq - 64);
 	}
+	iunlock(&intrlock);
 }
 
 void
@@ -142,6 +166,7 @@ intrdisable(int irq, void (*f)(Ureg*, void*), void *a, int tbdf, char *name)
 	if(irq < 0 || irq >= Nirq)
 		return;
 
+	ilock(&intrlock);
 	if(irq < 32)
 		INTREGS->GPUdisable[0] = 1 << irq;
 	else if(irq < 64)
@@ -160,6 +185,7 @@ intrdisable(int irq, void (*f)(Ureg*, void*), void *a, int tbdf, char *name)
 	vctl[irq].f = nil;
 	vctl[irq].a = nil;
 	vctl[irq].name = nil;
+	iunlock(&intrlock);
 }
 
 /*
@@ -177,7 +203,7 @@ intrrun(Ureg *u, int irq)
 		 * claimed. "unhandled IRQ" with no number sent the last
 		 * diagnosis to the register dump and a guess.
 		 */
-		irqorphan = irq;
+		irqorphan[m->machno] = irq;
 		return 0;
 	}
 	vctl[irq].f(u, vctl[irq].a);
@@ -238,6 +264,8 @@ intrinit(void)
 		vctl[i].a = nil;
 		vctl[i].name = nil;
 	}
+	for(i = 0; i < MAXMACH; i++)
+		irqorphan[i] = -1;
 
 	/*
 	 * Report what we inherited before changing it.
@@ -283,13 +311,23 @@ intrinit(void)
  * none of which were being printed.
  *
  * uartputstr rather than print: this runs at splhi from the trap path,
- * where the console queue has no reader.
+ * where the console queue has no reader. The whole dump is emitted under
+ * the console lock so that another core's output cannot land between
+ * its pieces -- one line of register values with another core's line
+ * spliced into the middle is exactly the report that cannot be read.
+ * Lirqsource0 is core 0's summary register; this core's own is the slot
+ * at 4*machno, and it is the one the dispatch on this core consulted.
  */
 void
 intrdump(void)
 {
-	uartputstr("intr: Lirqsource0 ");
-	uartputx(LOCAL(Lirqsource0));
+	int held;
+
+	held = uartlock();
+	uartputstr("intr: cpu");
+	uartputd(m->machno);
+	uartputstr(" Lirqsource ");
+	uartputx(LOCAL(Lirqsource0 + 4*m->machno));
 	uartputstr(" GPUpending ");
 	uartputx(INTREGS->GPUpending[0]);
 	uartputstr(" ");
@@ -305,8 +343,12 @@ intrdump(void)
 	uartputstr(" spurious ");
 	uartputd(nspurious);
 	uartputstr(" orphan ");
-	uartputd(irqorphan);
+	if(irqorphan[m->machno] < 0)
+		uartputstr("none");
+	else
+		uartputd(irqorphan[m->machno]);
 	uartputstr("\n");
+	uartunlock(held);
 }
 
 /*

--- a/os/bcm2837/io.h
+++ b/os/bcm2837/io.h
@@ -93,14 +93,35 @@ enum
 	 * line to pull. Arm it with a short timeout and let it expire.
 	 * Every write needs the password in the top half or it is
 	 * ignored silently.
+	 *
+	 * The same block is the boot watchdog (board.c): PM_WDOG is a
+	 * 20-bit down-counter at 65536Hz -- 16 seconds is the longest
+	 * timeout it can hold, which is why a 90-second boot budget is
+	 * kept by re-arming from the clock tick rather than by one write.
+	 * PM_RSTC's WRCFG field (bits 5:4) is what makes expiry reset the
+	 * chip; writing PM_RSTC's reset value 0x102 back, with the
+	 * password, clears that field and disarms it. That is the disarm
+	 * every reference driver uses -- Linux bcm2835_wdt.c and FreeBSD
+	 * bcm2835_wdog.c both write PM_PASSWORD|0x102 -- and the Broadcom
+	 * documentation of the block is not public, so the drivers ARE the
+	 * register description.
+	 *
+	 * PM_RSTS is the firmware's: reset cause and boot-partition bits.
+	 * Bit 5 (0x20) is HADWRQ, "the last reset was the watchdog", not
+	 * a tryboot request; the tryboot flag is asked for through the
+	 * mailbox (Tagsetrebootflags) and the firmware keeps it where it
+	 * likes. An earlier version of board.c set 0x20 here and called it
+	 * tryboot; see boardtryboot() for how that was found.
 	 */
 	Pmrstc		= 0x1C,
 	Pmrsts		= 0x20,
 	Pmwdog		= 0x24,
 	Pmpassword	= 0x5A000000,
 	Pmwrcfgclr	= 0xFFFFFFCF,
-	Pmwrcfgfull	= 0x00000020,	/* full reset */
-	Pmrststryboot	= 0x00000020,	/* one-shot: firmware loads tryboot.txt */
+	Pmwrcfgfull	= 0x00000020,	/* WRCFG = full reset on expiry */
+	Pmrstcreset	= 0x00000102,	/* PM_RSTC's reset value: watchdog disarmed */
+	Pmwdogmask	= 0x000FFFFF,	/* the 20-bit count */
+	Pmwdoghz	= 65536,	/* the count's rate */
 
 	TmrEnable	= 1<<7,
 	TmrIntEnable	= 1<<5,
@@ -191,6 +212,26 @@ enum
 	Taggettouchbuf	= 0x0004000F,
 	Taggetclockrate	= 0x00030002,	/* a peripheral clock's actual rate */
 	Taggetedidblock	= 0x00030020,	/* the display's own description */
+
+	/*
+	 * The kernel command line, as the firmware assembled it from
+	 * cmdline.txt plus its own additions (vc_mem.*, the MAC, ...).
+	 * QEMU answers it with -append. It is the one channel through
+	 * which config.txt -- and so a [tryboot] section or a tryboot.txt
+	 * -- can tell a kernel which boot it is.
+	 */
+	Taggetcmdline	= 0x00050001,
+
+	/*
+	 * How Linux on a Pi asks for a tryboot: SET_REBOOT_FLAGS with bit
+	 * 0, then NOTIFY_REBOOT, then the ordinary watchdog reset
+	 * (drivers/firmware/raspberrypi.c, rpi_firmware_notify_reboot).
+	 * The firmware records the flag itself; nothing in PM_RSTS is
+	 * ours to set.
+	 */
+	Tagnotifyreboot	= 0x00030048,
+	Tagsetrebootflags = 0x00038064,
+	Rebootflagtryboot = 1,
 
 	Clkemmc		= 1,		/* clock id for the SD controller */
 

--- a/os/bcm2837/mailbox.c
+++ b/os/bcm2837/mailbox.c
@@ -118,7 +118,7 @@ enum
 	/* every caller hands mboxcall the one shared buffer */
 	Mboxbufsize = 64 * sizeof(u32int),
 	Maxvalwords = 64 - 8,	/* room for the header, the tag and Tagend */
-	Cmdlinewords = 256,	/* 1KB of command line; see mboxcmdline */
+	Cmdlinewords = Mboxcmdlinemax / 4,	/* the value buffer; see mboxcmdline */
 };
 
 /*
@@ -236,18 +236,46 @@ mboxcall1(u32int chan, volatile u32int *buf, int size)
 	return buf[1] == Propok ? 0 : -1;
 }
 
+/* the buffer lock, for a caller that fills and reads mboxbuf itself */
+static void
+mboxlockbuf(void)
+{
+	if(mboxlockable)
+		lock(&mboxlock);
+}
+
+static void
+mboxunlockbuf(void)
+{
+	if(mboxlockable)
+		unlock(&mboxlock);
+}
+
 /*
  * Issue a single-tag property request.
  *
  * nreq words of request data are taken from data, and the tag's value
  * buffer is sized to the larger of the request and the expected reply so
  * that the firmware has room to answer in place.  On success the reply is
- * copied back into data.
+ * copied back into data, and the tag's own response word -- the length
+ * the firmware wrote, with Propok set if it understood the tag -- into
+ * *tagresp if that is not nil.
+ *
+ * The lock is held from the first word written to the last word read,
+ * NOT only around the mailbox exchange. mboxcall's lock covers the
+ * exchange; but mboxbuf is one buffer, and a caller that reads the
+ * reply out of it after mboxcall has returned reads whatever the next
+ * caller has by then written there. That next caller is routine: the
+ * framebuffer console makes a mailbox call on every scroll, from
+ * whichever process is printing, so a reply read after the unlock
+ * could be a scroll offset's. The first reader of the tag response
+ * word (mboxreboot) did exactly that, and the line it prints is the
+ * board evidence the README asks for, so it had to be made true.
  */
 int
-mboxprop(u32int tag, u32int *data, int nreq, int nresp)
+mboxprop1(u32int tag, u32int *data, int nreq, int nresp, u32int *tagresp)
 {
-	int i, nval;
+	int i, nval, r;
 
 	nval = nreq > nresp ? nreq : nresp;
 	/*
@@ -258,6 +286,8 @@ mboxprop(u32int tag, u32int *data, int nreq, int nresp)
 	 */
 	if(nval > Maxvalwords)
 		return -1;
+
+	mboxlockbuf();
 
 	mboxbuf[0] = (nval + 6) * 4;	/* total size in bytes */
 	mboxbuf[1] = Propreq;
@@ -272,30 +302,47 @@ mboxprop(u32int tag, u32int *data, int nreq, int nresp)
 
 	mboxbuf[5 + nval] = Tagend;
 
-	if(mboxcall(Mboxchanprop, mboxbuf, Mboxbufsize) < 0)
-		return -1;
+	r = mboxcall1(Mboxchanprop, mboxbuf, Mboxbufsize);
+	if(r == 0){
+		for(i = 0; i < nresp; i++)
+			data[i] = mboxbuf[5 + i];
+		if(tagresp != nil)
+			*tagresp = mboxbuf[4];
+	}
 
-	for(i = 0; i < nresp; i++)
-		data[i] = mboxbuf[5 + i];
+	mboxunlockbuf();
+	return r;
+}
 
-	return 0;
+int
+mboxprop(u32int tag, u32int *data, int nreq, int nresp)
+{
+	return mboxprop1(tag, data, nreq, nresp, nil);
 }
 
 /*
  * The firmware's kernel command line: cmdline.txt as named by the
  * config.txt (or tryboot.txt) that was in force, plus whatever the
  * firmware appends of its own. Copied into buf as a NUL-terminated
- * string, truncated to n-1 bytes; the return is the length the
- * firmware reported, or -1.
+ * string, truncated to n-1 bytes.
+ *
+ * The return is the length the firmware REPORTED, unclamped, or -1 if
+ * the tag went unanswered. That number is the caller's to judge: if
+ * it exceeds Mboxcmdlinemax the firmware copied nothing and buf is
+ * empty -- the protocol's response to a value buffer that is too
+ * short is to say how much it needed and write none of it -- and an
+ * empty buf then means "unread", not "no command line". An earlier
+ * version clamped the length to the buffer, so the two cases were
+ * indistinguishable to the caller and an over-long line would have
+ * booted a tryboot candidate with the watchdog unarmed, silently.
  *
  * A buffer of its own, four times mboxbuf. A real Pi's command line
  * runs to several hundred bytes -- the firmware adds vc_mem.mem_base,
- * the Ethernet MAC and the framebuffer geometry unasked -- and the
- * property protocol copies NOTHING when the value buffer is too short:
- * it reports the needed length and leaves the buffer empty, which
- * through mboxprop's 224 bytes would read as "no command line" on
- * exactly the machines that have one. QEMU answers with -append, so
- * the whole path is testable there; the length problem is not.
+ * the Ethernet MAC and the framebuffer geometry unasked -- and
+ * through mboxprop's 224 bytes it would have read as "no command
+ * line" on exactly the machines that have one. QEMU answers with
+ * -append, so the whole path is testable there; the length problem
+ * is not.
  */
 static volatile u32int cmdlinebuf[8 + Cmdlinewords] __attribute__((aligned(16)));
 
@@ -308,20 +355,21 @@ mboxcmdline(char *buf, int n)
 	cmdlinebuf[0] = (Cmdlinewords + 6) * 4;
 	cmdlinebuf[1] = Propreq;
 	cmdlinebuf[2] = Taggetcmdline;
-	cmdlinebuf[3] = Cmdlinewords * 4;
+	cmdlinebuf[3] = Mboxcmdlinemax;
 	cmdlinebuf[4] = Propreq;
 	for(i = 0; i < Cmdlinewords; i++)
 		cmdlinebuf[5 + i] = 0;
 	cmdlinebuf[5 + Cmdlinewords] = Tagend;
 
+	buf[0] = 0;
 	if(mboxcall(Mboxchanprop, cmdlinebuf, sizeof cmdlinebuf) < 0)
 		return -1;
 	if((cmdlinebuf[4] & Propok) == 0)
 		return -1;			/* the tag was not answered */
 
 	len = cmdlinebuf[4] & ~Propok;	/* the firmware's own length */
-	if(len > Cmdlinewords * 4)
-		len = Cmdlinewords * 4;	/* it copied nothing; see above */
+	if(len > Mboxcmdlinemax)
+		return len;		/* it copied nothing; buf stays empty */
 	p = (volatile uchar*)&cmdlinebuf[5];
 	for(i = 0; i < len && i < n - 1 && p[i] != 0; i++)
 		buf[i] = p[i];
@@ -351,14 +399,19 @@ mboxcmdline(char *buf, int n)
 int
 mboxreboot(int tryboot)
 {
-	u32int v[1];
+	u32int v[1], resp;
 	int r;
 
 	r = 0;
 	v[0] = 0;
 	if(tryboot){
 		v[0] = Rebootflagtryboot;
-		if(mboxprop(Tagsetrebootflags, v, 1, 1) < 0 || (mboxbuf[4] & Propok) == 0)
+		/*
+		 * mboxprop1, for the tag response word: read under the
+		 * buffer lock, so it is this tag's answer and not the
+		 * next framebuffer scroll's.
+		 */
+		if(mboxprop1(Tagsetrebootflags, v, 1, 1, &resp) < 0 || (resp & Propok) == 0)
 			r = -1;
 	}
 	if(mboxprop(Tagnotifyreboot, v, 0, 0) < 0)

--- a/os/bcm2837/mailbox.c
+++ b/os/bcm2837/mailbox.c
@@ -32,8 +32,8 @@
 #define MBOX(r)	(*(volatile u32int*)((uintptr)MBOXREGS + (r)))
 
 /*
- * Shared request buffer.  Single-threaded for now; when there is a
- * scheduler this needs a lock.
+ * Shared request buffer, one for the whole kernel, guarded by mboxmutex
+ * below -- see there for why it is the shape of lock it is.
  *
  * volatile is load-bearing, not decoration.  Until the MMU is up, ARMv8
  * treats all memory as Device-nGnRnE, which forbids unaligned access --
@@ -50,37 +50,86 @@
 static volatile u32int mboxbuf[64] __attribute__((aligned(16)));
 
 /*
- * One buffer, therefore one lock.
+ * One buffer, therefore one lock -- and it is the BUFFER that is
+ * protected, not just the exchange with the firmware.
  *
- * Every caller hands mboxcall the same mboxbuf, so two callers at once
- * interleave their requests into it and both get an answer to a
- * question neither asked. That is not hypothetical: the framebuffer
- * console sets a GPU offset through this on EVERY scroll, from whatever
- * process happened to be printing, so any two processes printing at
- * once already race here -- and it becomes routine the moment more than
- * one core is running.
+ * Every caller fills mboxbuf, posts it, and reads the reply back out of
+ * it. Two callers at once interleave their requests into it and both
+ * get an answer to a question neither asked. That is routine now, not
+ * hypothetical: the framebuffer console moves the scanout window
+ * through here on every scroll, from whatever process is printing on
+ * whatever core, while draw and the pointer run on the others. So the
+ * lock is held from the first word written to the last word read; an
+ * earlier version took it around the post-and-wait alone and left
+ * mboxfballoc reading its tags, and setpower its response word, out of
+ * a buffer the next caller was free to overwrite.
  *
- * A plain Lock, deliberately, not a QLock and not an ilock:
+ * Not lock() and not ilock(), but the bounded _tas mutex fbcons and the
+ * uart use, held with interrupts off. The reasons, in order:
  *
- *   - it is taken before the scheduler exists (board revision and
- *     memory size are read from kmain), which rules out sleeping locks;
- *   - a mailbox call can spin for a long time if the firmware never
- *     answers, and an ilock would hold interrupts off for all of it,
- *     turning a stalled firmware into a dead machine;
- *   - nothing takes it from interrupt context, so there is no handler
- *     to deadlock against. That last point rests on iprint reaching the
- *     screen only when iprintscreenputs is set, and it is not set. If
- *     that ever changes, this becomes an ilock and Mboxspin has to come
- *     down with it.
+ *   - the print path reaches here from INTERRUPT AND PANIC CONTEXT.
+ *     panic() is putstrn(), which is screenputs(), which scrolls the
+ *     console, which is a mailbox call; a trap handler that print()s
+ *     does the same. lock() spinning at splhi on a mutex whose holder
+ *     is the process this very core interrupted can never see it
+ *     released, and ends in lockloop(), which panics, which prints,
+ *     which takes the lock: the message that mattered is lost in the
+ *     recursion. The old comment here rested on iprint never reaching
+ *     the screen, and overlooked that panic does not use iprint.
+ *   - holding it with interrupts OFF is what rules the same-core case
+ *     out: a holder cannot be interrupted, so no interrupt-time print
+ *     on its core can arrive while it holds. What remains is another
+ *     core, which releases within one call's time, or a holder that
+ *     took an exception inside the call -- and that is the panic path.
+ *   - so the wait is bounded, and a waiter that times out proceeds
+ *     anyway, unlocked, and says so on the uart. The only way to reach
+ *     that is a holder that will never release (a dead core, an
+ *     exception mid-call, a firmware that stopped answering), and for a
+ *     panic message garbled beats silent. A waiter that arrives with
+ *     interrupts on spins with them on, so waiting costs nothing but
+ *     this core's time.
+ *
+ * Interrupts off while HELD means a call the firmware never answers
+ * keeps them off for the Mboxspin bound, on one core, once. The
+ * previous version avoided that in exchange for the recursion above;
+ * the trade is deliberate. A stalled mailbox is the display, the USB
+ * power domain and the memory map, and everything else happening on
+ * the machine then is the failure being reported.
+ *
+ * A per-caller buffer was the other way out and was rejected: the
+ * mailbox FIFO matches replies to channels, not to buffers, so two
+ * requests in flight on the property channel hand each other their
+ * answers whatever memory they came from. Separate buffers would move
+ * the corruption from the message to the reply, not remove it.
  */
-static Lock mboxlock;
+static ulong mboxmutex;
 static int mboxlockable;
+
+typedef struct Mboxhold Mboxhold;
+struct Mboxhold
+{
+	int	spl;		/* interrupt state to put back */
+	int	held;		/* the mutex is ours to release */
+};
+
+enum
+{
+	/*
+	 * In 10us steps: two seconds. An answered mailbox call takes
+	 * microseconds to tens of milliseconds, so a holder still there
+	 * after this is not coming back, and the waiter is better off
+	 * corrupting one exchange than waiting for ever with interrupts
+	 * off. Sized against the fbcons scroll-fold, the longest legitimate
+	 * hold on the console path, with a wide margin.
+	 */
+	Mboxlockwait = 200*1000,
+};
 
 /*
  * Start locking. Called once the MMU is on.
  *
  * NOT an optimisation -- taking the lock before this point FAULTS. A
- * Lock is acquired with load-exclusive/store-exclusive, and exclusive
+ * mutex is acquired with load-exclusive/store-exclusive, and exclusive
  * accesses are only architecturally supported on Normal memory with the
  * MMU enabled; with it off the core takes a data abort (ESR ...0x35,
  * the unsupported-exclusive fault) on the first one. The very first
@@ -98,6 +147,46 @@ void
 mboxlockon(void)
 {
 	mboxlockable = 1;
+}
+
+static void
+mboxacquire(Mboxhold *h)
+{
+	int i;
+
+	h->held = 0;
+	h->spl = 0;
+	if(!mboxlockable)
+		return;
+	for(i = 0; i < Mboxlockwait; i++){
+		h->spl = splhi();
+		if(_tas(&mboxmutex) == 0){
+			h->held = 1;
+			return;
+		}
+		splx(h->spl);
+		microdelay(10);
+	}
+	/*
+	 * The holder is not coming back. Go in anyway, with interrupts
+	 * off like a holder would have them, and leave the mutex to whoever
+	 * does own it: clearing it here would let a THIRD caller in on top
+	 * of both of us.
+	 */
+	uartputstr("mbox: lock held too long; proceeding unlocked\n");
+	h->spl = splhi();
+}
+
+static void
+mboxrelease(Mboxhold *h)
+{
+	if(!mboxlockable)
+		return;
+	if(h->held){
+		coherence();
+		mboxmutex = 0;
+	}
+	splx(h->spl);
 }
 
 static void
@@ -123,25 +212,12 @@ enum
 /*
  * Post the buffer to a channel and wait for the reply.  Returns 0 on
  * success, -1 if the firmware rejected the request.
+ *
+ * The caller holds the mutex (mboxacquire) for the whole of fill, post
+ * and copy-out; this does the middle third.
  */
-static int mboxcall1(u32int, volatile u32int*);
-
 static int
 mboxcall(u32int chan, volatile u32int *buf)
-{
-	int r;
-
-	if(!mboxlockable)
-		return mboxcall1(chan, buf);
-
-	lock(&mboxlock);
-	r = mboxcall1(chan, buf);
-	unlock(&mboxlock);
-	return r;
-}
-
-static int
-mboxcall1(u32int chan, volatile u32int *buf)
 {
 	u32int v, want;
 	long i;
@@ -237,11 +313,17 @@ mboxcall1(u32int chan, volatile u32int *buf)
  * buffer is sized to the larger of the request and the expected reply so
  * that the firmware has room to answer in place.  On success the reply is
  * copied back into data.
+ *
+ * resp, if not nil, receives the firmware's per-tag response word --
+ * read here, under the lock, because the only other place to read it
+ * from is the shared buffer after the lock has gone, which is what
+ * setpower used to do.
  */
-int
-mboxprop(u32int tag, u32int *data, int nreq, int nresp)
+static int
+mboxprop1(u32int tag, u32int *data, int nreq, int nresp, u32int *resp)
 {
-	int i, nval;
+	Mboxhold h;
+	int i, nval, r;
 
 	nval = nreq > nresp ? nreq : nresp;
 	/*
@@ -253,6 +335,7 @@ mboxprop(u32int tag, u32int *data, int nreq, int nresp)
 	if(nval > Maxvalwords)
 		return -1;
 
+	mboxacquire(&h);
 	mboxbuf[0] = (nval + 6) * 4;	/* total size in bytes */
 	mboxbuf[1] = Propreq;
 	mboxbuf[2] = tag;
@@ -266,13 +349,21 @@ mboxprop(u32int tag, u32int *data, int nreq, int nresp)
 
 	mboxbuf[5 + nval] = Tagend;
 
-	if(mboxcall(Mboxchanprop, mboxbuf) < 0)
-		return -1;
+	r = mboxcall(Mboxchanprop, mboxbuf);
+	if(r == 0)
+		for(i = 0; i < nresp; i++)
+			data[i] = mboxbuf[5 + i];
+	if(resp != nil)
+		*resp = mboxbuf[4];
+	mboxrelease(&h);
 
-	for(i = 0; i < nresp; i++)
-		data[i] = mboxbuf[5 + i];
+	return r;
+}
 
-	return 0;
+int
+mboxprop(u32int tag, u32int *data, int nreq, int nresp)
+{
+	return mboxprop1(tag, data, nreq, nresp, nil);
 }
 
 /*
@@ -285,7 +376,14 @@ int
 mboxfballoc(u32int disp, u32int w, u32int h, u32int depth, Fbinfo *fb)
 {
 	volatile u32int *p, *tagalloc, *tagpitch, *tagdisp;
+	Mboxhold hold;
 
+	/*
+	 * Held until the tags have been read back: they are read out of
+	 * the shared buffer, and a console scroll on another core between
+	 * the call returning and the reads would replace them.
+	 */
+	mboxacquire(&hold);
 	p = mboxbuf;
 	*p++ = 0;			/* size, patched below */
 	*p++ = Propreq;
@@ -347,13 +445,16 @@ mboxfballoc(u32int disp, u32int w, u32int h, u32int depth, Fbinfo *fb)
 
 	mboxbuf[0] = (u32int)((p - mboxbuf) * 4);
 
-	if(mboxcall(Mboxchanprop, mboxbuf) < 0)
+	if(mboxcall(Mboxchanprop, mboxbuf) < 0){
+		mboxrelease(&hold);
 		return -1;
+	}
 
 	fb->disp = tagdisp[3];
 	fb->base = tagalloc[3] & 0x3FFFFFFF;	/* bus -> ARM physical */
 	fb->size = tagalloc[4];
 	fb->pitch = tagpitch[3];
+	mboxrelease(&hold);
 	fb->width = w;
 	fb->height = h;
 	fb->depth = depth;
@@ -385,7 +486,7 @@ enum
 int
 setpower(int dev, int on)
 {
-	u32int buf[2];
+	u32int buf[2], resp;
 
 	buf[0] = dev;
 	buf[1] = Powerwait | (on ? 1 : 0);
@@ -410,7 +511,8 @@ setpower(int dev, int on)
 	 *
 	 * The result was also discarded, so none of this was visible.
 	 */
-	if(mboxprop(TagSetpower, buf, 2, 2) < 0){
+	resp = 0;
+	if(mboxprop1(TagSetpower, buf, 2, 2, &resp) < 0){
 		print("setpower: dev %d: property call failed\n", dev);
 		return -1;
 	}
@@ -421,12 +523,12 @@ setpower(int dev, int on)
 	 * Bit 1 is Powerwait on the way in and "device does not exist" on
 	 * the way back -- the same bit meaning two different things -- so
 	 * a verdict derived from it is worth exactly as much as the
-	 * assumption behind it. mboxbuf[4] carries the firmware's
-	 * per-tag response word, which says whether the tag was
-	 * processed at all.
+	 * assumption behind it. resp is the firmware's per-tag response
+	 * word, which says whether the tag was processed at all -- taken
+	 * from the shared buffer while it was still ours, not after.
 	 */
 	print("setpower: dev %d -> resp %8.8ux, dev %ud, state %8.8ux%s%s\n",
-		dev, mboxbuf[4], buf[0], buf[1],
+		dev, resp, buf[0], buf[1],
 		buf[1] & 1 ? " ON" : " OFF",
 		buf[1] & Powernodevice ? " NODEVICE" : "");
 

--- a/os/bcm2837/mailbox.c
+++ b/os/bcm2837/mailbox.c
@@ -118,30 +118,36 @@ enum
 	/* every caller hands mboxcall the one shared buffer */
 	Mboxbufsize = 64 * sizeof(u32int),
 	Maxvalwords = 64 - 8,	/* room for the header, the tag and Tagend */
+	Cmdlinewords = 256,	/* 1KB of command line; see mboxcmdline */
 };
 
 /*
  * Post the buffer to a channel and wait for the reply.  Returns 0 on
  * success, -1 if the firmware rejected the request.
  */
-static int mboxcall1(u32int, volatile u32int*);
+static int mboxcall1(u32int, volatile u32int*, int);
 
+/*
+ * size is the buffer's length in bytes: the cache maintenance below
+ * has to cover the whole of what the firmware will read and write, and
+ * the command line needs a buffer four times the size of mboxbuf.
+ */
 static int
-mboxcall(u32int chan, volatile u32int *buf)
+mboxcall(u32int chan, volatile u32int *buf, int size)
 {
 	int r;
 
 	if(!mboxlockable)
-		return mboxcall1(chan, buf);
+		return mboxcall1(chan, buf, size);
 
 	lock(&mboxlock);
-	r = mboxcall1(chan, buf);
+	r = mboxcall1(chan, buf, size);
 	unlock(&mboxlock);
 	return r;
 }
 
 static int
-mboxcall1(u32int chan, volatile u32int *buf)
+mboxcall1(u32int chan, volatile u32int *buf, int size)
 {
 	u32int v, want;
 	long i;
@@ -168,7 +174,7 @@ mboxcall1(u32int chan, volatile u32int *buf)
 	 * may rely on -- and would show up as calls that succeed early in
 	 * boot and fail later, once more code has been through the cache.
 	 */
-	cachedwbse((void*)buf, Mboxbufsize);
+	cachedwbse((void*)buf, size);
 	dsb();
 
 	/*
@@ -225,7 +231,7 @@ mboxcall1(u32int chan, volatile u32int *buf)
 	 * That ordering is load-bearing -- doing this without the clean
 	 * above would risk exactly the corruption it is meant to prevent.
 	 */
-	cachedwbinvse((void*)buf, Mboxbufsize);
+	cachedwbinvse((void*)buf, size);
 
 	return buf[1] == Propok ? 0 : -1;
 }
@@ -266,13 +272,98 @@ mboxprop(u32int tag, u32int *data, int nreq, int nresp)
 
 	mboxbuf[5 + nval] = Tagend;
 
-	if(mboxcall(Mboxchanprop, mboxbuf) < 0)
+	if(mboxcall(Mboxchanprop, mboxbuf, Mboxbufsize) < 0)
 		return -1;
 
 	for(i = 0; i < nresp; i++)
 		data[i] = mboxbuf[5 + i];
 
 	return 0;
+}
+
+/*
+ * The firmware's kernel command line: cmdline.txt as named by the
+ * config.txt (or tryboot.txt) that was in force, plus whatever the
+ * firmware appends of its own. Copied into buf as a NUL-terminated
+ * string, truncated to n-1 bytes; the return is the length the
+ * firmware reported, or -1.
+ *
+ * A buffer of its own, four times mboxbuf. A real Pi's command line
+ * runs to several hundred bytes -- the firmware adds vc_mem.mem_base,
+ * the Ethernet MAC and the framebuffer geometry unasked -- and the
+ * property protocol copies NOTHING when the value buffer is too short:
+ * it reports the needed length and leaves the buffer empty, which
+ * through mboxprop's 224 bytes would read as "no command line" on
+ * exactly the machines that have one. QEMU answers with -append, so
+ * the whole path is testable there; the length problem is not.
+ */
+static volatile u32int cmdlinebuf[8 + Cmdlinewords] __attribute__((aligned(16)));
+
+int
+mboxcmdline(char *buf, int n)
+{
+	int i, len;
+	volatile uchar *p;
+
+	cmdlinebuf[0] = (Cmdlinewords + 6) * 4;
+	cmdlinebuf[1] = Propreq;
+	cmdlinebuf[2] = Taggetcmdline;
+	cmdlinebuf[3] = Cmdlinewords * 4;
+	cmdlinebuf[4] = Propreq;
+	for(i = 0; i < Cmdlinewords; i++)
+		cmdlinebuf[5 + i] = 0;
+	cmdlinebuf[5 + Cmdlinewords] = Tagend;
+
+	if(mboxcall(Mboxchanprop, cmdlinebuf, sizeof cmdlinebuf) < 0)
+		return -1;
+	if((cmdlinebuf[4] & Propok) == 0)
+		return -1;			/* the tag was not answered */
+
+	len = cmdlinebuf[4] & ~Propok;	/* the firmware's own length */
+	if(len > Cmdlinewords * 4)
+		len = Cmdlinewords * 4;	/* it copied nothing; see above */
+	p = (volatile uchar*)&cmdlinebuf[5];
+	for(i = 0; i < len && i < n - 1 && p[i] != 0; i++)
+		buf[i] = p[i];
+	buf[i] = 0;
+	return len;
+}
+
+/*
+ * Tell the firmware what the coming reset is for.
+ *
+ * With tryboot set, the boot after the reset -- and only that one --
+ * takes its configuration from tryboot.txt, or from the [tryboot]
+ * section of config.txt. The flag is the firmware's to keep: it is
+ * asked for here, through the same tag Linux's reboot notifier uses,
+ * and the kernel never learns where it is stored. NOTIFY_REBOOT is
+ * what Linux sends next, always, flag or no flag.
+ *
+ * The check is on the TAG's response bit, not only the message's:
+ * the message succeeds whenever the firmware parsed it, and what this
+ * caller needs to know is whether this particular tag was understood.
+ * QEMU's property model sets the bit for every tag it is handed,
+ * known or not, so under emulation the answer is always yes and proves
+ * only that the message was well formed. The board is where the
+ * answer means something, and the line printed from it is the
+ * evidence the README asks for.
+ */
+int
+mboxreboot(int tryboot)
+{
+	u32int v[1];
+	int r;
+
+	r = 0;
+	v[0] = 0;
+	if(tryboot){
+		v[0] = Rebootflagtryboot;
+		if(mboxprop(Tagsetrebootflags, v, 1, 1) < 0 || (mboxbuf[4] & Propok) == 0)
+			r = -1;
+	}
+	if(mboxprop(Tagnotifyreboot, v, 0, 0) < 0)
+		r = -1;
+	return r;
 }
 
 /*
@@ -347,7 +438,7 @@ mboxfballoc(u32int disp, u32int w, u32int h, u32int depth, Fbinfo *fb)
 
 	mboxbuf[0] = (u32int)((p - mboxbuf) * 4);
 
-	if(mboxcall(Mboxchanprop, mboxbuf) < 0)
+	if(mboxcall(Mboxchanprop, mboxbuf, Mboxbufsize) < 0)
 		return -1;
 
 	fb->disp = tagdisp[3];

--- a/os/bcm2837/uart.c
+++ b/os/bcm2837/uart.c
@@ -160,13 +160,13 @@ uartgetc(void)
  * came out as "cpuccp1: uppuu2", which is comedy until a panic
  * message does it, and the first SMP panic did exactly that -- the
  * one line that would have named the bug was shredded across three
- * cores' output. A plain spin Lock is enough: emission is short,
- * bounded, and already runs at splhi from the callers that matter.
- * _tas directly rather than lock() so a panic INSIDE the lock
+ * cores' output. A plain spin lock is enough: emission is short and
+ * bounded. _tas directly rather than lock() so a panic INSIDE the lock
  * machinery can still print: after a bounded spin, print anyway --
  * garbled beats silent.
  *
- * uartowner is the core holding uartmutex, or -1. It does two jobs.
+ * uartowner is the core holding uartmutex, or -1, and the lock is
+ * held at splhi. Together they do three jobs.
  *
  * First, a writer that gave up waiting must not release the lock on
  * its way out. The first version did: "spin, print, store 0" with no
@@ -175,17 +175,37 @@ uartgetc(void)
  * and a third core walked straight in. Only the acquirer stores the 0.
  *
  * Second, the same core re-enters this file while holding the lock:
- * uartputs() is writing a console line at spllo, an interrupt arrives
- * on that core, and the handler prints. Before, that inner print spun
- * out the whole bound -- a million exclusive loads at splhi -- and
- * then printed anyway. Now it recognises its own core as the holder
- * and writes through at once, leaving the release to the outer call.
- * The inner text lands inside the outer line, which is the same result
- * as before minus the stall; the alternative, a queue, is what print()
- * already is, and this is the path for when print() cannot be trusted.
+ * dumpureg holds it across a whole report and calls uartputstr for
+ * each line, and a fault taken INSIDE an emission -- the panic path --
+ * prints from the same core again. Before, that inner print spun out
+ * the whole bound -- a million exclusive loads at splhi -- and then
+ * printed anyway. Now it recognises its own core as the holder and
+ * writes through at once, leaving the release to the outer call.
+ *
+ * Third, and this is why splhi: the owner is named by CORE, but the
+ * holder that matters is a PROCESS. uartputs() is the console write,
+ * called from putstrn0 in process context at spllo, and hzclock now
+ * preempts on every core. Held at spllo, a process could be
+ * descheduled mid-line with the lock, be picked up by any idle core
+ * (runproc's second pass ignores affinity) and resume writing there;
+ * back on the core it left, uartowner still named that core, so the
+ * next print there took the "my own core holds it" exit and wrote
+ * straight through -- two cores emitting at once, which is the one
+ * thing the lock exists to prevent -- while an interrupt-time print on
+ * the new core saw a foreign owner and spun the whole bound. Raising
+ * splhi before the spin and holding it until the release means the
+ * holder cannot be preempted, so it cannot migrate, so the core IS the
+ * holder for as long as the lock is held; the same discipline as
+ * ilock. The cost is interrupts masked on one core for one emission:
+ * conswrite chunks at 256 bytes, about 22ms at 115200 baud on the
+ * board, and a pending tick is delayed, not lost. The nested case
+ * above is unchanged by it -- with interrupts masked, the only way
+ * back into this file on the holding core is a synchronous exception
+ * or a direct call, and both are the same core.
  */
 static ulong uartmutex;
 static int uartowner = -1;
+static int uartspl;		/* the acquirer's level, for uartunlock */
 
 /*
  * ...and NOT ONE writer before the MMU is on. _tas is a load/store
@@ -219,28 +239,48 @@ uartlockon(void)
 int
 uartlock(void)
 {
-	int i;
+	int i, s;
 
 	if(!uartlocking)
 		return 0;
-	if(uartowner == m->machno)
+	/*
+	 * splhi before the test-and-set, not after: a tick between a
+	 * successful _tas and a later splhi would leave a Ready process
+	 * holding the console lock with interrupts on -- the migration
+	 * case described above, in a narrower window.
+	 */
+	s = splhi();
+	if(uartowner == m->machno){
+		splx(s);
 		return 0;
+	}
 	for(i = 0; i < 1000000; i++)
 		if(_tas(&uartmutex) == 0){
 			uartowner = m->machno;
+			uartspl = s;
 			return 1;
 		}
+	/*
+	 * Gave up: the text goes out over the holder's, at the caller's
+	 * level. Nothing was taken, so nothing is held and nothing is
+	 * restored later; put the level back here.
+	 */
+	splx(s);
 	return 0;
 }
 
 void
 uartunlock(int held)
 {
+	int s;
+
 	if(!held)
 		return;
+	s = uartspl;
 	uartowner = -1;
 	coherence();
 	uartmutex = 0;
+	splx(s);
 }
 
 void

--- a/os/bcm2837/uart.c
+++ b/os/bcm2837/uart.c
@@ -165,8 +165,27 @@ uartgetc(void)
  * _tas directly rather than lock() so a panic INSIDE the lock
  * machinery can still print: after a bounded spin, print anyway --
  * garbled beats silent.
+ *
+ * uartowner is the core holding uartmutex, or -1. It does two jobs.
+ *
+ * First, a writer that gave up waiting must not release the lock on
+ * its way out. The first version did: "spin, print, store 0" with no
+ * memory of whether the spin had succeeded, so a core that had timed
+ * out and printed over the holder then also FREED THE HOLDER'S LOCK,
+ * and a third core walked straight in. Only the acquirer stores the 0.
+ *
+ * Second, the same core re-enters this file while holding the lock:
+ * uartputs() is writing a console line at spllo, an interrupt arrives
+ * on that core, and the handler prints. Before, that inner print spun
+ * out the whole bound -- a million exclusive loads at splhi -- and
+ * then printed anyway. Now it recognises its own core as the holder
+ * and writes through at once, leaving the release to the outer call.
+ * The inner text lands inside the outer line, which is the same result
+ * as before minus the stall; the alternative, a queue, is what print()
+ * already is, and this is the path for when print() cannot be trusted.
  */
 static ulong uartmutex;
+static int uartowner = -1;
 
 /*
  * ...and NOT ONE writer before the MMU is on. _tas is a load/store
@@ -185,58 +204,103 @@ uartlockon(void)
 	uartlocking = 1;
 }
 
-void
-uartputstr(char *s)
+/*
+ * Take the console for one emission. Returns whether THIS call took the
+ * lock, and that value -- not a guess -- is what uartunlock() wants
+ * back: 0 means locking is off, or this core already holds it from an
+ * outer call, or the bounded spin gave up and the text is going out
+ * over somebody else's. In none of those cases is the lock ours to free.
+ *
+ * Exported so a multi-line report (dumpureg, intrdump) can hold the
+ * console across all of its lines rather than only within each one;
+ * the nested-owner rule above is what makes that safe for the
+ * uartputstr() calls inside it.
+ */
+int
+uartlock(void)
 {
 	int i;
 
-	if(uartlocking)
-		for(i = 0; i < 1000000; i++)
-			if(_tas(&uartmutex) == 0)
-				break;
+	if(!uartlocking)
+		return 0;
+	if(uartowner == m->machno)
+		return 0;
+	for(i = 0; i < 1000000; i++)
+		if(_tas(&uartmutex) == 0){
+			uartowner = m->machno;
+			return 1;
+		}
+	return 0;
+}
+
+void
+uartunlock(int held)
+{
+	if(!held)
+		return;
+	uartowner = -1;
+	coherence();
+	uartmutex = 0;
+}
+
+void
+uartputstr(char *s)
+{
+	int held;
+
+	held = uartlock();
 	while(*s){
 		if(*s == '\n')
 			uartputc('\r');
 		uartputc(*s++);
 	}
-	if(uartlocking){
-		coherence();
-		uartmutex = 0;
-	}
+	uartunlock(held);
 }
 
+/*
+ * The numbers are emitted under the lock too, as one piece. They used
+ * to go out by bare uartputc() after a locked "0x", so a register dump
+ * from one core could carry another core's digits in the middle of a
+ * value -- and a value with foreign digits in it is not a wrong value
+ * that can be spotted, it is a plausible one.
+ */
 void
 uartputx(u64int v)
 {
 	char buf[16];
-	int i;
+	int i, held;
 
 	for(i = 15; i >= 0; i--){
 		buf[i] = "0123456789abcdef"[v & 0xF];
 		v >>= 4;
 	}
-	uartputstr("0x");
+	held = uartlock();
+	uartputc('0');
+	uartputc('x');
 	for(i = 0; i < 16; i++)
 		uartputc(buf[i]);
+	uartunlock(held);
 }
 
 void
 uartputd(u64int v)
 {
 	char buf[20];
-	int i;
+	int i, held;
 
-	if(v == 0){
+	held = uartlock();
+	if(v == 0)
 		uartputc('0');
-		return;
+	else{
+		i = 0;
+		while(v > 0 && i < (int)sizeof(buf)){
+			buf[i++] = '0' + (int)(v % 10);
+			v /= 10;
+		}
+		while(--i >= 0)
+			uartputc(buf[i]);
 	}
-	i = 0;
-	while(v > 0 && i < (int)sizeof(buf)){
-		buf[i++] = '0' + (int)(v % 10);
-		v /= 10;
-	}
-	while(--i >= 0)
-		uartputc(buf[i]);
+	uartunlock(held);
 }
 
 /*
@@ -253,19 +317,13 @@ uartputd(u64int v)
 void
 uartputs(char *s, int n)
 {
-	int i;
+	int i, held;
 
-	if(uartlocking)
-		for(i = 0; i < 1000000; i++)
-			if(_tas(&uartmutex) == 0)
-				break;
+	held = uartlock();
 	for(i = 0; i < n; i++){
 		if(s[i] == '\n')
 			uartputc('\r');
 		uartputc(s[i]);
 	}
-	if(uartlocking){
-		coherence();
-		uartmutex = 0;
-	}
+	uartunlock(held);
 }

--- a/os/init/etherusb.b
+++ b/os/init/etherusb.b
@@ -701,25 +701,23 @@ init(nil: ref Draw->Context, argv: list of string)
 	if(probe != nil){
 		probe = nil;
 		#
-		# Close the endpoints DETERMINISTICALLY, by dup'ing the
-		# null device over their descriptor numbers. Dropping the
-		# last Limbo reference ought to do it -- freeFD closes the
-		# number when the FD object is destroyed -- but measured
-		# on this kernel the destructor does not run at the
-		# assignment: the endpoint stayed inuse until process
-		# exit, and the kernel's open of it got "already in use"
-		# no matter how long the handoff waited. dup replaces the
-		# chan under the number inline, in the kernel, with no
-		# destructor in the loop. (Why =nil is not prompt here is
-		# a separate hunt -- if it is real it leaks every dropped
-		# fd on the system until its process exits.)
+		# Close the endpoints by dropping our last references to
+		# them. The endpoints are exclusive-open, so this MUST
+		# close them before the ctl write below asks the kernel
+		# to open them, and it does: freeFD runs when the FD's
+		# last reference goes, synchronously, in this assignment.
 		#
-		nullfd := sys->open("#c/null", Sys->ORDWR);
-		if(nullfd != nil){
-			sys->dup(nullfd.fd, bulkfd.fd);
-			if(bulkoutfd.fd != bulkfd.fd)
-				sys->dup(nullfd.fd, bulkoutfd.fd);
-		}
+		# It did not always. This used to sys->dup #c/null over
+		# the descriptor numbers first, because on this kernel the
+		# endpoints stayed inuse after the assignment and the
+		# kernel's open got "already in use". That was the JIT:
+		# comp-arm64.c's macfrp() branched on stale flags and never
+		# reached rdestroy, so compiled code never ran ANY
+		# destructor -- every dropped fd waited for the collector.
+		# Fixed in macfrp; tests/fdclose_test.b and osinit's fd
+		# self-check pin it. If this handoff ever reports "already
+		# in use" again, suspect that macro before anything here.
+		#
 		bulkfd = nil;
 		bulkoutfd = nil;
 		burst := 3116;			# two RNDIS messages' worth

--- a/os/init/etherusb.b
+++ b/os/init/etherusb.b
@@ -1317,7 +1317,9 @@ dhcp(): (string, string, string)
 	}
 
 	rc := chan of array of byte;
-	spawn dhcpreader(d, rc);
+	pidc := chan of int;
+	spawn dhcpreader(d, rc, pidc);
+	rpid := <-pidc;
 
 	#
 	# Give the switch time to start forwarding.
@@ -1394,9 +1396,11 @@ dhcp(): (string, string, string)
 			ntp = gw;
 		sys->print("etherusb: DHCP gave %s mask %s\n", addr, mask);
 		ntpserver = ntp;
+		dhcpdone(rpid);
 		return (addr, mask, gw);
 	}
 	sys->print("etherusb: no DHCP reply after 14 tries over ~45 seconds\n");
+	dhcpdone(rpid);
 	return (nil, nil, nil);
 }
 
@@ -1432,8 +1436,18 @@ dhcpxchg(d: ref Sys->FD, pkt: array of byte, xid, kind: int,
 # with no DHCP server can never be reached. The boot hangs on the one
 # case the fallback was written for.
 #
-dhcpreader(d: ref Sys->FD, c: chan of array of byte)
+#
+# It lives exactly as long as the exchange. The reader has no way to
+# know when the caller has its answer -- it is parked in a read the
+# kernel will not return from until a datagram arrives -- so the caller
+# is told the reader's pid and kills it when done (dhcpdone). Left
+# alone, every one of these used to sit on port 68 for the life of the
+# machine, holding the conversation open, and each later broadcast on
+# the port woke it to block for ever on a channel nobody reads.
+#
+dhcpreader(d: ref Sys->FD, c: chan of array of byte, pidc: chan of int)
 {
+	pidc <-= sys->pctl(0, nil);
 	for(;;){
 		buf := array[Udphdr7 + 576] of byte;
 		n := sys->read(d, buf, len buf);
@@ -1447,6 +1461,47 @@ dhcptimer(c: chan of int, ms: int)
 {
 	sys->sleep(ms);
 	c <-= 1;
+}
+
+#
+# Kill a reader parked in sys->read. A kill through /prog reaches a
+# process blocked inside the kernel: killprog finds it in Prelease and
+# swiproc wakes its sleep with "interrupted", so the read returns an
+# error and the process is gone by its next instruction. That is what
+# makes "kill it" honest here -- a reader that could not be woken would
+# be marked dead and still hold the conversation.
+#
+# Silent when /prog has nothing by that pid: a reader that got its
+# datagram has already exited on its own.
+#
+killreader(pid: int, what: string)
+{
+	c := sys->open("/prog/" + string pid + "/ctl", Sys->OWRITE);
+	if(c == nil)
+		return;
+	if(sys->fprint(c, "kill") < 0)
+		sys->print("etherusb: cannot kill %s reader %d: %r\n", what, pid);
+}
+
+#
+# The DHCP exchange is over, one way or the other: reap the reader and
+# say whether it went. The print is what the boot log -- and the test
+# harness reading it -- gets to see; without it a reader that quietly
+# outlived its purpose would look exactly like one that did not.
+# Bounded, because a check that can hang is worse than no check.
+#
+dhcpdone(pid: int)
+{
+	killreader(pid, "dhcp");
+	for(i := 0; i < 50; i++){
+		(ok, nil) := sys->stat("/prog/" + string pid);
+		if(ok < 0){
+			sys->print("etherusb: dhcp reader %d exited\n", pid);
+			return;
+		}
+		sys->sleep(10);
+	}
+	sys->print("etherusb: dhcp reader %d still running\n", pid);
 }
 
 #
@@ -1542,7 +1597,9 @@ pingout(dest: string)
 	# looks like from outside.
 	#
 	rc := chan of array of byte;
-	spawn pingreader(d, rc);
+	pidc := chan of int;
+	spawn pingreader(d, rc, pidc);
+	rpid := <-pidc;
 	tc := chan of int;
 	spawn dhcptimer(tc, 3000);
 
@@ -1552,11 +1609,19 @@ pingout(dest: string)
 			dest, len rep, int rep[20]);
 	<-tc =>
 		sys->print("etherusb: no echo reply from %s\n", dest);
+		#
+		# No reply means the reader is still in its read, and
+		# would be for ever: the conversation it holds open is
+		# not closed until it is gone. A reply means it has
+		# already exited on its own, so only this arm needs it.
+		#
+		killreader(rpid, "icmp");
 	}
 }
 
-pingreader(d: ref Sys->FD, c: chan of array of byte)
+pingreader(d: ref Sys->FD, c: chan of array of byte, pidc: chan of int)
 {
+	pidc <-= sys->pctl(0, nil);
 	rep := array[128] of byte;
 	n := sys->read(d, rep, len rep);
 	if(n > 0)
@@ -3629,7 +3694,9 @@ trytime(server: string): int
 	# sys->read on a socket blocks.
 	#
 	rc := chan of array of byte;
-	spawn ntpreader(d, rc);
+	pidc := chan of int;
+	spawn ntpreader(d, rc, pidc);
+	rpid := <-pidc;
 	tc := chan of int;
 	spawn ntptimer(tc, 3000);
 	rep: array of byte;
@@ -3637,6 +3704,9 @@ trytime(server: string): int
 	rep = <-rc =>
 		;
 	<-tc =>
+		# As for the echo reader: a timeout leaves it parked, and
+		# it holds the conversation until killed.
+		killreader(rpid, "ntp");
 		return -1;
 	}
 	if(rep == nil || len rep < 48)
@@ -3673,8 +3743,9 @@ trytime(server: string): int
 	return 0;
 }
 
-ntpreader(d: ref Sys->FD, rc: chan of array of byte)
+ntpreader(d: ref Sys->FD, rc: chan of array of byte, pidc: chan of int)
 {
+	pidc <-= sys->pctl(0, nil);
 	buf := array[128] of byte;
 	n := sys->read(d, buf, len buf);
 	if(n <= 0)

--- a/os/init/osinit.b
+++ b/os/init/osinit.b
@@ -92,6 +92,7 @@ init()
 	sys->print("init: allocated %d bytes through the Dis heap\n", total);
 	kernelimage();
 	gpiocheck();
+	bootargs();
 
 	#
 	# A fixed arithmetic loop, timed. Reported so the harness can run
@@ -305,6 +306,20 @@ init()
 		sys->print("init: cannot load %s: %r\n", Command->PATH);
 		return;
 	}
+
+	#
+	# The boot is over: tell the kernel, which releases the boot
+	# watchdog a tryboot candidate armed in kmain.
+	#
+	# Here, and not earlier, because "booted" means "a shell can be
+	# typed at": the module is loaded and the next statement runs it.
+	# Not later, because sh->init does not return while the shell
+	# runs. The USB walk and the network are still in flight in their
+	# own threads and are deliberately NOT waited for -- a keyboard
+	# behind a slow hub or a DHCP server that never answers must not
+	# be what resets a working candidate back to the old kernel.
+	#
+	booted();
 
 	#
 	# -l, so the shell reads /lib/sh/profile.
@@ -2262,6 +2277,61 @@ devnum(name: string): int
 			break;
 	}
 	return n;
+}
+
+#
+# Declare the boot finished. The kernel side is devcons's "booted"
+# sysctl word; what it does to the hardware is in os/bcm2837/board.c.
+# The kernel prints its own line either way, which is what the harness
+# checks; this one only reports a write that did not get there.
+#
+booted()
+{
+	fd := sys->open("/dev/sysctl", Sys->OWRITE);
+	if(fd == nil || sys->fprint(fd, "booted") < 0)
+		sys->print("init: cannot write booted to /dev/sysctl: %r\n");
+}
+
+#
+# The command line the firmware handed this boot, from #B/bootargs.
+#
+# The one word that matters here is "tryboot": the tryboot
+# configuration on the card puts it there and config.txt's does not,
+# so it is how a kernel image -- the same bytes either way -- learns
+# that it is the candidate and not the incumbent. A candidate that got
+# this far has booted to a shell under the watchdog and is about to
+# have that watchdog released, which is exactly the moment to say how
+# it is promoted. The commands are printed rather than run: promotion
+# is the operator's decision, and a candidate that boots but has a
+# broken keyboard driver is one they will not want to keep.
+#
+bootargs()
+{
+	fd := sys->open("/dev/bootargs", Sys->OREAD);
+	if(fd == nil){
+		sys->print("init: /dev/bootargs: %r\n");
+		return;
+	}
+	buf := array[1100] of byte;
+	n := sys->read(fd, buf, len buf);
+	args := "";
+	if(n > 0)
+		args = string buf[0:n];
+	(nil, words) := sys->tokenize(args, " \t\r\n");
+	if(words == nil){
+		sys->print("init: bootargs: (none)\n");
+		return;
+	}
+	sys->print("init: bootargs: %s\n", args);
+	candidate := 0;
+	for(w := words; w != nil; w = tl w)
+		if(hd w == "tryboot")
+			candidate = 1;
+	if(!candidate)
+		return;
+	sys->print("init: CANDIDATE kernel: this boot came from the tryboot configuration\n");
+	sys->print("init: to keep it:     mv /n/dos/tryboot.img /n/dos/infernode8.img\n");
+	sys->print("init: to reject it:   echo reboot > /dev/sysctl   (boots infernode8.img)\n");
 }
 
 #

--- a/os/init/osinit.b
+++ b/os/init/osinit.b
@@ -92,6 +92,7 @@ init()
 	sys->print("init: allocated %d bytes through the Dis heap\n", total);
 	kernelimage();
 	gpiocheck();
+	smpticks();
 
 	#
 	# A fixed arithmetic loop, timed. Reported so the harness can run
@@ -2300,6 +2301,81 @@ kernelimage()
 			dig += sys->sprint("%.2x", int h[i]);
 	}
 	sys->print("init: /dev/bootimage %d bytes stat %bd sha1 %s\n", n, d.length, dig);
+}
+
+#
+# Every core's clock, read through the namespace.
+#
+# /dev/sysstat has one line per running core -- "cpuN ticks T intrs I
+# timers F" -- and a core whose tick count does not move between two
+# reads a fifth of a second apart has a clock interrupt that arrives
+# and does nothing. That was cores 1-3 until secclockinit gave each its
+# own hzclock Timer: their interrupt count climbed, their ticks sat at
+# 1, and no process on them was ever preempted. The kernel's own
+# comments said otherwise, which is why this is measured rather than
+# believed. One line, so the harness can assert it.
+#
+smpticks()
+{
+	a := cputicks();
+	if(a == nil){
+		sys->print("init: clock: /dev/sysstat gave no cpu lines\n");
+		return;
+	}
+	sys->sleep(200);
+	b := cputicks();
+	moving := 0;
+	total := 0;
+	r := "";
+	for(l := a; l != nil; l = tl l){
+		(name, t0) := hd l;
+		t1 := lookup(b, name);
+		total++;
+		d := t1 - t0;
+		if(t1 >= 0 && d > 0)
+			moving++;
+		r += sys->sprint(" %s +%d", name, d);
+	}
+	sys->print("init: clock ticks on %d of %d cores (%s)\n", moving, total, r);
+}
+
+#
+# The per-core tick counts, in cpu order. Returns nil if the file is
+# missing or holds nothing recognisable, so the caller can say so.
+#
+cputicks(): list of (string, int)
+{
+	fd := sys->open("/dev/sysstat", Sys->OREAD);
+	if(fd == nil){
+		sys->print("init: clock: cannot open /dev/sysstat: %r\n");
+		return nil;
+	}
+	buf := array[1024] of byte;
+	n := sys->read(fd, buf, len buf);
+	if(n <= 0)
+		return nil;
+	res: list of (string, int);
+	(nil, lines) := sys->tokenize(string buf[0:n], "\n");
+	for(; lines != nil; lines = tl lines){
+		(nf, f) := sys->tokenize(hd lines, " ");
+		if(nf >= 3 && hd tl f == "ticks")
+			res = (hd f, int hd tl tl f) :: res;
+	}
+	# tokenize gave the lines in order; consing reversed them
+	rev: list of (string, int);
+	for(; res != nil; res = tl res)
+		rev = hd res :: rev;
+	return rev;
+}
+
+lookup(l: list of (string, int), name: string): int
+{
+	for(; l != nil; l = tl l){
+		(n, v) := hd l;
+		if(n == name)
+			return v;
+	}
+	return -1;
 }
 
 #

--- a/os/init/osinit.b
+++ b/os/init/osinit.b
@@ -111,6 +111,7 @@ init()
 	sys->print("bench: %d iterations in %d ms (acc=%d)\n", 2000000, t1-t0, acc);
 
 	jitstress();
+	fdcheck();
 
 	#
 	# Put the IP stack where Inferno expects it.
@@ -2006,6 +2007,103 @@ jitfold(h, v: int): int
 Nrep:	con 5;		# samples per workload
 
 bench: Bench;
+
+#
+# Does dropping an fd close it NOW, in compiled code?
+#
+# Limbo has no close(): "fd = nil" closes the file by running the FD's
+# destructor when the last reference goes. Under the JIT that drop is
+# the MacFRP macro in comp-arm64.c, and until it was fixed the macro
+# branched on stale flags and never reached rdestroy -- no compiled
+# code ever ran a destructor, every dropped fd stayed open until the
+# collector swept it, and etherusb had to dup #c/null over its
+# endpoints to hand them to #l. This is the check that would have
+# caught it, and the harness asserts on both lines with the JIT on.
+#
+# The observable is a pipe: hold the read end, drop the write end,
+# read. EOF within Fdms means the destructor ran at the drop. Two
+# drops, because they are two code paths in the compiler: assignment
+# (movp) and a local going out of scope with its frame (macret and
+# the frame's own destructor).
+#
+# Reader and timer are processes that both send into one buffered
+# channel, and this receives whichever comes first. No alt, so that
+# the check exercises as little of the VM as possible beyond the
+# thing under test.
+#
+Fdms: con 2000;
+Fdtimedout: con -2;
+
+fdreader(fd: ref Sys->FD, c: chan of int)
+{
+	buf := array[16] of byte;
+	c <-= sys->read(fd, buf, len buf);
+}
+
+fdtimer(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= Fdtimedout;
+}
+
+# A pipe whose write end has gone with this frame: only the read end
+# comes back, and the FD holding the other end is dropped by the
+# function's return, not by an assignment.
+fdreadend(): ref Sys->FD
+{
+	p := array[2] of ref Sys->FD;
+	if(sys->pipe(p) < 0)
+		return nil;
+	rd := p[0];
+	wr := p[1];
+	p = nil;
+	if(wr == nil)
+		return nil;
+	return rd;
+}
+
+fdreport(what: string, n: int, t0: int)
+{
+	if(n == 0)
+		sys->print("init: fd: %s closed its pipe (EOF after %d ms)\n",
+			what, sys->millisec() - t0);
+	else if(n == Fdtimedout)
+		sys->print("init: fd: %s did NOT close its pipe within %d ms -- the FD destructor did not run\n",
+			what, Fdms);
+	else
+		sys->print("init: fd: %s: read returned %d (%r)\n", what, n);
+}
+
+fdcheck()
+{
+	# By assignment.
+	p := array[2] of ref Sys->FD;
+	if(sys->pipe(p) < 0){
+		sys->print("init: fd: cannot make a pipe: %r\n");
+		return;
+	}
+	rd := p[0];
+	wr := p[1];
+	p = nil;
+	res := chan[4] of int;
+	t0 := sys->millisec();
+	spawn fdreader(rd, res);
+	wr = nil;
+	spawn fdtimer(res, Fdms);
+	fdreport("dropped fd", <-res, t0);
+
+	# By return.
+	rd = fdreadend();
+	if(rd == nil){
+		sys->print("init: fd: cannot make the second pipe: %r\n");
+		return;
+	}
+	res = chan[4] of int;
+	t0 = sys->millisec();
+	spawn fdreader(rd, res);
+	spawn fdtimer(res, Fdms);
+	fdreport("fd dropped on return", <-res, t0);
+}
 
 jitstress()
 {

--- a/os/init/osinit.b
+++ b/os/init/osinit.b
@@ -1,26 +1,27 @@
 implement Init;
 
 #
-# Initial Dis program for the bare-metal AArch64 ports.
-#
-# Shared by os/bcm2837 and os/virt: nothing in it is board-specific,
-# and having one file means a divergence between the two ports cannot
-# hide in a second copy of the first program either of them runs.
+# Initial Dis program for the bare-metal AArch64 port.
 #
 # This is what disinit() loads and schedmod() runs -- the first Limbo
 # code the kernel executes, and the point at which the machine stops
-# being a C program and starts being Inferno.
+# being a C program and starts being Inferno. Nothing in it is
+# board-specific; the board's own facts (the SD device, the pins the
+# kernel claims) are read from the namespace, not compiled in.
 #
-# Deliberately smaller than upstream's geninit.b, which loads the
-# keyring, binds a mouse and serial device, starts a ramfile server for
-# DNS, and finally execs /dis/sh.dis. None of those exist in this
-# kernel's root filesystem yet: it carries this module and nothing else,
-# because every file in it is compiled into the kernel image. Adding the
-# shell means adding sh.dis and everything it loads.
+# It is the counterpart of upstream's geninit.b, and it has grown the
+# way that one did: it proves the VM and the namespace, walks the USB
+# bus and starts the class drivers (etherusb, kbdusb, mouseusb), runs
+# the built-in self-checks the harness asserts on, mounts the SD card
+# on /n/dos, applies the rootpath policy (which root the card asks
+# for), binds a writable /usr, and finally starts the shell with the
+# profile -- which is where the userspace on the card takes over
+# (auth/secstored, wm/logon, the desktop).
 #
-# So this does the one thing worth proving: that Dis bytecode runs, that
-# it can reach the namespace the C kernel built, and that Sys calls
-# cross back into the kernel correctly.
+# Every file the kernel image carries is a recovery floor: enough to
+# boot to a shell and repair a card, and no more. What a usable machine
+# runs comes from the card or the network, so that fixing it does not
+# mean reflashing a kernel.
 #
 
 include "sys.m";

--- a/os/init/osinit.b
+++ b/os/init/osinit.b
@@ -538,7 +538,6 @@ Fportreset:	con 4;
 #
 Resetrecovery:	con 50;
 Watchival:	con 1000;	# how often a hub's ports are re-read, ms
-lastdev := "";		# the device enumerate() last created, for the port that owns it
 Enumattempts:	con 3;
 Fportpower:	con 8;
 
@@ -718,7 +717,14 @@ usbwalk()
 	}
 
 	walking = 1;
-	enumerate("/usb/usb/ep1.0/ctl", d, 1, speedname(status), "");
+	(ok, dev) := enumerate("/usb/usb/ep1.0/ctl", d, 1, speedname(status), "");
+	#
+	# The root port has no watcher to clean up after it: a device that
+	# failed to come up here would otherwise hold its ep0 for the life
+	# of the machine.
+	#
+	if(ok < 0 && dev != "")
+		detachdev(dev);
 	startpending();
 }
 
@@ -762,12 +768,20 @@ reresetport(d: ref Sys->FD, port: int, indent: string): int
 	return 0;
 }
 
-enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): int
+#
+# Returns (status, device): status is 0 if the device came up, and
+# device is the devusb name newdev gave it -- "" if it never got one,
+# and otherwise the name WHETHER OR NOT it came up, because a device
+# that failed half way through still exists in devusb and the caller
+# has to be able to detach it. Nothing about the device is kept in a
+# global: this runs concurrently, once per hub watcher.
+#
+enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): (int, string)
 {
 	c := sys->open(hubctl, Sys->ORDWR);
 	if(c == nil){
 		sys->print("init: cannot open %s: %r\n", hubctl);
-		return -1;
+		return (-1, "");
 	}
 
 	#
@@ -778,7 +792,7 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	#
 	if(sys->fprint(c, "newdev %s %d", speed, port) < 0){
 		sys->print("init: usb newdev failed: %r\n");
-		return -1;
+		return (-1, "");
 	}
 
 	#
@@ -793,15 +807,14 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	n := sys->pread(c, nbuf, len nbuf, big 0);
 	if(n <= 0){
 		sys->print("init: usb newdev gave no name (%d)\n", n);
-		return -1;
+		return (-1, "");
 	}
 	name := string nbuf[0:n];
-	lastdev = name;
 
 	d := sys->open("/usb/usb/" + name + "/data", Sys->ORDWR);
 	if(d == nil){
 		sys->print("init: cannot open %s: %r\n", name);
-		return -1;
+		return (-1, name);
 	}
 
 	#
@@ -867,7 +880,7 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	}
 	if(!ok){
 		sys->print("init: %s%s never answered after reset\n", indent, name);
-		return -1;
+		return (-1, name);
 	}
 	if(try > 0)
 		sys->print("init: %sdescriptor read succeeded on attempt %d\n",
@@ -900,7 +913,7 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	dctl := sys->open("/usb/usb/" + name + "/ctl", Sys->ORDWR);
 	if(dctl == nil){
 		sys->print("init: cannot open %s ctl: %r\n", name);
-		return -1;
+		return (-1, name);
 	}
 	sys->fprint(dctl, "maxpkt %d", maxpkt);
 
@@ -908,7 +921,7 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	rep := array[4] of byte;
 	if(ctlreq(d, Rh2d, Rsetaddress, nb, 0, 0, rep) < 0){
 		sys->print("init: %s set address %d failed: %r\n", name, nb);
-		return -1;
+		return (-1, name);
 	}
 	sys->fprint(dctl, "address");
 
@@ -929,11 +942,11 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	# entitled to ignore it in that state.
 	#
 	if(configure(name, d, indent) < 0)
-		return -1;
+		return (-1, name);
 
 	if(class == Clhub){
 		hubwalk(name, d, dctl, indent + "  ");
-		return -1;
+		return (0, name);
 	}
 
 	hidproto = 0;
@@ -977,7 +990,7 @@ enumerate(hubctl: string, hubd: ref Sys->FD, port: int, speed, indent: string): 
 	#
 	if(class == Clcomm || (class == Clvendor && vendor == Vmicrochip))
 		startdriver("/dis/etherusb.dis", name, -1, 0, 0);
-	return 0;
+	return (0, name);
 }
 
 
@@ -1773,9 +1786,27 @@ portsetup(d: ref Sys->FD, name: string, port: int, indent: string): string
 	#
 	sys->sleep(Resetrecovery);
 
-	lastdev = "";
-	enumerate("/usb/usb/" + name + "/ctl", d, port, speedname(status), indent);
-	return lastdev;
+	#
+	# The device's name comes back from enumerate rather than through
+	# a global: this runs in every hub's watcher at once, and two hubs
+	# enumerating together through one shared variable handed each
+	# other's device names to the wrong port -- so an unplug on one
+	# hub could detach a device on the other.
+	#
+	# A device that did not make it through enumeration is detached
+	# HERE, on the spot. It exists in devusb from the moment newdev
+	# answered, and until now nothing released it: the boot walk has
+	# no watcher yet, so a device pulled out mid-enumerate at boot left
+	# its ep0 allocated for good, and even under the watcher a dead
+	# device sat on the port until it was unplugged. What is returned
+	# is only ever a device that is alive and owned by this port.
+	#
+	(ok, dev) := enumerate("/usb/usb/" + name + "/ctl", d, port, speedname(status), indent);
+	if(ok < 0 && dev != ""){
+		detachdev(dev);
+		return "";
+	}
+	return dev;
 }
 
 

--- a/os/ip/iproute.c
+++ b/os/ip/iproute.c
@@ -6,15 +6,15 @@
  * covered by the permissive MIT licence", and this tree's LICENSE
  * already credits Vita Nuova's revisions.
  *
- * NOT YET IN THE BUILD. The test harness compiles os/port and the board
- * directory; os/ip is landed first so tests/host/iproute_test.sh can
- * extract the real code and check it, before any of it is ported.
- *
- * That order is deliberate. iproute.c is the one file in os/ip with a
- * SILENT WRONG ANSWER failure mode -- a route table that returns the
- * wrong route does not crash, it misroutes -- and it holds three
- * separate width bugs under LP64. Getting a test in front of it is
- * worth more than getting it compiling.
+ * In the build (tests/host/baremetal_test.sh compiles all of os/ip),
+ * and guarded by tests/host/iproute_test.sh, which extracts the
+ * route-range arithmetic and checks it under LP64 on the host. That
+ * test landed BEFORE this file was compiled, deliberately: iproute.c is
+ * the one file in os/ip with a SILENT WRONG ANSWER failure mode -- a
+ * route table that returns the wrong route does not crash, it
+ * misroutes -- and it held three separate width bugs under LP64.
+ * Getting a test in front of it was worth more than getting it
+ * compiling. Keep the test ahead of any change here.
  */
 #include	"u.h"
 #include	"../port/lib.h"

--- a/os/port/devcons.c
+++ b/os/port/devcons.c
@@ -18,6 +18,8 @@
 
 extern int cflag;
 extern int keepbroken;
+extern ulong intrcount[];	/* portclock.c: clock interrupts, per core */
+extern ulong fcallcount[];	/* portclock.c: Timer callbacks run, per core */
 
 void	(*serwrite)(char *, int);
 
@@ -662,6 +664,7 @@ enum{
 	Qtime,
 	Quser,
 	Qjit,
+	Qsysstat,
 };
 
 static Dirtab consdir[]=
@@ -685,6 +688,7 @@ static Dirtab consdir[]=
 	"time",		{Qtime},	0,		0664,
 	"user",		{Quser},	0,	0644,
 	"jit",		{Qjit},	0,	0666,
+	"sysstat",	{Qsysstat},	0,	0444,
 };
 
 ulong	boottime;		/* seconds since epoch at boot */
@@ -1133,6 +1137,41 @@ consread(Chan *c, void *buf, long n, vlong offset)
 
 	case Qmemory:
 		return poolread(buf, n, offset);
+
+	/*
+	 * One line per running core: its tick count, how many clock
+	 * interrupts it has taken and how many Timer callbacks it has
+	 * run. Plan 9's #c/sysstat is the precedent; the fields are
+	 * labelled here because the reader is a person at a serial
+	 * console or a shell script, not a program with the layout
+	 * compiled in.
+	 *
+	 * The tick count is the one that earns the file its place. A
+	 * core whose clock interrupt arrives but whose hzclock never runs
+	 * -- cores 1-3 of the bcm2837 port, for months -- shows intrs
+	 * climbing and ticks frozen, and nothing else in the system can
+	 * tell the two apart from outside. osinit reads this twice at
+	 * boot and reports which cores' clocks move.
+	 */
+	case Qsysstat:
+		p = malloc(READSTR);
+		if(p == nil)
+			error(Enomem);
+		l = 0;
+		for(i = 0; i < conf.nmach; i++){
+			if((active.machs & (1<<i)) == 0)
+				continue;
+			l += snprint(p+l, READSTR-l, "cpu%d ticks %lud intrs %lud timers %lud\n",
+				i, MACHP(i)->ticks, intrcount[i], fcallcount[i]);
+		}
+		if(waserror()){
+			free(p);
+			nexterror();
+		}
+		n = readstr(offset, buf, n, p);
+		poperror();
+		free(p);
+		return n;
 
 	case Qdrivers:
 		p = malloc(READSTR);

--- a/os/port/devcons.c
+++ b/os/port/devcons.c
@@ -59,6 +59,7 @@ enum
 {
 	CMreboot,
 	CMtryboot,
+	CMbooted,
 	CMhalt,
 	CMpanic,
 	CMbroken,
@@ -70,6 +71,7 @@ static Cmdtab sysctlcmd[] =
 {
 	CMreboot,	"reboot",	0,
 	CMtryboot,	"tryboot",	0,
+	CMbooted,	"booted",	0,	/* the boot is over: release its watchdog */
 	CMhalt,	"halt", 0,
 	CMpanic,	"panic", 0,
 	CMconsole,	"console", 1,
@@ -1325,6 +1327,9 @@ conswrite(Chan *c, void *va, long n, vlong offset)
 			break;
 		case CMtryboot:
 			tryboot();
+			break;
+		case CMbooted:
+			booted();
 			break;
 		case CMhalt:
 			halt();

--- a/os/port/devusb.c
+++ b/os/port/devusb.c
@@ -1344,7 +1344,29 @@ epctl(Ep *ep, Chan *c, void *a, long n)
 			error("can't detach a root hub");
 		deprint("usb epctl %s ep%d.%d\n",
 			cb->f[0], ep->dev->nb, ep->nb);
+		/*
+		 * Once, and only once. Each putep below drops the file
+		 * system's ONE reference to an endpoint; a second pass
+		 * drops references that belong to the open channels, and
+		 * the endpoints are freed under whoever still holds them.
+		 * ctlwrite turns away every write to a device already in
+		 * Ddetach, so a second "detach" typed at the ctl file never
+		 * gets here -- but two writers arriving together both pass
+		 * that check, and both ran this loop. The transition is made
+		 * under epslck so exactly one of them proceeds; the other
+		 * finds the device detached, which is what it asked for, and
+		 * succeeds quietly. epslck rather than the device's ep0 lock
+		 * because ep->ql is held across a whole control transfer,
+		 * and a transfer to a device that has just been unplugged is
+		 * exactly what is stalling when detach is written.
+		 */
+		qlock(&epslck);
+		if(ep->dev->state == Ddetach){
+			qunlock(&epslck);
+			break;
+		}
 		ep->dev->state = Ddetach;
+		qunlock(&epslck);
 		/* Release file system ref. for its endpoints */
 		for(i = 0; i < nelem(ep->dev->eps); i++)
 			putep(ep->dev->eps[i]);

--- a/os/port/portclock.c
+++ b/os/port/portclock.c
@@ -244,18 +244,41 @@ timerintr(Ureg *u, uvlong)
 	iunlock(&tt->l);
 }
 
+/*
+ * The periodic Timer whose whole job is to make timerintr() call
+ * hzclock(): tf is nil, and timerintr counts a nil tf as "run the
+ * clock" rather than as a callback. One is needed PER CORE, because
+ * timeradd() queues onto timers[m->machno] and timerintr() walks only
+ * the calling core's queue -- so the Timer core 0 makes in timersinit()
+ * is invisible to every other core's clock interrupt.
+ *
+ * That is what left cores 1-3 of the bcm2837 port without a tick: their
+ * clockintr() called timerintr() faithfully, found an empty queue, and
+ * returned. No preemption, m->ticks frozen, active.exiting never seen.
+ * A secondary calls this from its own clock setup so that the Timer
+ * lands on ITS queue; todinit() is not repeated, tod is one machine-wide
+ * clock and was initialised by core 0 before any secondary ran.
+ */
 void
-timersinit(void)
+timersinitmach(void)
 {
 	Timer *t;
 
-	todinit();
 	t = malloc(sizeof(*t));
+	if(t == nil)
+		panic("timersinitmach: no memory for cpu%d's clock", m->machno);
 	t->tmode = Tperiodic;
 	t->tt = nil;
 	t->tns = 1000000000/HZ;
 	t->tf = nil;
 	timeradd(t);
+}
+
+void
+timersinit(void)
+{
+	todinit();
+	timersinitmach();
 }
 
 Timer*

--- a/os/port/portfns.h
+++ b/os/port/portfns.h
@@ -304,6 +304,7 @@ ulong		_tas(ulong*);
 void		timeradd(Timer*);
 void		timerdel(Timer*);
 void		timersinit(void);
+void		timersinitmach(void);
 void		timerintr(Ureg*, uvlong);
 void		timerset(uvlong);
 ulong	tk2ms(ulong);

--- a/tests/fdclose_test.b
+++ b/tests/fdclose_test.b
@@ -1,0 +1,279 @@
+implement FdcloseTest;
+
+#
+# Does dropping the last reference to an fd close it NOW?
+#
+# Limbo has no close(): a Sys->FD is closed when its last reference
+# goes away, by the FD type's destructor (freeFD in inferno.c). That
+# is what makes "fd = nil" mean close. It only means that if the code
+# that drops the reference actually runs the destructor -- and under
+# the JIT that is the MacFRP macro in comp-<arch>.c, not the
+# interpreter's destroy() in xec.c. comp-arm64.c's macfrp() branched
+# on stale flags and never reached rdestroy, so every dropped fd on
+# the AArch64 JIT stayed open until the collector swept it, and
+# os/init/etherusb.b grew a sys->dup of #c/null to close its endpoints
+# by hand. This test is the one that would have caught it.
+#
+# The observable is a pipe: hold the read end, drop the write end one
+# way or another, and read. EOF (0) within a bounded time means the
+# destructor ran at the drop; a timeout means it did not. Each of the
+# ways compiled code can drop a reference is a separate case -- movp
+# by assignment, the frame destructor on return, a ref adt's own
+# destructor, a list cell freed by tl -- because they are separate
+# code paths in the compiler.
+#
+# Run it both ways, on every JIT platform:
+#   emu -c0 -r . /dis/tests/fdclose_test.dis	(interpreter, the reference)
+#   emu -c1 -r . /dis/tests/fdclose_test.dis	(compiled)
+#
+
+include "sys.m";
+	sys: Sys;
+
+include "draw.m";
+
+include "testing.m";
+	testing: Testing;
+	T: import testing;
+
+FdcloseTest: module
+{
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+SRCFILE: con "/tests/fdclose_test.b";
+
+# How long a close is allowed to take before it is "did not happen".
+# Closing is synchronous in the destructor; the reader and the timer
+# are separate processes, so this is scheduling latency, not close
+# latency. Generous so a busy CI machine does not fail it.
+Eofms: con 3000;
+
+# How long to insist a NOT-closed fd stays open before believing it.
+Openms: con 300;
+
+passed := 0;
+failed := 0;
+skipped := 0;
+
+run(name: string, testfn: ref fn(t: ref T))
+{
+	t := testing->newTsrc(name, SRCFILE);
+	{
+		testfn(t);
+	} exception {
+	"fail:fatal" =>
+		;
+	"fail:skip" =>
+		;
+	"*" =>
+		t.failed = 1;
+	}
+
+	if(testing->done(t))
+		passed++;
+	else if(t.skipped)
+		skipped++;
+	else
+		failed++;
+}
+
+# A reference-counted holder: dropping the holder must drop the fd.
+Holder: adt {
+	fd:	ref Sys->FD;
+};
+
+#
+# Read once from fd and report the count. Runs as its own process so
+# the test can time out rather than hang if the write end never closes.
+# It holds its own reference to the READ end only, which is fine: that
+# is the end we want to stay open.
+#
+reader(fd: ref Sys->FD, c: chan of int)
+{
+	buf := array[16] of byte;
+	c <-= sys->read(fd, buf, len buf);
+}
+
+# What the timer sends. Distinct from anything read() can return.
+Timedout: con -2;
+
+timer(c: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	c <-= Timedout;
+}
+
+#
+# A result channel. Reader and timer both send into it and the test
+# receives whichever comes first, so no alt is needed -- the check
+# should exercise as little of the VM as possible beyond the thing
+# under test. Buffered deep enough that every sender always completes:
+# emu does not exit while any process is alive, and a timer left
+# blocked on a send nobody receives made the first version of this
+# test pass and then hang until the harness killed it.
+#
+Depth: con 8;
+
+results(): chan of int
+{
+	return chan[Depth] of int;
+}
+
+#
+# Wait up to ms for a result; Timedout means none came.
+#
+await(res: chan of int, ms: int): int
+{
+	spawn timer(res, ms);
+	return <-res;
+}
+
+#
+# Make a pipe and return its two ends as separate variables, with the
+# array that pipe() filled already gone -- so the ONLY references to
+# each end are the ones the caller holds.
+#
+mkpipe(t: ref T): (ref Sys->FD, ref Sys->FD)
+{
+	p := array[2] of ref Sys->FD;
+	if(sys->pipe(p) < 0)
+		t.fatal(sys->sprint("pipe: %r"));
+	rd := p[0];
+	wr := p[1];
+	p = nil;
+	return (rd, wr);
+}
+
+#
+# movp: the last reference dropped by assigning nil to the variable
+# that holds it. This is the plain "fd = nil" every Limbo program
+# writes to mean close.
+#
+testDropByAssignment(t: ref T)
+{
+	(rd, wr) := mkpipe(t);
+	res := results();
+	spawn reader(rd, res);
+	wr = nil;
+	n := await(res, Eofms);
+	t.asserteq(n, 0, sys->sprint("read after wr = nil returned %d; want 0 (EOF) -- the FD destructor did not run at the assignment", n));
+}
+
+#
+# The frame destructor: the write end lives only in a local of a
+# function that has returned. Nothing assigns nil; the compiled
+# function's epilogue (macret -> the frame's Type.destroy) drops it.
+#
+readendonly(t: ref T): ref Sys->FD
+{
+	(rd, wr) := mkpipe(t);
+	if(wr == nil)
+		t.fatal("no write end");
+	return rd;		# wr goes with the frame
+}
+
+testDropOnReturn(t: ref T)
+{
+	rd := readendonly(t);
+	res := results();
+	spawn reader(rd, res);
+	n := await(res, Eofms);
+	t.asserteq(n, 0, sys->sprint("read after the holder returned gave %d; want 0 (EOF) -- the frame destructor did not free the fd", n));
+}
+
+#
+# A ref adt: the fd is a field of a heap cell. Dropping the cell runs
+# its destructor, which drops the field. Two destructors in a row, the
+# second reached from C (freeheap) rather than from the macro.
+#
+testDropRefAdt(t: ref T)
+{
+	(rd, wr) := mkpipe(t);
+	h := ref Holder(wr);
+	wr = nil;		# the holder now has the only reference
+	res := results();
+	spawn reader(rd, res);
+	if(await(res, Openms) != Timedout)
+		t.error("pipe closed while the adt still held the write end");
+	h = nil;
+	n := await(res, Eofms);
+	t.asserteq(n, 0, sys->sprint("read after h = nil returned %d; want 0 (EOF) -- dropping the adt did not free its fd", n));
+}
+
+#
+# A list cell: tl frees the cell whose head was the fd. That is the
+# MacFRP call blmac'd from the tail instruction, a different call site
+# from movp.
+#
+testDropListCell(t: ref T)
+{
+	(rd, wr) := mkpipe(t);
+	l := wr :: nil;
+	wr = nil;
+	res := results();
+	spawn reader(rd, res);
+	if(await(res, Openms) != Timedout)
+		t.error("pipe closed while the list still held the write end");
+	l = tl l;
+	n := await(res, Eofms);
+	t.asserteq(n, 0, sys->sprint("read after l = tl l returned %d; want 0 (EOF) -- freeing the list cell did not free its fd", n));
+}
+
+#
+# The other half of the contract: a reference that is NOT the last one
+# must decrement and store, not destroy. If the "ref > 1" path failed
+# to store, the second drop would see ref == 2 and never close; if it
+# destroyed early, the first drop would close a file still in use.
+#
+testSecondReferenceKeepsOpen(t: ref T)
+{
+	(rd, wr) := mkpipe(t);
+	other := wr;
+	res := results();
+	spawn reader(rd, res);
+
+	wr = nil;
+	if(await(res, Openms) != Timedout)
+		t.fatal("pipe closed while a second reference to the write end was live");
+
+	# Prove the reader is still there and the pipe still works: one
+	# byte through the surviving reference.
+	if(sys->write(other, array[] of {byte 'x'}, 1) != 1)
+		t.fatal(sys->sprint("write through the surviving reference: %r"));
+	n := await(res, Eofms);
+	t.asserteq(n, 1, sys->sprint("reader got %d after a 1-byte write; want 1", n));
+
+	# Now the genuinely last reference.
+	spawn reader(rd, res);
+	other = nil;
+	n = await(res, Eofms);
+	t.asserteq(n, 0, sys->sprint("read after the last reference went returned %d; want 0 (EOF)", n));
+}
+
+init(nil: ref Draw->Context, args: list of string)
+{
+	sys = load Sys Sys->PATH;
+	testing = load Testing Testing->PATH;
+
+	if(testing == nil) {
+		sys->fprint(sys->fildes(2), "cannot load testing module: %r\n");
+		raise "fail:cannot load testing";
+	}
+
+	testing->init();
+
+	for(a := args; a != nil; a = tl a) {
+		if(hd a == "-v")
+			testing->verbose(1);
+	}
+
+	run("DropByAssignment", testDropByAssignment);
+	run("DropOnReturn", testDropOnReturn);
+	run("DropRefAdt", testDropRefAdt);
+	run("DropListCell", testDropListCell);
+	run("SecondReferenceKeepsOpen", testSecondReferenceKeepsOpen);
+
+	if(testing->summary(passed, failed, skipped) > 0)
+		raise "fail:tests failed";
+}

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -2,36 +2,41 @@
 #
 # tests/host/baremetal_test.sh
 #
-# Build and boot the bare-metal AArch64 kernels under QEMU and assert on
-# what they report over the PL011 console.
+# Build the bare-metal AArch64 kernel (os/arm64 + os/bcm2837), boot it
+# under QEMU's raspi3b machine, and assert on what it reports over the
+# PL011 console -- and, where the console cannot tell, on what QMP shows
+# (framebuffer pixels, USB hotplug) and on what comes back through the
+# emulated network (TCP echo, DHCP) and SD card (the install image).
 #
-# Two machines, from one shared os/arm64 tree:
+# This is also the only supported way to BUILD the kernel; see
+# os/bcm2837/README.md "Building" for why. BAREMETAL_BUILD_DIR keeps the
+# artefacts (bcm2837-kernel.img is the kernel8.img for a card).
 #
-#   bcm2837  QEMU raspi3b -- the Raspberry Pi 3B+ SoC, the hardware
-#            target. Has a VideoCore mailbox, a firmware framebuffer,
-#            GPIO and a second fixed-rate clock; has no NIC model.
-#   virt     QEMU virt    -- a synthetic machine, the development
-#            target. Has a GICv2 and virtio-mmio (net, gpu, input);
-#            has no framebuffer and no second clock.
+# What it covers, in boot order: EL2->EL1 and the exception round trip
+# (with an injected fault to prove the panic path reports), the MMU,
+# clocks and interrupts, allocators, the scheduler, the namespace and
+# devices, the Dis VM and the JIT (bit-identical against the interpreter,
+# and faster), the shell, os/ip over the USB Ethernet driver, USB
+# keyboard and mouse including hot-plug and unplug, the SD card and
+# dossrv, GPIO, and #B/bootimage against the file it booted.
 #
-# Running both is the point rather than a convenience: the two boards
-# share os/port and os/arm64, so a failure on one and not the other
-# localises itself. It also stops the shared tree from quietly growing a
-# dependency on one machine's peculiarities.
+# What it cannot cover, and only the board does: split I/D caches (the
+# JIT's icache maintenance), bus vs physical DMA addresses, the LAN78xx
+# family (QEMU's usb-net speaks RNDIS), SMP timing, tryboot, the DSI
+# panel, and anything the userspace on a card does after osinit
+# (logon, secstored, the desktop). See the README's "Next".
 #
-# This covers the parts of early bring-up that otherwise fail as a silent
-# hang: dropping EL2->EL1, installing VBAR_EL1, and the exception
-# save/dispatch/restore round trip. It also injects a deliberate fault to
-# prove the panic path still reports rather than wedging.
+# There was once a second machine here (QEMU virt). It is not in the
+# tree; the shared os/arm64 split it forced is.
 #
-# Deliberately does NOT source common.sh: that resolves $EMU and the Limbo
-# toolchain, and this test needs neither -- it exercises a cross-built
-# AArch64 kernel, not anything running inside emu.
+# Does NOT source common.sh: that resolves $EMU, and nothing here runs
+# inside emu. The native limbo IS needed, for runt.h/sysmod.h and the
+# Dis modules compiled into the image.
 #
 # Skips cleanly when the cross toolchain or QEMU is absent, so it is safe
 # to run anywhere.
 #
-# Run from project root: ./tests/host/baremetal_pi_test.sh [-v]
+# Run from project root: ./tests/host/baremetal_test.sh [-v]
 #
 
 ROOT="${ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
@@ -58,7 +63,7 @@ fail()  { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED+1)); return 0; }
 skip()  { echo -e "${YELLOW}SKIP${NC}: $1"; SKIPPED=$((SKIPPED+1)); return 0; }
 info()  { [[ "$VERBOSE" -eq 1 ]] && echo "  $1" || true; return 0; }
 
-echo -e "${BOLD}Bare-metal AArch64 boot tests (bcm2837 + virt)${NC}"
+echo -e "${BOLD}Bare-metal AArch64 boot tests (bcm2837)${NC}"
 echo ""
 
 #
@@ -120,7 +125,7 @@ if [[ -z "$QEMU" ]]; then
     echo "Passed: $PASSED  Failed: $FAILED  Skipped: $SKIPPED"
     exit 0
 fi
-for mach in raspi3b virt; do
+for mach in raspi3b; do
     if ! "$QEMU" -machine help 2>/dev/null | grep -q "^$mach"; then
         skip "this QEMU build has no $mach machine model"
         echo ""
@@ -1322,8 +1327,8 @@ check "etherusb: ep3.0 ready"                  "the packet filter is accepted"
 #   ARP, Request who-has 10.0.2.2 tell 10.0.2.15
 #   ARP, Reply 10.0.2.2 is-at 52:55:0a:00:02:02
 #
-# The reply is on the wire; receiving it does not work yet. See
-# "Receive does not complete" in os/bcm2837/README.md.
+# The reply comes back too, now; the race that once ate it is under
+# "Networking works, intermittently (RESOLVED)" in os/bcm2837/README.md.
 check "etherusb: serving /net/ether0"          "the driver publishes a netif file interface"
 check "10.0.2.15 mask 255.255.255.0 on ipifc"       "os/ip binds an interface to a driver outside the kernel"
 check "default route via 10.0.2.2"             "a default route is installed"
@@ -2863,22 +2868,10 @@ fi
 run_platform bcm2837 "-M raspi3b -netdev user,id=n0 -device usb-net,netdev=n0"
 
 #
-# The virt machine.
-#
-# -cpu cortex-a53 is NOT optional, and is the single most confusing
-# thing about this target: -M virt defaults to cortex-a15, a 32-bit
-# ARMv7 CPU, even under qemu-system-aarch64. An AArch64 kernel booted
-# without it does not fail -- it produces absolutely no output at all,
-# because the CPU is decoding the image as ARM32. Picking the same A53
-# the Pi has also keeps the MIDR assertion common to both platforms.
-#
-# -m 1024 matches the Pi 3B+'s 1GB, and is asserted on: it proves the
-# device-tree parse read a real number rather than falling back to a
-# default that happened to look plausible.
-#
-# The virtio devices are attached so the transport scan has something to
-# find. They are not driven -- there are no drivers yet -- but their
-# presence is what makes virt worth having, so the test asserts it.
+# A second machine (QEMU virt) once ran here too. If one comes back,
+# remember: -M virt defaults to cortex-a15, a 32-bit CPU, even under
+# qemu-system-aarch64, and an AArch64 kernel booted without
+# -cpu cortex-a53 produces no output at all.
 #
 
 

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -1188,6 +1188,30 @@ check "vectors:         installed"    "installs VBAR_EL1"
 check "save/restore OK"               "exception save/dispatch/restore round trips"
 check "boot OK"                       "completes boot without faulting"
 
+# SMP. Until these lines nothing here asserted that the secondaries came
+# up at all, let alone that they keep time: the kernel claimed in two
+# comments that cores 1-3 ticked and preempted, and for months neither
+# was true -- each secondary's clock interrupt walked an empty Timer
+# queue and returned. The three checks below are the three claims.
+#
+# "cpuN: up" is squidboy's ack, printed after the core has its vectors,
+# MMU and clock. "did not answer" is launchsmp giving up on a core.
+check "cpu1: up"                      "core 1 answers the release and enters its scheduler"
+check "cpu2: up"                      "core 2 answers the release and enters its scheduler"
+check "cpu3: up"                      "core 3 answers the release and enters its scheduler"
+refute "did not answer"               "no secondary core failed to answer the release"
+# osinit reads /dev/sysstat twice, 200ms apart, and counts the cores
+# whose tick count moved. A core with a live interrupt and a dead
+# hzclock shows here as "3 of 4".
+check "init: clock ticks on 4 of 4 cores" \
+                                      "every core's clock advances (hzclock runs on cpu1-3, read back through /dev/sysstat)"
+# smpcheck (main.c) wires a spinning kproc to each secondary, then a
+# second kproc to the same core, and times how long the second waits to
+# run there. Preemption makes that a tick or two; without it the probe
+# waits for the hog to finish, 250ms, and the line says BROKEN.
+check "smp:  preempt cpu1 [0-9]*us cpu2 [0-9]*us cpu3 [0-9]*us OK" \
+                                      "a kproc wired to a busy secondary is preempted onto it within the tick budget"
+
 # The mailbox round trip. 0xa02082 is a real Pi 3B board revision, so
 # this also confirms we are talking to a plausible BCM2837 and not just
 # reading back zeroes.
@@ -1388,6 +1412,7 @@ SHOUT="$(shell_session "$BUILD/$PLAT-kernel.img" \
         'echo grep-found-it | grep found' \
         'ps | wc -l' \
         'sleep 0; echo slept-ok' \
+        'cat /dev/sysstat' \
         'for(i in x y z){ echo loop2-$i }')"
 
 # Strip carriage returns once, here.
@@ -1412,6 +1437,15 @@ if grep -q "/dis/sh.dis" <<<"$SHOUT"; then
     pass "ls lists the in-kernel root filesystem"
 else
     fail "ls did not list /dis"
+fi
+
+# The per-core clock is readable from the shell, not only asserted at
+# boot: one line per core that came up, and the fourth core's line is
+# the one that proves the file is not merely core 0 talking about itself.
+if grep -q "^cpu3 ticks [0-9][0-9]* intrs [0-9][0-9]* timers [0-9][0-9]*$" <<<"$SHOUT"; then
+    pass "/dev/sysstat reports every core's ticks, interrupts and timer callbacks"
+else
+    fail "/dev/sysstat did not show a line for cpu3"
 fi
 
 # Pipelines and command substitution both go through #|. Before the pipe

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -1195,11 +1195,17 @@ check "boot OK"                       "completes boot without faulting"
 # queue and returned. The three checks below are the three claims.
 #
 # "cpuN: up" is squidboy's ack, printed after the core has its vectors,
-# MMU and clock. "did not answer" is launchsmp giving up on a core.
+# MMU and clock. "cpuN: did not answer" is launchsmp giving up on a core.
+# The refutation is anchored to launchsmp's exact form because osinit
+# has a "did not answer" of its own -- "init: port N did not answer;
+# resetting it again", from reresetport() -- and that one is a device
+# failing to enumerate on the first try, which its own comment says is
+# routine on this board. A bare "did not answer" would fail an SMP check
+# for a USB retry.
 check "cpu1: up"                      "core 1 answers the release and enters its scheduler"
 check "cpu2: up"                      "core 2 answers the release and enters its scheduler"
 check "cpu3: up"                      "core 3 answers the release and enters its scheduler"
-refute "did not answer"               "no secondary core failed to answer the release"
+refute "cpu[0-9]*: did not answer"    "no secondary core failed to answer the release"
 # osinit reads /dev/sysstat twice, 200ms apart, and counts the cores
 # whose tick count moved. A core with a live interrupt and a dead
 # hzclock shows here as "3 of 4".

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -551,7 +551,7 @@ build_kernel() {
         printf '16\t13\n0x0000\t0x0100\tVera.14.0000\n' > "$BUILD/unicode.14.font"
         rootmanifest+=(
             "/fonts/vera/Vera/unicode.14.font=$BUILD/unicode.14.font"
-            "/fonts/vera/Vera/Vera.14.0000=$ROOT/fonts/vera/Vera/Vera.14.0000"
+            "/fonts/vera/Vera/Vera.14.0000=$ROOT/fonts/vera/vera/vera.14.0000"
         )
 
         python3 "$ROOT/tools/mkrootfs.py" "$BUILD/rootfs.c" \
@@ -1180,7 +1180,8 @@ check "midr_el1:        0x00000000410fd0" \
     check "exception level: EL1"      "drops from EL2 to EL1"
 check "types:           arm64 u.h OK" "arm64 type foundation holds (LP64 + stdarg)"
 KIMG="$BUILD/$PLAT-kernel.img"
-check "init: /dev/bootimage $(stat -f%z "$KIMG") bytes stat $(stat -f%z "$KIMG") sha1 $(shasum "$KIMG" | cut -c1-40)" \
+kimgsz=$(wc -c < "$KIMG" | tr -d ' ')
+check "init: /dev/bootimage $kimgsz bytes stat $kimgsz sha1 $(shasum "$KIMG" | cut -c1-40)" \
     "/dev/bootimage reproduces the image the loader was given, byte for byte"
 check "init: gpio 21 out 1->1 0->0; pin 14: in use by uart" "GPIO pins are files: an output reads back what was written, the console pin refuses"
 check "vectors:         installed"    "installs VBAR_EL1"

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -1595,6 +1595,10 @@ fi
 # variant image that skips the release and must reset at the budget
 # would be the natural third check; it is not here because the model
 # has no budget to reach, and a check that cannot fail is not one.
+# For the same reason nothing here exercises the reload -- the tick's
+# or microdelay's poll for the interrupts-masked half of kmain -- nor
+# the unreadable-command-line arming: -append is short, and QEMU
+# answers GET_COMMAND_LINE. Those are board results (README).
 #
 WDOUT="$(boot_kernel "$BUILD/$PLAT-kernel.img" 8 tryboot)"
 OUT_SAVED="$OUT"; OUT="$WDOUT"
@@ -1624,15 +1628,26 @@ OUT="$OUT_SAVED"
 # reset can be from outside: the boot banner appears a second time.
 # shell_session waits up to 30s for a drain marker the reset machine
 # never echoes, which is what gives the second boot time to print.
+#
+# Honest accounting: of these three, only the middle one is new with
+# the mailbox handshake. The first line and the reset were already
+# there when boardtryboot set a PM_RSTS bit -- notyet.c's print and
+# the PM_RSTC full reset predate the change -- so those two PIN the
+# path from /dev/sysctl to the PM block against regression rather than
+# test the fix; and the middle one shows only that the tag message was
+# well formed, since QEMU acknowledges every tag. Nothing QEMU prints
+# distinguishes the SET_REBOOT_FLAGS tag from the old PM_RSTS write,
+# and this block does not pretend otherwise.
 TBOUT="$(shell_session "$BUILD/$PLAT-kernel.img" 'echo tryboot > /dev/sysctl')"
 TBOUT="$(tr -d '\r' <<<"$TBOUT")"
 OUT_SAVED="$OUT"; OUT="$TBOUT"
-check "tryboot: resetting; next boot is the CANDIDATE kernel" "tryboot on /dev/sysctl reaches the board's reset path"
+check "tryboot: resetting; next boot is the CANDIDATE kernel" \
+      "tryboot on /dev/sysctl reaches the board's reset path (pre-existing path, pinned)"
 check "tryboot: firmware acknowledged reboot flags 0x1 (tryboot)" \
       "the reboot-flags tag round-trips the mailbox (the firmware's real answer is a board result)"
 nboot="$(grep -c 'InferNode bare-metal' <<<"$TBOUT")"
 if [[ "$nboot" -ge 2 ]]; then
-    pass "tryboot reset the machine: it booted again ($nboot banners)"
+    pass "tryboot reset the machine: it booted again ($nboot banners; pre-existing reset, pinned)"
 else
     fail "tryboot did not reset the machine ($nboot boot banner(s))"
 fi

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -1331,6 +1331,13 @@ check "etherusb: ep3.0 ready"                  "the packet filter is accepted"
 # The reply comes back too, now; the race that once ate it is under
 # "Networking works, intermittently (RESOLVED)" in os/bcm2837/README.md.
 check "etherusb: serving /net/ether0"          "the driver publishes a netif file interface"
+# The kernel data path specifically. The endpoints are exclusive-open,
+# so this line only appears if etherusb's "fd = nil" actually closed
+# them before #l tried to take them -- the "init: fd:" destructor
+# checks after the JIT section, exercised on a real device rather than
+# a pipe. It used to be reached only through a sys->dup of #c/null
+# over the descriptors.
+check "etherusb: serving /net/ether0 (kernel data path)" "the endpoints are free for #l when etherusb drops its fds, with no dup workaround"
 check "10.0.2.15 mask 255.255.255.0 on ipifc"       "os/ip binds an interface to a driver outside the kernel"
 check "default route via 10.0.2.2"             "a default route is installed"
 
@@ -1611,6 +1618,19 @@ if build_kernel "$BUILD/$PLAT-nojit.img" "" "-DCFLAG=0"; then
 else
     fail "the JIT-off comparison kernel failed to build"
 fi
+
+# Destructors run in compiled code. The opcode classes above compute
+# the right ANSWERS; this is about what compiled code does when it
+# drops a reference. comp-arm64.c's macfrp() used to branch on the nil
+# check's flags and never reach rdestroy, so "fd = nil" closed nothing
+# and every dropped fd waited for the collector -- the reason etherusb
+# once needed a sys->dup of #c/null to free its endpoints for #l.
+# osinit drops a pipe's write end two ways (assignment, and a local
+# going out of scope with its frame) and reads the other end; EOF
+# within two seconds means the destructor ran at the drop. The main
+# boot runs with the JIT on, so these lines come from compiled code.
+check "init: fd: dropped fd closed its pipe"           "compiled code runs the FD destructor when the last reference is assigned away"
+check "init: fd: fd dropped on return closed its pipe" "compiled code runs the FD destructor when a frame holding the last reference returns"
 
 check "pool: smprint/strdup OK"       "libkern allocator-dependent entry points work"
 

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -449,6 +449,11 @@ build_kernel() {
             "/dis/ns.dis=$ROOT/dis/ns.dis"
             "/dis/bind.dis=$ROOT/dis/bind.dis"
             "/dis/mount.dis=$ROOT/dis/mount.dis"
+            # unmount is how a namespace is narrowed -- boot-baremetal.sh
+            # takes the card and the pins out of the desktop's /dev with
+            # it -- and a recovery shell that can bind but not unbind is
+            # half a tool.
+            "/dis/unmount.dis=$ROOT/dis/unmount.dis"
             "/dis/mkdir.dis=$ROOT/dis/mkdir.dis"
             "/dis/rm.dis=$ROOT/dis/rm.dis"
             "/dis/cp.dis=$ROOT/dis/cp.dis"
@@ -2236,6 +2241,106 @@ if grep -q '^first$' <<<"$FSOUT" && grep -q '^second$' <<<"$FSOUT"; then
     pass "a file can be created and then appended to"
 else
     fail "appending to a file on the card did not take"
+fi
+
+#
+#     The desktop's namespace can be narrowed, and the console's is not.
+#
+#     Every process on this machine is the host owner, so the only thing
+#     between a desktop program and the raw card is what its namespace
+#     does not contain. lib/lucifer/boot-baremetal.sh builds that
+#     namespace before it starts logon: forks it, unmounts #S and #G
+#     from /dev, and binds /dev/null over /dev/sysctl. This types the
+#     same sequence into a child shell -- the boot script itself needs
+#     a card userspace this kernel image does not carry -- and asserts
+#     both halves: inside, the card, the pins and sysctl are gone; back
+#     outside, the console shell still has every one of them. Both
+#     halves matter. A narrowing that leaked into the parent would take
+#     the management plane's card away, and pass a test that only
+#     looked inside.
+#
+#     "echo halt > /dev/sysctl" inside is the check that means it: were
+#     /dev/sysctl still #c's, the machine would stop there and nothing
+#     after it would print. The marker lines are echoed on their own so
+#     the extraction below can tell the command being typed (which
+#     carries the marker word too) from its output.
+#
+#     The card image is the FAT16 one, attached so that #S has a card
+#     to bind and /dev/sdcard is there to take away.
+#
+QEMUARGS="$SAVEDARGS -drive file=$SDIMG,if=sd,format=raw"
+NSOUT="$(shell_session "$BUILD/$PLAT-kernel.img" \
+        'path=(/dis .)' \
+        'load std' \
+        'sh' \
+        'load std' \
+        'pctl forkns' \
+        "unmount '#S' /dev" \
+        "unmount '#G' /dev" \
+        'bind /dev/null /dev/sysctl' \
+        'bind /dev/null /dev/hostowner' \
+        'echo INNER' \
+        'ls /dev/sdcard /dev/sdctl /dev/gpio' \
+        'v=`{cat /dev/sysctl}; echo inner-sysctl-words $#v' \
+        'echo halt > /dev/sysctl' \
+        'echo inner-still-alive' \
+        'echo INNER-END' \
+        'exit' \
+        'echo OUTER' \
+        'ls /dev/sdcard /dev/sdctl /dev/gpio/21/ctl' \
+        'v=`{cat /dev/sysctl}; echo outer-sysctl-words $#v' \
+        'echo OUTER-END')"
+QEMUARGS="$SAVEDARGS"
+NSOUT="$(tr -d '\r' <<<"$NSOUT")"
+[[ "$VERBOSE" -eq 1 ]] && { echo "  --- namespace ---"; echo "$NSOUT"; }
+
+# Only whole-line markers delimit the sections: the typed command line
+# carries "echo INNER" and is not a match for ^INNER$.
+NSIN="$(sed -n '/^INNER$/,/^INNER-END$/p' <<<"$NSOUT")"
+NSOUTER="$(sed -n '/^OUTER$/,/^OUTER-END$/p' <<<"$NSOUT")"
+
+if grep -q 'INNER-END' <<<"$NSIN" && grep -q 'OUTER-END' <<<"$NSOUTER"; then
+    pass "a child shell forks its namespace, narrows it, exits, and the console shell comes back"
+else
+    fail "the narrowed-namespace session did not run to both markers"
+fi
+
+if grep -q "/dev/sdcard.*does not exist" <<<"$NSIN" \
+   && grep -q "/dev/sdctl.*does not exist" <<<"$NSIN"; then
+    pass "unmount '#S' /dev takes the raw card and its partition table out of the namespace"
+else
+    fail "/dev/sdcard or /dev/sdctl is still reachable after unmount '#S' /dev"
+fi
+
+if grep -q "/dev/gpio.*does not exist" <<<"$NSIN"; then
+    pass "unmount '#G' /dev takes the pins out of the namespace"
+else
+    fail "/dev/gpio is still reachable after unmount '#G' /dev"
+fi
+
+if grep -q '^inner-sysctl-words 0$' <<<"$NSIN"; then
+    pass "bind /dev/null /dev/sysctl: sysctl reads empty in the narrowed namespace"
+else
+    fail "/dev/sysctl still reads the kernel's version line after bind /dev/null over it"
+fi
+
+if grep -q '^inner-still-alive$' <<<"$NSIN"; then
+    pass "'echo halt > /dev/sysctl' in the narrowed namespace does not halt the machine"
+else
+    fail "the machine did not answer after a halt written to the narrowed /dev/sysctl"
+fi
+
+if grep -q '^/dev/sdcard$' <<<"$NSOUTER" && grep -q '^/dev/sdctl$' <<<"$NSOUTER" \
+   && grep -q '^/dev/gpio/21/ctl$' <<<"$NSOUTER"; then
+    pass "the console shell still has /dev/sdcard, /dev/sdctl and the pins after the child narrowed its own"
+else
+    fail "the narrowing leaked into the console shell's namespace (card or pins missing outside)"
+fi
+
+if grep -q '^outer-sysctl-words [1-9]' <<<"$NSOUTER"; then
+    pass "the console shell's /dev/sysctl is still the kernel's"
+else
+    fail "the console shell's /dev/sysctl reads empty: the null bind leaked out of the child"
 fi
 
 #

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -1884,15 +1884,27 @@ OUT="$OUT_SAVED"
 #
 #     Detaching a device twice.
 #
-#     osinit writes "detach" once when a hub port empties. A second
-#     write to the same device -- a second watcher, a person at the
-#     shell -- used to run devusb's release loop again and drop
-#     references the open files still held, freeing endpoints under
-#     their owners. Typed as one block, both writes go down ONE open fd,
-#     so the second reaches the device rather than a path that has
-#     already gone. The keyboard is the victim because it is the device
-#     the machine can spare; what must be seen is the driver exiting
-#     once, the second write REFUSED, and the shell still answering.
+#     osinit writes "detach" once when a hub port empties. devusb's
+#     CMdetach runs a release loop that drops the file system's one
+#     reference to each endpoint, and a second pass through it drops
+#     references the open files hold, freeing endpoints under their
+#     owners. Two writers that arrive TOGETHER both used to run it; the
+#     transition to Ddetach is now made under epslck so only one does.
+#
+#     This check does not reach that race, and is not claimed to: two
+#     writes typed one after the other are serial, and the second is
+#     turned away by ctlwrite's pre-existing Ddetach check before epctl
+#     is called -- so this passes on the unfixed kernel too. What it
+#     pins is the contract the fix depends on, which nothing else
+#     asserted: a detach written at the shell reaches the driver, which
+#     exits once; a second write down the SAME open fd (typed as one
+#     block, so it reaches the device rather than a path that has gone)
+#     is refused with the device's own error and not "i/o error"; and
+#     the shell still answers. The compare-and-set itself is verified
+#     by inspection only -- there is one assignment of Ddetach in the
+#     tree, and epslck is taken in process context with no other lock
+#     held. The keyboard is the victim because it is the device the
+#     machine can spare.
 #
 #     The sleep first is not padding. The prompt appears while the hub
 #     walk is still powering ports, and a detach typed then reaches a

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -410,6 +410,9 @@ build_kernel() {
             # needs.
             "/dis/echo.dis=$ROOT/dis/echo.dis"
             "/dis/cat.dis=$ROOT/dis/cat.dis"
+            # rm, for removing a file through dossrv and looking at
+            # what it left on the card afterwards.
+            "/dis/rm.dis=$ROOT/dis/rm.dis"
             "/dis/pwd.dis=$ROOT/dis/pwd.dis"
             "/dis/ls.dis=$ROOT/dis/ls.dis"
             "/dis/lib/readdir.dis=$ROOT/dis/lib/readdir.dis"
@@ -1334,6 +1337,16 @@ check "etherusb: serving /net/ether0"          "the driver publishes a netif fil
 check "10.0.2.15 mask 255.255.255.0 on ipifc"       "os/ip binds an interface to a driver outside the kernel"
 check "default route via 10.0.2.2"             "a default route is installed"
 
+# The DHCP client's reader lives exactly as long as the exchange. It is
+# parked in a read the kernel returns from only when a datagram arrives,
+# so it used to outlive its caller for the life of the machine, holding
+# port 68's conversation open. The client now kills it and says whether
+# it went. Under QEMU the exchange ends in the fallback, which is the
+# path that matters: a client that gets no answer is the one that used
+# to leave its reader behind.
+check "etherusb: dhcp reader [0-9]* exited"    "the DHCP reader is reaped when the exchange is over"
+refute "dhcp reader [0-9]* still running"      "no DHCP reader outlives its exchange"
+
 # Interrupts, asserted rather than assumed.
 #
 # The clock probe elsewhere tests the generic timer, which is PER-CORE
@@ -1869,6 +1882,58 @@ refute "configuration unreadable"   "every device configuration was readable"
 OUT="$OUT_SAVED"
 
 #
+#     Detaching a device twice.
+#
+#     osinit writes "detach" once when a hub port empties. A second
+#     write to the same device -- a second watcher, a person at the
+#     shell -- used to run devusb's release loop again and drop
+#     references the open files still held, freeing endpoints under
+#     their owners. Typed as one block, both writes go down ONE open fd,
+#     so the second reaches the device rather than a path that has
+#     already gone. The keyboard is the victim because it is the device
+#     the machine can spare; what must be seen is the driver exiting
+#     once, the second write REFUSED, and the shell still answering.
+#
+#     The sleep first is not padding. The prompt appears while the hub
+#     walk is still powering ports, and a detach typed then reaches a
+#     device the driver has not yet opened: the endpoint is freed under
+#     kbdusb's own open, which is a different failure from the one this
+#     is written to catch. Fifteen seconds is what the keyboard boot
+#     check above allows the driver, with margin.
+#
+KBDEP="$(grep -oE 'kbdusb: ep[0-9]+\.0 ready' <<<"$KBDOUT" | head -1 | sed 's/kbdusb: //;s/ ready//')"
+if [[ -n "$KBDEP" ]]; then
+    SAVEDARGS="$QEMUARGS"
+    QEMUARGS="$QEMUARGS -device usb-kbd"
+    DETOUT="$(shell_session "$BUILD/$PLAT-kernel.img" \
+            'path=(/dis .)' \
+            'sleep 15' \
+            "{echo detach; echo detach} > /usb/usb/$KBDEP/ctl" \
+            'echo detach-twice-survived' \
+            "cat /usb/usb/$KBDEP/ctl")"
+    QEMUARGS="$SAVEDARGS"
+    DETOUT="$(tr -d '\r' <<<"$DETOUT")"
+    [[ "$VERBOSE" -eq 1 ]] && { echo "  --- double detach ---"; echo "$DETOUT"; }
+    if grep -q "kbdusb: $KBDEP detached" <<<"$DETOUT"; then
+        pass "detach written at the shell detaches the keyboard and its driver exits"
+    else
+        fail "the first detach of $KBDEP did not reach the driver"
+    fi
+    # Refused with the device's own error, not "i/o error": that would
+    # mean the endpoint had been freed between the two writes, i.e.
+    # nobody -- not even the driver -- still held it.
+    if grep -q 'echo: write error: device is detached' <<<"$DETOUT" \
+       && grep -v 'echo ' <<<"$DETOUT" | grep -q 'detach-twice-survived' \
+       && ! grep -qi 'panic' <<<"$DETOUT"; then
+        pass "a second detach of the same device is refused and the machine carries on"
+    else
+        fail "the second detach of $KBDEP was not refused cleanly"
+    fi
+else
+    skip "double detach (no keyboard endpoint name in the keyboard boot)"
+fi
+
+#
 # 3d. A keystroke, from the HID device to the shell.
 #
 #     3c proves the keyboard is found and claimed. It does NOT prove a
@@ -2336,7 +2401,11 @@ QEMUARGS="$SAVEDARGS -drive file=$SD32,if=sd,format=raw"
 FS32="$(shell_session "$BUILD/$PLAT-kernel.img" \
         'path=(/dis .)' \
         'ls /n/dos' \
-        'cat /n/dos/HELLO32.TXT')"
+        'cat /n/dos/HELLO32.TXT' \
+        'echo cluster-owner > /n/dos/badent-1' \
+        'ls -l /n/dos' \
+        'rm /n/dos/badent-1' \
+        'ls /n/dos')"
 QEMUARGS="$SAVEDARGS"
 FS32="$(tr -d '\r' <<<"$FS32")"
 [[ "$VERBOSE" -eq 1 ]] && { echo "  --- fat32 ---"; echo "$FS32"; }
@@ -2345,6 +2414,100 @@ if grep -q 'fat32 works on bare metal' <<<"$FS32"; then
     pass "a FAT32 filesystem is mounted and read (the Pi boot partition's format)"
 else
     fail "FAT32 could not be read"
+fi
+
+#
+#     A healthy file that merely LOOKS like a damage alias.
+#
+#     dossrv names an entry it cannot present -- control characters, a
+#     slash, an empty name -- badent-<location>, and rm on that alias
+#     zaps the directory entry alone, deliberately leaving the clusters
+#     (the start-cluster word of a damaged entry is not to be trusted).
+#     The test for "is this the damaged case" used to be a prefix match
+#     on the name handed OUT, so a healthy file someone had called
+#     badent-1 took the same path: gone from the directory, its cluster
+#     chain still allocated and reachable from nowhere.
+#
+#     The check is made from outside, on the image the guest wrote,
+#     the way fsck would: every allocated cluster must be reachable
+#     from the root directory. The deleted entry has to be there too,
+#     or a session that never created the file passes for free.
+#
+python3 - "$SD32" <<'PYEOF' > "$BUILD/$PLAT-badent.txt" 2>&1
+import struct, sys
+img = open(sys.argv[1], "rb").read()
+SEC = 512
+pstart = struct.unpack_from("<I", img, 446 + 8)[0]
+bs = img[pstart*SEC : pstart*SEC + SEC]
+spc = bs[13]
+resv = struct.unpack_from("<H", bs, 14)[0]
+nfat = bs[16]
+fatsz = struct.unpack_from("<I", bs, 36)[0]
+rootclus = struct.unpack_from("<I", bs, 44)[0]
+fatoff = (pstart + resv) * SEC
+data = (pstart + resv + nfat*fatsz) * SEC
+nclus = fatsz * SEC // 4
+
+def fat(n):
+    return struct.unpack_from("<I", img, fatoff + 4*n)[0] & 0x0FFFFFFF
+
+def chain(n):
+    out = []
+    while 2 <= n < 0x0FFFFFF8 and n not in out and len(out) < nclus:
+        out.append(n)
+        n = fat(n)
+    return out
+
+def cluster(n):
+    off = data + (n-2)*spc*SEC
+    return img[off : off + spc*SEC]
+
+reachable = set()
+deleted = 0
+def walk(start, depth):
+    global deleted
+    ch = chain(start)
+    reachable.update(ch)
+    for c in ch:
+        b = cluster(c)
+        for o in range(0, len(b), 32):
+            e = b[o:o+32]
+            if e[0] == 0:
+                return
+            if e[0] == 0xE5:
+                if e[1:6] == b"ADENT":
+                    deleted += 1
+                continue
+            if e[11] & 0x08:                 # long-name piece or volume label
+                continue
+            if e[0:1] == b".":
+                continue
+            if e[0:6] == b"BADENT":
+                print("LIVE-BADENT")
+            st = (struct.unpack_from("<H", e, 20)[0] << 16) | struct.unpack_from("<H", e, 26)[0]
+            if st >= 2:
+                if e[11] & 0x10 and depth < 8:
+                    walk(st, depth + 1)
+                else:
+                    reachable.update(chain(st))
+
+walk(rootclus, 0)
+allocated = {n for n in range(2, nclus) if fat(n) != 0}
+lost = sorted(allocated - reachable)
+print("DELETED-BADENT" if deleted else "NO-DELETED-BADENT")
+print("LOST %d %s" % (len(lost), lost[:8]))
+PYEOF
+BADOUT="$(cat "$BUILD/$PLAT-badent.txt")"
+[[ "$VERBOSE" -eq 1 ]] && { echo "  --- badent ---"; echo "$BADOUT"; }
+if grep -q 'DELETED-BADENT' <<<"$BADOUT" && ! grep -q 'LIVE-BADENT' <<<"$BADOUT"; then
+    pass "a file named badent-1 is created and removed through dossrv"
+else
+    fail "the badent-1 fixture was not created and removed ($(tr '\n' ' ' <<<"$BADOUT"))"
+fi
+if grep -q '^LOST 0 ' <<<"$BADOUT"; then
+    pass "removing a healthy file that is merely named badent-* frees its clusters"
+else
+    fail "clusters left allocated and unreachable after rm ($(grep '^LOST' <<<"$BADOUT"))"
 fi
 
 #

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -18,13 +18,18 @@
 # devices, the Dis VM and the JIT (bit-identical against the interpreter,
 # and faster), the shell, os/ip over the USB Ethernet driver, USB
 # keyboard and mouse including hot-plug and unplug, the SD card and
-# dossrv, GPIO, and #B/bootimage against the file it booted.
+# dossrv, GPIO, #B/bootimage against the file it booted, and this side
+# of the tryboot A/B path: the command line reaching the kernel and
+# osinit, the boot watchdog's arming write and its "booted" release,
+# and "tryboot" on /dev/sysctl resetting the machine.
 #
 # What it cannot cover, and only the board does: split I/D caches (the
 # JIT's icache maintenance), bus vs physical DMA addresses, the LAN78xx
-# family (QEMU's usb-net speaks RNDIS), SMP timing, tryboot, the DSI
-# panel, and anything the userspace on a card does after osinit
-# (logon, secstored, the desktop). See the README's "Next".
+# family (QEMU's usb-net speaks RNDIS), SMP timing, the firmware's side
+# of tryboot and the watchdog's countdown (QEMU acknowledges every
+# property tag and resets on the arming write; see the tryboot section
+# below), the DSI panel, and anything the userspace on a card does
+# after osinit (logon, secstored, the desktop). See the README's "Next".
 #
 # There was once a second machine here (QEMU virt). It is not in the
 # tree; the shared os/arm64 split it forced is.
@@ -911,14 +916,20 @@ SBEOF
 
 # Boot an image and capture the serial output. The kernel never exits, so
 # it must be killed; partial output is what we want.
+# The optional third argument is a kernel command line, handed to QEMU
+# as -append, which its firmware model returns for the GET_COMMAND_LINE
+# property tag exactly as the Pi's firmware returns cmdline.txt. It is
+# a separate argument rather than part of $QEMUARGS because that string
+# is split on spaces and a command line has spaces in it.
 boot_kernel() {
-    local img="$1" secs="${2:-10}"
-    python3 - "$QEMU" "$img" "$secs" "$QEMUARGS" <<'PYEOF'
+    local img="$1" secs="${2:-10}" append="${3:-}"
+    python3 - "$QEMU" "$img" "$secs" "$QEMUARGS" "$append" <<'PYEOF'
 import subprocess, sys
-qemu, img, secs, extra = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
-p = subprocess.Popen([qemu] + extra.split() + ["-kernel", img,
-                      "-display", "none", "-serial", "stdio"],
-                     stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+qemu, img, secs, extra, append = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4], sys.argv[5]
+args = [qemu] + extra.split() + ["-kernel", img, "-display", "none", "-serial", "stdio"]
+if append:
+    args += ["-append", append]
+p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 try:
     out, _ = p.communicate(timeout=secs)
 except subprocess.TimeoutExpired:
@@ -1184,6 +1195,23 @@ kimgsz=$(wc -c < "$KIMG" | tr -d ' ')
 check "init: /dev/bootimage $kimgsz bytes stat $kimgsz sha1 $(shasum "$KIMG" | cut -c1-40)" \
     "/dev/bootimage reproduces the image the loader was given, byte for byte"
 check "init: gpio 21 out 1->1 0->0; pin 14: in use by uart" "GPIO pins are files: an output reads back what was written, the console pin refuses"
+
+# The boot watchdog's two ends on a boot that does not arm it.
+#
+# Only a boot whose command line says "tryboot" (or "bootwatchdog") is
+# put under the watchdog; this boot has no -append, so the kernel must
+# say it read an empty command line and chose not to arm -- and osinit
+# must still write "booted", because the release line is how the
+# handshake is known to reach the board hook at all. The PM registers
+# are printed so that a wrong PMREGS base would show as garbage here
+# rather than as a watchdog write that lands nowhere. 0x1000 and 0x102
+# are the reset values QEMU's model reports; the board reports the
+# reset cause.
+check "boot: command line: (empty)"  "the kernel reads the firmware command line through the mailbox"
+check "pm:   rsts 0x0000000000001000 rstc 0x0000000000000102" "the PM block reads back at PMREGS (QEMU's reset values)"
+check "wdog: not armed (not a tryboot candidate)" "a boot the command line does not mark is not put under the watchdog"
+check "init: bootargs: (none)"        "#B/bootargs serves the command line to osinit"
+check "wdog: boot complete; no watchdog was armed" "osinit's booted on /dev/sysctl reaches the board hook"
 check "vectors:         installed"    "installs VBAR_EL1"
 check "save/restore OK"               "exception save/dispatch/restore round trips"
 check "boot OK"                       "completes boot without faulting"
@@ -1530,6 +1558,86 @@ fi
 #
 # The JIT, measured against itself.
 #
+#
+# tryboot and the boot watchdog, this side of the firmware.
+#
+# The A/B path is: install the running kernel as tryboot.img, write
+# "tryboot" to /dev/sysctl, and the firmware boots the [tryboot]
+# section of config.txt exactly once -- a different kernel file and a
+# command line carrying the word "tryboot". That word is what makes the
+# kernel arm the boot watchdog in kmain and osinit print the promotion
+# step; "booted" on /dev/sysctl releases the watchdog once the shell is
+# loaded. See os/bcm2837/board.c and the README's "Working on the board
+# without moving the card".
+#
+# What QEMU can and cannot show here is settled by two facts about its
+# model, both read in the source (hw/misc/bcm2835_powermgt.c and
+# bcm2835_property.c, v8.2) and confirmed by the boots below:
+#
+#   - PM_WDOG is stored and never counted down, and a write to PM_RSTC
+#     with the full-reset WRCFG resets the machine on the spot. So a
+#     candidate boot under QEMU prints "wdog: armed" and is reset by
+#     the arming write itself, and boots again, for ever. That is
+#     asserted below as at least two boot banners in eight seconds. It
+#     proves the write reached the PM block with the right password
+#     and bits -- a wrong password is dropped without a reset -- and
+#     nothing about the countdown or the reload from the clock tick,
+#     which only the board can show (README: "wdogtest").
+#
+#   - The property mailbox sets the response bit on every tag, known
+#     or not, so "firmware acknowledged reboot flags" is what the
+#     message round trip looks like and not the firmware's opinion.
+#
+# Because arming under QEMU is a reset, the candidate boot that runs
+# to the shell -- osinit recognising the word, printing the promotion
+# step, and writing "booted" -- is driven with "nowatchdog" on the same
+# command line, which is the word a kernel under a debugger uses. A
+# variant image that skips the release and must reset at the budget
+# would be the natural third check; it is not here because the model
+# has no budget to reach, and a check that cannot fail is not one.
+#
+WDOUT="$(boot_kernel "$BUILD/$PLAT-kernel.img" 8 tryboot)"
+OUT_SAVED="$OUT"; OUT="$WDOUT"
+check "boot: command line: tryboot"  "-append reaches the kernel as the firmware command line"
+check "wdog: armed, 90 s boot budget; a hang resets to config.txt's kernel" \
+      "a candidate boot arms the boot watchdog before the MMU is on"
+nboot="$(grep -c 'InferNode bare-metal' <<<"$WDOUT")"
+if [[ "$nboot" -ge 2 ]]; then
+    pass "the arming write reached the PM block with the password and WRCFG bits (QEMU resets on it: $nboot boots in 8s)"
+else
+    fail "the arming write did not reset QEMU's PM model ($nboot boot banner(s) in 8s)"
+fi
+OUT="$OUT_SAVED"
+
+# 45 seconds: the shell is loaded at about 12s under emulation, and the
+# release line follows it directly; the rest is margin for a busy host.
+CANDOUT="$(boot_kernel "$BUILD/$PLAT-kernel.img" 45 "tryboot nowatchdog")"
+OUT_SAVED="$OUT"; OUT="$CANDOUT"
+check "wdog: not armed (nowatchdog on the command line)" "nowatchdog overrides a candidate's arming"
+check "init: bootargs: tryboot nowatchdog" "osinit reads the command line through #B/bootargs"
+check "init: CANDIDATE kernel: this boot came from the tryboot configuration" "osinit recognises a candidate boot"
+check "init: to keep it:     mv /n/dos/tryboot.img /n/dos/infernode8.img" "osinit prints the promotion step, from a candidate name"
+check "wdog: boot complete; no watchdog was armed" "the candidate's booted handshake reaches the board hook"
+OUT="$OUT_SAVED"
+
+# "tryboot" typed at the shell. The reset is asserted the only way a
+# reset can be from outside: the boot banner appears a second time.
+# shell_session waits up to 30s for a drain marker the reset machine
+# never echoes, which is what gives the second boot time to print.
+TBOUT="$(shell_session "$BUILD/$PLAT-kernel.img" 'echo tryboot > /dev/sysctl')"
+TBOUT="$(tr -d '\r' <<<"$TBOUT")"
+OUT_SAVED="$OUT"; OUT="$TBOUT"
+check "tryboot: resetting; next boot is the CANDIDATE kernel" "tryboot on /dev/sysctl reaches the board's reset path"
+check "tryboot: firmware acknowledged reboot flags 0x1 (tryboot)" \
+      "the reboot-flags tag round-trips the mailbox (the firmware's real answer is a board result)"
+nboot="$(grep -c 'InferNode bare-metal' <<<"$TBOUT")"
+if [[ "$nboot" -ge 2 ]]; then
+    pass "tryboot reset the machine: it booted again ($nboot banners)"
+else
+    fail "tryboot did not reset the machine ($nboot boot banner(s))"
+fi
+OUT="$OUT_SAVED"
+
 # Build a second image differing ONLY by -DCFLAG=0 and compare the same
 # fixed arithmetic loop. Two things are being checked and they are not
 # the same: that compiled code computes the RIGHT ANSWER (the accumulator

--- a/tests/host/baremetal_test.sh
+++ b/tests/host/baremetal_test.sh
@@ -454,6 +454,10 @@ build_kernel() {
             # it -- and a recovery shell that can bind but not unbind is
             # half a tool.
             "/dis/unmount.dis=$ROOT/dis/unmount.dis"
+            # ftest is what boot-baremetal.sh's fail-closed check asks
+            # whether the card and the pins are still there with, and
+            # the namespace session below types that check verbatim.
+            "/dis/ftest.dis=$ROOT/dis/ftest.dis"
             "/dis/mkdir.dis=$ROOT/dis/mkdir.dis"
             "/dis/rm.dis=$ROOT/dis/rm.dis"
             "/dis/cp.dis=$ROOT/dis/cp.dis"
@@ -2250,14 +2254,21 @@ fi
 #     between a desktop program and the raw card is what its namespace
 #     does not contain. lib/lucifer/boot-baremetal.sh builds that
 #     namespace before it starts logon: forks it, unmounts #S and #G
-#     from /dev, and binds /dev/null over /dev/sysctl. This types the
-#     same sequence into a child shell -- the boot script itself needs
-#     a card userspace this kernel image does not carry -- and asserts
-#     both halves: inside, the card, the pins and sysctl are gone; back
-#     outside, the console shell still has every one of them. Both
-#     halves matter. A narrowing that leaked into the parent would take
-#     the management plane's card away, and pass a test that only
-#     looked inside.
+#     from /dev, binds /dev/null over /dev/sysctl and /dev/hostowner,
+#     and refuses the desktop if any of them is still there. This types
+#     those lines -- read out of the script here, not copied into this
+#     file, so that the two cannot drift apart and deleting them from
+#     the script turns these checks red -- into a child shell, and
+#     asserts both halves: inside, the card, the pins and sysctl are
+#     gone and the script's own check says so; back outside, the
+#     console shell still has every one of them. Both halves matter. A
+#     narrowing that leaked into the parent would take the management
+#     plane's card away, and pass a test that only looked inside.
+#
+#     What this does NOT run is the script: it needs the card userspace
+#     (wm/logon, luciuisrv, lucifer) this kernel image does not carry.
+#     The $status handling and the retry loop below the narrowing are
+#     exercised on the hosted emulator against child shells, not here.
 #
 #     "echo halt > /dev/sysctl" inside is the check that means it: were
 #     /dev/sysctl still #c's, the machine would stop there and nothing
@@ -2265,21 +2276,47 @@ fi
 #     the extraction below can tell the command being typed (which
 #     carries the marker word too) from its output.
 #
+#     The outer probe lists the pin's DIRECTORY, /dev/gpio/21, whose
+#     listing names both files; a stat of the leaf itself is a separate
+#     check further down, because until devgpio's gen answered for a
+#     leaf that stat failed on every kernel, narrowed or not, and a
+#     namespace check that trips over it says nothing about namespaces.
+#
 #     The card image is the FAT16 one, attached so that #S has a card
 #     to bind and /dev/sdcard is there to take away.
 #
+BOOTSH="$ROOT/lib/lucifer/boot-baremetal.sh"
+NARROW=()
+while IFS= read -r l; do NARROW+=("$l"); done \
+    < <(sed -n '/^pctl forkns$/,/^bind \/dev\/null \/dev\/hostowner$/p' "$BOOTSH")
+# The check block, from narrowed=1 to the close of the if that refuses
+# the desktop. Leading tabs are dropped: the shell does not need them
+# and the serial line discipline should not be asked about them here.
+NARROWCHK=()
+while IFS= read -r l; do NARROWCHK+=("$l"); done \
+    < <(sed -n '/^narrowed=1$/,/^}$/p' "$BOOTSH" | sed 's/^[[:space:]]*//')
+
+if [[ ${#NARROW[@]} -ge 5 && "${NARROW[0]}" == 'pctl forkns' ]] \
+   && printf '%s\n' "${NARROW[@]}" | grep -q "^unmount '#S' /dev$" \
+   && printf '%s\n' "${NARROW[@]}" | grep -q "^unmount '#G' /dev$" \
+   && printf '%s\n' "${NARROW[@]}" | grep -q '^bind /dev/null /dev/sysctl$' \
+   && [[ ${#NARROWCHK[@]} -ge 6 && "${NARROWCHK[0]}" == 'narrowed=1' ]] \
+   && printf '%s\n' "${NARROWCHK[@]}" | grep -q '^exit$'; then
+    pass "boot-baremetal.sh carries the narrowing (forkns, unmount #S #G, null over sysctl) and a fail-closed check after it"
+else
+    fail "could not read the narrowing or its check out of boot-baremetal.sh (${#NARROW[@]} and ${#NARROWCHK[@]} lines)"
+fi
+
 QEMUARGS="$SAVEDARGS -drive file=$SDIMG,if=sd,format=raw"
 NSOUT="$(shell_session "$BUILD/$PLAT-kernel.img" \
         'path=(/dis .)' \
         'load std' \
         'sh' \
         'load std' \
-        'pctl forkns' \
-        "unmount '#S' /dev" \
-        "unmount '#G' /dev" \
-        'bind /dev/null /dev/sysctl' \
-        'bind /dev/null /dev/hostowner' \
+        "${NARROW[@]}" \
+        "${NARROWCHK[@]}" \
         'echo INNER' \
+        'echo narrowed $narrowed' \
         'ls /dev/sdcard /dev/sdctl /dev/gpio' \
         'v=`{cat /dev/sysctl}; echo inner-sysctl-words $#v' \
         'echo halt > /dev/sysctl' \
@@ -2287,22 +2324,41 @@ NSOUT="$(shell_session "$BUILD/$PLAT-kernel.img" \
         'echo INNER-END' \
         'exit' \
         'echo OUTER' \
-        'ls /dev/sdcard /dev/sdctl /dev/gpio/21/ctl' \
+        'ls /dev/sdcard /dev/sdctl /dev/gpio/21' \
         'v=`{cat /dev/sysctl}; echo outer-sysctl-words $#v' \
-        'echo OUTER-END')"
+        'echo OUTER-END' \
+        'echo LEAF' \
+        'ls /dev/gpio/21/level' \
+        'echo LEAF-END')"
 QEMUARGS="$SAVEDARGS"
-NSOUT="$(tr -d '\r' <<<"$NSOUT")"
+# The prompt is "; " with no newline. A command that takes longer than
+# the typing interval -- the first `{cat ...} in a fresh child shell
+# does, it loads cat -- lets the lines typed after it echo as
+# type-ahead, and the prompts for those lines are then printed just
+# before the output that was waited for, as a prefix on it: the first
+# run of this session saw "; ; inner-still-alive" and "; LEAF", and two
+# checks that the transcript itself showed passing went red on the
+# anchored match. So leading prompt fragments are stripped before any
+# line is matched. An output line never begins with "; ".
+NSOUT="$(tr -d '\r' <<<"$NSOUT" | sed 's/^\(; \)*//')"
 [[ "$VERBOSE" -eq 1 ]] && { echo "  --- namespace ---"; echo "$NSOUT"; }
 
 # Only whole-line markers delimit the sections: the typed command line
 # carries "echo INNER" and is not a match for ^INNER$.
 NSIN="$(sed -n '/^INNER$/,/^INNER-END$/p' <<<"$NSOUT")"
 NSOUTER="$(sed -n '/^OUTER$/,/^OUTER-END$/p' <<<"$NSOUT")"
+NSLEAF="$(sed -n '/^LEAF$/,/^LEAF-END$/p' <<<"$NSOUT")"
 
 if grep -q 'INNER-END' <<<"$NSIN" && grep -q 'OUTER-END' <<<"$NSOUTER"; then
     pass "a child shell forks its namespace, narrows it, exits, and the console shell comes back"
 else
     fail "the narrowed-namespace session did not run to both markers"
+fi
+
+if grep -q '^narrowed 1$' <<<"$NSIN"; then
+    pass "boot-baremetal.sh's own fail-closed check (ftest on the card and the pins, an empty sysctl) passes in the narrowed namespace"
+else
+    fail "the script's narrowed= check did not come out 1 in the narrowed namespace (or its exit fired)"
 fi
 
 if grep -q "/dev/sdcard.*does not exist" <<<"$NSIN" \
@@ -2331,7 +2387,7 @@ else
 fi
 
 if grep -q '^/dev/sdcard$' <<<"$NSOUTER" && grep -q '^/dev/sdctl$' <<<"$NSOUTER" \
-   && grep -q '^/dev/gpio/21/ctl$' <<<"$NSOUTER"; then
+   && grep -q '^/dev/gpio/21/ctl$' <<<"$NSOUTER" && grep -q '^/dev/gpio/21/level$' <<<"$NSOUTER"; then
     pass "the console shell still has /dev/sdcard, /dev/sdctl and the pins after the child narrowed its own"
 else
     fail "the narrowing leaked into the console shell's namespace (card or pins missing outside)"
@@ -2341,6 +2397,20 @@ if grep -q '^outer-sysctl-words [1-9]' <<<"$NSOUTER"; then
     pass "the console shell's /dev/sysctl is still the kernel's"
 else
     fail "the console shell's /dev/sysctl reads empty: the null bind leaked out of the child"
+fi
+
+#
+#     A GPIO leaf file can be stat'ed. devgpio's gen used to answer -1
+#     for every s >= 0 when called on /dev/gpio/N/ctl or /level, so
+#     devstat printed "devstat G <qid>" and raised "file does not
+#     exist" for a file the directory listing showed and reads worked
+#     on -- ls on the leaf, and ftest -e, were the ways to see it.
+#
+if grep -q '^/dev/gpio/21/level$' <<<"$NSLEAF" \
+   && ! grep -q 'devstat G\|does not exist' <<<"$NSLEAF"; then
+    pass "stat of a GPIO leaf file (/dev/gpio/21/level) succeeds"
+else
+    fail "stat of /dev/gpio/21/level failed: devgpio's gen does not answer for a leaf"
 fi
 
 #

--- a/tests/host/dossrv_badent_test.sh
+++ b/tests/host/dossrv_badent_test.sh
@@ -1,0 +1,302 @@
+#!/bin/sh
+# dossrv "badent" alias test (host-side)
+#
+# dossrv names a directory entry it cannot present -- an empty name, a
+# slash, a control character -- badent-<location>, and rm on that alias
+# zaps the entry alone, deliberately leaving its clusters for an offline
+# fsck (a damaged entry's start-cluster word is not to be trusted).
+# rremove used to decide "damaged" by prefix-matching the name it HANDS
+# OUT, so a healthy file that happened to be called badent-1 -- a legal
+# 8.3 name -- was removed by the same path and its clusters were lost.
+#
+# Two things are asserted on the FAT32 image the guest writes, the way
+# fsck would, from the host:
+#
+#   1. A healthy file named badent-1, created and removed through
+#      dossrv, leaves NO allocated cluster unreachable from the root.
+#      (The old dossrv leaves exactly one.)
+#   2. A genuinely damaged entry -- a name with a control character in
+#      it, planted in the image -- is still removed by its alias, with
+#      its cluster deliberately left: the fix must not have made the
+#      damage path go through the ordinary remove.
+#
+# The same fixture runs under QEMU in baremetal_test.sh, which no CI
+# workflow runs; this is the hosted copy so the fix cannot regress
+# silently. Exit 77 = emu or python3 missing.
+
+. "$(dirname "$0")/common.sh"
+
+if [ ! -x "$EMU" ]; then
+    echo "SKIP: emu not found at $EMU"
+    exit 77
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not found"
+    exit 77
+fi
+for d in dossrv rm ls; do
+    if [ ! -f "$ROOT/dis/$d.dis" ]; then
+        echo "SKIP: $ROOT/dis/$d.dis not built"
+        exit 77
+    fi
+done
+
+echo "=== dossrv badent alias test ==="
+
+# The image lives under $ROOT/tmp so the guest sees it as /tmp/...
+mkdir -p "$ROOT/tmp" 2>/dev/null || true
+IMG="$ROOT/tmp/dossrv_badent_test.img"
+GIMG="/tmp/dossrv_badent_test.img"
+SCRIPT="$ROOT/tmp/dossrv_badent_testscript.sh"
+# mount(2) will not create its target, and a checkout has no /n/dos.
+MNT="$ROOT/tmp/dossrv_badent_mnt"
+GMNT="/tmp/dossrv_badent_mnt"
+mkdir -p "$MNT"
+OUT=$(mktemp /tmp/dossrv_badent_test_out.XXXXXX)
+trap 'rm -f "$IMG" "$SCRIPT" "$OUT"; rmdir "$MNT" 2>/dev/null' EXIT
+
+#
+# A 64MB FAT32 partition, the layout baremetal_test.sh puts behind an
+# MBR for the Pi's boot partition -- but bare, with no partition table:
+# under bare metal osinit hands dossrv the partition RANGE, and the MBR
+# scan in dosfs() only knows types 01, 04 and 06, so a whole-disk image
+# with a type-0C partition is "unknown format" to a hosted dossrv -f.
+# Cluster 2 is the root, cluster 3 holds a plain file, cluster 4 belongs
+# to the damaged entry -- name "BAD\x01ENT TXT", which dossrv must alias
+# because the kernel refuses names with control characters at dirread.
+#
+python3 - "$IMG" <<'PYEOF'
+import struct, sys
+
+SEC   = 512
+PSTART = 0               # hidden sectors: none, the image IS the partition
+PSECS  = 131072
+SPC    = 1
+RESV   = 32
+NFAT   = 2
+FATSZ  = 1024
+
+part = bytearray(PSECS * SEC)
+
+bs = bytearray(SEC)
+bs[0:3]   = b"\xEB\x58\x90"
+bs[3:11]  = b"INFRNODE"
+struct.pack_into("<H", bs, 11, SEC)
+bs[13] = SPC
+struct.pack_into("<H", bs, 14, RESV)
+bs[16] = NFAT
+struct.pack_into("<H", bs, 17, 0)      # root entries: zero, FAT32
+struct.pack_into("<H", bs, 19, 0)
+bs[21] = 0xF8
+struct.pack_into("<H", bs, 22, 0)      # 16-bit sectors/FAT: zero, see 36
+struct.pack_into("<H", bs, 24, 32)
+struct.pack_into("<H", bs, 26, 64)
+struct.pack_into("<I", bs, 28, PSTART)
+struct.pack_into("<I", bs, 32, PSECS)
+struct.pack_into("<I", bs, 36, FATSZ)
+struct.pack_into("<H", bs, 40, 0)
+struct.pack_into("<H", bs, 42, 0)
+struct.pack_into("<I", bs, 44, 2)      # root's first cluster
+struct.pack_into("<H", bs, 48, 1)
+struct.pack_into("<H", bs, 50, 6)
+bs[64] = 0x80
+bs[66] = 0x29
+struct.pack_into("<I", bs, 67, 0x32323232)
+bs[71:82] = b"INFR32     "
+bs[82:90] = b"FAT32   "
+bs[510] = 0x55; bs[511] = 0xAA
+part[0:SEC] = bs
+
+CONTENT = b"fat32 works in the hosted emu\n"
+DAMAGED = b"this entry's name is damaged\n"
+
+fat = bytearray(FATSZ * SEC)
+struct.pack_into("<I", fat, 0, 0x0FFFFFF8)
+struct.pack_into("<I", fat, 4, 0x0FFFFFFF)
+struct.pack_into("<I", fat, 8, 0x0FFFFFFF)   # root, one cluster
+struct.pack_into("<I", fat, 12, 0x0FFFFFFF)  # HELLO32.TXT
+struct.pack_into("<I", fat, 16, 0x0FFFFFFF)  # the damaged entry's cluster
+for i in range(NFAT):
+    off = (RESV + i*FATSZ) * SEC
+    part[off:off+len(fat)] = fat
+
+data = (RESV + NFAT*FATSZ) * SEC
+
+def dirent(name, clus, size):
+    d = bytearray(32)
+    d[0:11] = name
+    d[11] = 0x20
+    struct.pack_into("<H", d, 20, clus >> 16)
+    struct.pack_into("<H", d, 26, clus & 0xFFFF)
+    struct.pack_into("<I", d, 28, size)
+    return d
+
+part[data:data+32]    = dirent(b"HELLO32 TXT", 3, len(CONTENT))
+part[data+32:data+64] = dirent(b"BAD\x01ENT TXT", 4, len(DAMAGED))
+
+part[data + (3-2)*SPC*SEC : data + (3-2)*SPC*SEC + len(CONTENT)] = CONTENT
+part[data + (4-2)*SPC*SEC : data + (4-2)*SPC*SEC + len(DAMAGED)] = DAMAGED
+
+open(sys.argv[1], "wb").write(part)
+PYEOF
+
+#
+# dossrv is CALLED, not spawned: it forks its server and mounts before
+# it returns, so the shell that follows sees the mount. The damaged
+# entry is removed by whatever alias dossrv chose for it -- the name
+# encodes the entry's location and is not worth hard-coding -- so the
+# shell globs for it after the healthy badent-1 is already gone.
+#
+cat > "$SCRIPT" <<INFERNO
+load std
+dossrv -f $GIMG -m $GMNT
+ls $GMNT
+cat $GMNT/HELLO32.TXT
+echo cluster-owner > $GMNT/badent-1
+ls -l $GMNT
+rm $GMNT/badent-1
+ls $GMNT
+rm $GMNT/badent-*
+ls $GMNT
+echo '=== SCRIPT DONE ==='
+INFERNO
+
+"$EMU" -r"$ROOT" -c0 sh /tmp/dossrv_badent_testscript.sh > "$OUT" 2>&1 &
+EMU_PID=$!
+# dossrv keeps serving, so emu never self-exits: wait for the marker.
+i=0
+while [ $i -lt 60 ]; do
+    if grep -q '=== SCRIPT DONE ===' "$OUT" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 $EMU_PID 2>/dev/null; then
+        break
+    fi
+    sleep 1
+    i=$((i + 1))
+done
+kill $EMU_PID 2>/dev/null
+wait $EMU_PID 2>/dev/null
+
+if ! grep -q '=== SCRIPT DONE ===' "$OUT"; then
+    echo "FAIL: guest script did not finish"
+    cat "$OUT"
+    exit 1
+fi
+if ! grep -q 'fat32 works in the hosted emu' "$OUT"; then
+    echo "FAIL: dossrv did not mount and read the FAT32 image"
+    cat "$OUT"
+    exit 1
+fi
+if ! grep -q 'badent-[0-9a-f]*$' "$OUT"; then
+    echo "FAIL: the damaged entry was not presented under a badent- alias"
+    cat "$OUT"
+    exit 1
+fi
+
+#
+# The walk: every allocated cluster reachable from the root, except the
+# one the damaged entry owned. Both removals must have happened -- an
+# E5 entry whose remaining bytes spell ADENT is badent-1, one spelling
+# AD\x01ENT is the damaged one -- or a session that never got as far as
+# creating the file would pass for free.
+#
+WALK="$(python3 - "$IMG" <<'PYEOF'
+import struct, sys
+img = open(sys.argv[1], "rb").read()
+SEC = 512
+pstart = 0
+bs = img[0:SEC]
+spc = bs[13]
+resv = struct.unpack_from("<H", bs, 14)[0]
+nfat = bs[16]
+fatsz = struct.unpack_from("<I", bs, 36)[0]
+rootclus = struct.unpack_from("<I", bs, 44)[0]
+fatoff = (pstart + resv) * SEC
+data = (pstart + resv + nfat*fatsz) * SEC
+nclus = fatsz * SEC // 4
+
+def fat(n):
+    return struct.unpack_from("<I", img, fatoff + 4*n)[0] & 0x0FFFFFFF
+
+def chain(n):
+    out = []
+    while 2 <= n < 0x0FFFFFF8 and n not in out and len(out) < nclus:
+        out.append(n)
+        n = fat(n)
+    return out
+
+def cluster(n):
+    off = data + (n-2)*spc*SEC
+    return img[off : off + spc*SEC]
+
+reachable = set()
+deleted_healthy = 0
+deleted_damaged = 0
+live = []
+def walk(start, depth):
+    global deleted_healthy, deleted_damaged
+    for c in chain(start):
+        reachable.add(c)
+        b = cluster(c)
+        for o in range(0, len(b), 32):
+            e = b[o:o+32]
+            if e[0] == 0:
+                return
+            if e[0] == 0xE5:
+                if e[1:6] == b"ADENT":
+                    deleted_healthy += 1
+                if e[1:7] == b"AD\x01ENT":
+                    deleted_damaged += 1
+                continue
+            if e[11] & 0x08:
+                continue
+            if e[0:1] == b".":
+                continue
+            live.append(bytes(e[0:11]))
+            st = (struct.unpack_from("<H", e, 20)[0] << 16) | struct.unpack_from("<H", e, 26)[0]
+            if st >= 2:
+                if e[11] & 0x10 and depth < 8:
+                    walk(st, depth + 1)
+                else:
+                    reachable.update(chain(st))
+
+walk(rootclus, 0)
+allocated = {n for n in range(2, nclus) if fat(n) != 0}
+lost = sorted(allocated - reachable)
+print("DELETED-HEALTHY" if deleted_healthy else "NO-DELETED-HEALTHY")
+print("DELETED-DAMAGED" if deleted_damaged else "NO-DELETED-DAMAGED")
+print("LIVE %s" % " ".join(repr(n) for n in live))
+print("LOST %d %s" % (len(lost), lost))
+PYEOF
+)"
+echo "$WALK"
+
+status=0
+if ! echo "$WALK" | grep -q '^DELETED-HEALTHY$'; then
+    echo "FAIL: badent-1 was not created and removed through dossrv"
+    status=1
+fi
+if ! echo "$WALK" | grep -q '^DELETED-DAMAGED$'; then
+    echo "FAIL: the damaged entry was not removed through its badent- alias"
+    status=1
+fi
+if echo "$WALK" | grep -q "BADENT"; then
+    echo "FAIL: a BADENT entry is still live in the root directory"
+    status=1
+fi
+# Exactly the damaged entry's cluster is left behind, and nothing else:
+# LOST 0 would mean the damage path went through the ordinary remove
+# and trusted a start cluster it must not; LOST 2 is the old bug.
+if ! echo "$WALK" | grep -q '^LOST 1 \[4\]$'; then
+    echo "FAIL: expected exactly cluster 4 (the damaged entry's) left allocated, got: $(echo "$WALK" | grep '^LOST')"
+    status=1
+fi
+
+if [ $status -ne 0 ]; then
+    echo "--- guest output ---"
+    cat "$OUT"
+    exit 1
+fi
+echo "PASS: a healthy badent-1 frees its clusters; a damaged entry is zapped and its cluster left"
+exit 0

--- a/tests/host/iproute_test.sh
+++ b/tests/host/iproute_test.sh
@@ -4,7 +4,7 @@
 #
 # Guard os/ip/iproute.c's route-range arithmetic against LP64.
 #
-# WHY THIS TEST EXISTS BEFORE THE PORT DOES
+# WHY THIS TEST WAS WRITTEN BEFORE iproute.c WAS COMPILED
 #
 # iproute.c is the one file in os/ip with a silent-wrong-answer failure
 # mode. A route table that returns the wrong route does not crash and

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -35,6 +35,7 @@ TARG=\
 	editor_test.dis\
 	example_test.dis\
 	factotum_test.dis\
+	fdclose_test.dis\
 	font_format_test.dis\
 	git_test.dis\
 	goroutine_leak_test.dis\

--- a/tools/dis-manifest.txt
+++ b/tools/dis-manifest.txt
@@ -177,6 +177,7 @@ dis/disk/mkext.dis
 dis/disk/mkfs.dis
 dis/disk/pedit.dis
 dis/disk/prep.dis
+dis/dossrv.dis
 dis/du.dis
 dis/echo.dis
 dis/ed.dis

--- a/tools/dis-manifest.txt
+++ b/tools/dis-manifest.txt
@@ -679,6 +679,7 @@ dis/tests/ethcrypto_test.dis
 dis/tests/ethrpc_conv_test.dis
 dis/tests/example_test.dis
 dis/tests/factotum_test.dis
+dis/tests/fdclose_test.dis
 dis/tests/font_format_test.dis
 dis/tests/fractal_tool_test.dis
 dis/tests/geomap_test.dis


### PR DESCRIPTION
## Summary

This is the completion of the bare-metal AArch64 kernel for the Raspberry Pi 3B+. The system now boots from SD card to a Tk login screen on HDMI with USB keyboard and mouse, wired Ethernet configured by DHCP, a writable `/usr` on the card, secstore-backed keys, and the Lucifer desktop. All four cores schedule. The Dis JIT runs at 27× the interpreter with bit-identical results. Everything has been exercised on real hardware except where explicitly noted.

## Changes

**Kernel (os/arm64 + os/bcm2837):**
- Boot watchdog mechanism: arming before a candidate kernel boots, disarming once the shell is ready, with "tryboot" command-line flag to mark candidate boots and "nowatchdog" to skip the guard
- Command-line parsing and publication via `#B/bootargs` for osinit to read
- SMP fixes: per-core clock initialization (secclockinit), per-core Timer queue servicing, preemption guards
- Mailbox mutex redesign: held across the entire buffer exchange (not just post-and-wait), taken with interrupts off to handle panic/interrupt context re-entry
- UART lock improvements: recognizes same-core re-entry, prevents lock release by timed-out waiters
- Atomic increment primitive (ainc) for lock-free counters
- GPIO pin enumeration as files (`#G`)
- SD card as a file (`#S`), running kernel image as a file (`#B/bootimage`)
- Microsecond timer (`#b`), framebuffer console (fbcons), draw device (`#i`), pointer (`#m`), keyboard on `/dev/keyboard`
- SSL device (`#D`), hardware-fed entropy pool, tick-driven sampling profiler
- Full os/ip stack (ARP, ICMP, TCP, UDP, routing) as `#I`
- Ethernet data path in kernel (~2.6 MB/s in, ~4 MB/s out) bound to endpoints a Limbo driver sets up
- USB DWC OTG host stack with split transactions, single-shot bulk transfers, hot-plug/unplug

**Userspace (os/init + card):**
- osinit: USB bus walk, hub watcher, SD mount, rootpath policy, `/usr` binding
- etherusb: RNDIS for QEMU, LAN78xx with PHY autonegotiation for board, DHCP, `#l` handoff
- kbdusb, mouseusb: USB keyboard and mouse drivers
- dossrv: FAT32 filesystem server with fixes for damaged entries (badent alias)
- auth/secstored: key storage
- wm/logon: Tk login form with three exit states (logged in, skipped, failed)
- luciuisrv and lucifer: desktop environment

**Testing & CI:**
- baremetal_test.sh: now boots only raspi3b (virt machine removed from tree), covers 194 checks including framebuffer pixels via QMP, USB hotplug, TCP echo, DHCP, kernel image round-trip
- New fdclose_test.dis: validates that dropping FD references closes them synchronously in the JIT (caught a MacFRP bug)
- New dossrv_badent_test.sh: validates dossrv's damaged-entry handling does not delete healthy files with similar names
- CI job added for dossrv badent check

**Documentation:**
- os/bcm2837/README.md: completely rewritten to reflect working system, boot watchdog design, tryboot A/B mechanism, known divergences from QEMU, real-hardware bring-up recipe
- baremetal_test.sh: updated comments to reflect single-machine focus and expanded test coverage
- JIT.md: added "Open faults" section for known unreproduced issues
- boot-baremetal.sh: namespace narrowing for desktop (removes raw card, pins, sysctl from non-eve processes)
- boot.sh: logon exit status contract documented
- Various code comments expanded (mailbox, uart, clock,

https://claude.ai/code/session_01KSuBrMfpEnkLtWx3iBA734