### PR TITLE
fix(build): sync generated MREADONLY constant

### DIFF
--- a/libinterp/keyringif.h
+++ b/libinterp/keyringif.h
@@ -717,6 +717,7 @@ struct F_Sys_wstat
 #define Sys_MBEFORE 1
 #define Sys_MAFTER 2
 #define Sys_MCREATE 4
+#define Sys_MREADONLY 8
 #define Sys_MCACHE 16
 #define Sys_NEWFD 1
 #define Sys_FORKFD 2


### PR DESCRIPTION
## Motivation\n\nPR #591 added Sys.MREADONLY to module/sys.m, but did not update the tracked generated libinterp/keyringif.h. A clean build consequently modifies a tracked file, making git-verifiable campaign provenance impossible.\n\n## Change\n\nAdd the generated Sys_MREADONLY constant to keyringif.h.\n\n## Verification\n\n- git diff --check\n- clean Linux amd64 headless build demonstrated that this is the sole generated delta\n\nRefs INFR-456.