### PR TITLE
fix(codex-gate): stage fresh OAuth homes (INFR-462)

### DIFF
--- a/docs/CODEX-GATE.md
+++ b/docs/CODEX-GATE.md
@@ -160,7 +160,7 @@ Config (env, read at start):
 | `CODEX_GATE_QUOTA_RESET_GRACE` | `30` | grace after a minute-precision reset time before retrying |
 | `CODEX_GATE_SANDBOX` | `read-only` | `--sandbox` value |
 | `CODEX_GATE_WORKDIR` | `~/.cache/codex-gate/workdir` | `--cd` value |
-| `CODEX_GATE_CODEX_HOME` | *(unset)* | `CODEX_HOME` for the child, to isolate `~/.codex` (you must copy `auth.json` in yourself) |
+| `CODEX_GATE_CODEX_HOME` | *(unset)* | `CODEX_HOME` for the child; use `--prepare-home` for an isolated campaign |
 | `CODEX_GATE_EXEC_ARGS` | *(empty)* | extra args appended to every `codex exec` |
 | `CODEX_GATE_PROMPT_ARGV` | *(unset)* | `1` = pass the prompt as argv instead of stdin |
 | `CODEX_GATE_HARDEN` | `1` | pin the CLI feature surface (see below); `0` disables the pinning but never the adapter's own `--disable shell_tool` |
@@ -168,6 +168,30 @@ Config (env, read at start):
 | `CODEX_GATE_HOME_ALLOW` | `auth.json,auth.json.lock,version.json,installation_id` | what the isolated Codex home may contain at startup |
 | `CODEX_GATE_MOCK`, `CODEX_GATE_DEBUG` | — | test backend, verbose logs |
 | `CODEX_GATE_MOCK_ERROR_SYSTEM_MATCH` | *(empty)* | mock-only fault selector; inject the configured mock error only when the system prompt contains this exact text |
+
+For an isolated campaign, never reuse a previous campaign's OAuth file. Create
+a fresh login source and hand only its newly issued credential to a new gateway
+home:
+
+```sh
+login_home=$(mktemp -d "${TMPDIR:-/tmp}/codex-login.XXXXXX")
+campaign_home="${TMPDIR:-/tmp}/codex-campaign-$(date -u +%Y%m%dT%H%M%SZ)"
+chmod 700 "$login_home"
+CODEX_HOME="$login_home" codex login --device-auth
+tools/codex-gate/serve-codex-gate.sh \
+  --prepare-home "$login_home" "$campaign_home"
+CODEX_GATE_CODEX_HOME="$campaign_home" \
+  tools/codex-gate/serve-codex-gate.sh
+```
+
+Current Codex releases may create `log/` and `tmp/` during login. The handoff
+accepts those only in the private login source and copies only a non-empty,
+regular, mode-0600 `auth.json` into a newly created mode-0700 destination. It
+rejects an existing destination, symlinks, configuration, plugins, skills, and
+other inherited state. The login source is left untouched: retain it privately
+until the campaign is over, log out using the active campaign home, then remove
+both credential directories. Do not archive either directory with evidence;
+use `--inventory` to record hashes and metadata only.
 
 ## Pinned CLI surface
 

--- a/tests/host/codex_gate_test.sh
+++ b/tests/host/codex_gate_test.sh
@@ -553,6 +553,81 @@ with tempfile.TemporaryDirectory() as td:
     assert any("credentials" in v for v in violations), violations
     os.chmod(home, 0o700)
 
+    # A current device login creates log/ and tmp/ before the first gateway
+    # request. The canonical handoff copies only its private OAuth credential
+    # into a new home; it never broadens the gateway startup allowlist.
+    login = os.path.join(td, "fresh-login")
+    campaign = os.path.join(td, "campaign-home")
+    os.mkdir(login, 0o700)
+    auth = os.path.join(login, "auth.json")
+    with open(auth, "w") as f:
+        f.write("fresh-oauth-state")
+    os.chmod(auth, 0o600)
+    os.mkdir(os.path.join(login, "log"), 0o700)
+    os.mkdir(os.path.join(login, "tmp"), 0o700)
+    open(os.path.join(login, "version.json"), "w").write("{}")
+    prepared = m.prepare_codex_home(login, campaign)
+    assert prepared == campaign
+    assert sorted(os.listdir(campaign)) == ["auth.json"]
+    assert open(os.path.join(campaign, "auth.json")).read() == \
+        "fresh-oauth-state"
+    assert os.stat(campaign).st_mode & 0o777 == 0o700
+    assert os.stat(os.path.join(campaign, "auth.json")).st_mode & 0o777 == 0o600
+    assert m.codex_home_violations(campaign, m.home_allowlist()) == []
+    assert os.path.isdir(os.path.join(login, "log"))
+
+    try:
+        m.prepare_codex_home(login, campaign)
+    except SystemExit as e:
+        assert "already exists" in str(e), e
+    else:
+        raise AssertionError("existing campaign home was replaced")
+
+    config = os.path.join(login, "config.toml")
+    open(config, "w").write("untrusted = true")
+    try:
+        m.prepare_codex_home(login, os.path.join(td, "with-config"))
+    except SystemExit as e:
+        assert "unsanctioned state" in str(e), e
+    else:
+        raise AssertionError("login source configuration was accepted")
+    os.unlink(config)
+
+    os.chmod(auth, 0o644)
+    try:
+        m.prepare_codex_home(login, os.path.join(td, "public-auth"))
+    except SystemExit as e:
+        assert "mode 0600" in str(e), e
+    else:
+        raise AssertionError("public OAuth credential was accepted")
+    os.chmod(auth, 0o600)
+
+    symlink_login = os.path.join(td, "symlink-login")
+    os.mkdir(symlink_login, 0o700)
+    os.symlink(auth, os.path.join(symlink_login, "auth.json"))
+    try:
+        m.prepare_codex_home(symlink_login, os.path.join(td, "symlink-auth"))
+    except SystemExit as e:
+        assert "symlink" in str(e), e
+    else:
+        raise AssertionError("symlinked OAuth credential was accepted")
+
+    try:
+        m.prepare_codex_home(login, os.path.join(login, "nested-campaign"))
+    except SystemExit as e:
+        assert "must not be inside" in str(e), e
+    else:
+        raise AssertionError("campaign home inside login source was accepted")
+
+    os.chmod(login, 0o755)
+    try:
+        m.prepare_codex_home(login, os.path.join(td, "public-login"))
+    except SystemExit as e:
+        assert "mode 0700" in str(e), e
+    else:
+        raise AssertionError("public login source was accepted")
+    os.chmod(login, 0o700)
+
     # The post-campaign inventory accounts for what the CLI created itself.
     os.makedirs(os.path.join(home, "plugins", "cache"))
     open(os.path.join(home, "plugins", "cache", "catalog.json"), "w").write("[]")

--- a/tools/codex-gate/codex_gate.py
+++ b/tools/codex-gate/codex_gate.py
@@ -74,8 +74,9 @@
 #   CODEX_GATE_DISABLE_FEATURES  comma list replacing the pinned disable set
 #   CODEX_GATE_HOME_ALLOW comma list of entries allowed in CODEX_GATE_CODEX_HOME
 #
-# Also: `codex_gate.py --inventory [CODEX_HOME]` prints a hashed inventory of
-# the model-side state the CLI created, and exits.  Run it after a campaign.
+# Maintenance modes:
+#   --inventory [CODEX_HOME]              hash model-side state and exit
+#   --prepare-home LOGIN_HOME CAMPAIGN_HOME copy only fresh OAuth state
 #
 # Billing guard: OPENAI_API_KEY in the environment can make the CLI bill the
 # API instead of the ChatGPT plan.  serve-codex-gate.sh unsets it; we also
@@ -90,6 +91,7 @@ import os
 import re
 import shlex
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -217,6 +219,11 @@ DEFAULT_DISABLED_FEATURES = (
 DEFAULT_HOME_ALLOW = ("auth.json", "auth.json.lock", "version.json",
                       "installation_id")
 
+# A fresh device login may create these operational directories before the
+# gateway ever runs. They are acceptable only as input to --prepare-home and
+# are never copied into the campaign home.
+LOGIN_SOURCE_ALLOW = frozenset(DEFAULT_HOME_ALLOW + ("log", "tmp"))
+
 
 def disabled_features():
     """The features every `codex exec` turns off.
@@ -268,6 +275,123 @@ def codex_home_violations(home, allow):
         kind = "directory" if os.path.isdir(os.path.join(home, name)) else "file"
         violations.append("unexpected %s %r" % (kind, name))
     return violations
+
+
+def prepare_codex_home(source, destination):
+    """Copy only fresh OAuth state into a new, private gateway home.
+
+    The login source remains untouched.  Refusing an existing destination is
+    deliberate: replacing or merging OAuth state can resurrect a rotated
+    refresh token or carry model-side state between campaigns.
+    """
+    source = os.path.abspath(os.path.expanduser(source))
+    destination = os.path.abspath(os.path.expanduser(destination))
+    if source == destination:
+        raise SystemExit("codex-gate: login source and campaign home are the same")
+    if os.path.commonpath((os.path.realpath(source),
+                           os.path.realpath(destination))) == os.path.realpath(source):
+        raise SystemExit("codex-gate: campaign home must not be inside login source")
+
+    try:
+        source_stat = os.lstat(source)
+    except OSError as e:
+        raise SystemExit("codex-gate: cannot inspect login source: %s" % e)
+    if not stat.S_ISDIR(source_stat.st_mode):
+        raise SystemExit("codex-gate: login source must be a real directory")
+    if stat.S_IMODE(source_stat.st_mode) != 0o700:
+        raise SystemExit("codex-gate: login source holds credentials and must be mode 0700")
+    if hasattr(os, "geteuid") and source_stat.st_uid != os.geteuid():
+        raise SystemExit("codex-gate: login source is not owned by this user")
+
+    try:
+        names = set(os.listdir(source))
+    except OSError as e:
+        raise SystemExit("codex-gate: cannot read login source: %s" % e)
+    unexpected = sorted(names - LOGIN_SOURCE_ALLOW)
+    if unexpected:
+        raise SystemExit(
+            "codex-gate: login source contains unsanctioned state: %s"
+            % ", ".join(repr(name) for name in unexpected))
+    if "auth.json" not in names:
+        raise SystemExit("codex-gate: login source has no auth.json")
+    for name in sorted(names):
+        path = os.path.join(source, name)
+        try:
+            entry_stat = os.lstat(path)
+        except OSError as e:
+            raise SystemExit("codex-gate: cannot inspect login source entry: %s" % e)
+        if stat.S_ISLNK(entry_stat.st_mode):
+            raise SystemExit("codex-gate: login source entry %r is a symlink" % name)
+        if name in ("log", "tmp"):
+            valid = stat.S_ISDIR(entry_stat.st_mode)
+        else:
+            valid = stat.S_ISREG(entry_stat.st_mode)
+        if not valid:
+            raise SystemExit("codex-gate: login source entry %r has wrong type" % name)
+
+    auth_path = os.path.join(source, "auth.json")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        auth_fd = os.open(auth_path, os.O_RDONLY | nofollow)
+    except OSError as e:
+        raise SystemExit("codex-gate: cannot open login auth.json safely: %s" % e)
+    try:
+        auth_stat = os.fstat(auth_fd)
+        if not stat.S_ISREG(auth_stat.st_mode) or auth_stat.st_size == 0:
+            raise SystemExit("codex-gate: login auth.json must be a non-empty regular file")
+        if stat.S_IMODE(auth_stat.st_mode) != 0o600:
+            raise SystemExit("codex-gate: login auth.json must be mode 0600")
+        if hasattr(os, "geteuid") and auth_stat.st_uid != os.geteuid():
+            raise SystemExit("codex-gate: login auth.json is not owned by this user")
+
+        try:
+            os.mkdir(destination, 0o700)
+        except FileExistsError:
+            raise SystemExit(
+                "codex-gate: campaign home already exists; use a new path")
+        except OSError as e:
+            raise SystemExit("codex-gate: cannot create campaign home: %s" % e)
+
+        tmp_name = ".auth.json.tmp-%d" % os.getpid()
+        tmp_path = os.path.join(destination, tmp_name)
+        try:
+            out_fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL |
+                             nofollow, 0o600)
+            try:
+                while True:
+                    chunk = os.read(auth_fd, 1 << 20)
+                    if not chunk:
+                        break
+                    view = memoryview(chunk)
+                    while view:
+                        written = os.write(out_fd, view)
+                        if written <= 0:
+                            raise OSError("short write preparing campaign home")
+                        view = view[written:]
+                os.fsync(out_fd)
+            finally:
+                os.close(out_fd)
+            os.replace(tmp_path, os.path.join(destination, "auth.json"))
+            dir_fd = os.open(destination, os.O_RDONLY |
+                             getattr(os, "O_DIRECTORY", 0))
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            try:
+                os.rmdir(destination)
+            except OSError:
+                pass
+            raise
+    finally:
+        os.close(auth_fd)
+
+    return destination
 
 
 def file_sha256(path):
@@ -1285,6 +1409,14 @@ def main():
                 os.environ.get("CODEX_HOME") or
                 os.path.expanduser("~/.codex"))
         print(json.dumps(codex_home_inventory(home), indent=2))
+        return
+
+    if argv and argv[0] == "--prepare-home":
+        if len(argv) != 3:
+            raise SystemExit(
+                "usage: codex_gate.py --prepare-home LOGIN_HOME CAMPAIGN_HOME")
+        destination = prepare_codex_home(argv[1], argv[2])
+        print("codex-gate: prepared auth-only CODEX_HOME at %s" % destination)
         return
 
     if os.environ.get("OPENAI_API_KEY") and not MOCK \

--- a/tools/codex-gate/serve-codex-gate.sh
+++ b/tools/codex-gate/serve-codex-gate.sh
@@ -10,10 +10,11 @@
 #   serve-codex-gate.sh              # 127.0.0.1:11436, codex CLI backend
 #   serve-codex-gate.sh --mock       # deterministic mock backend (tests)
 #   serve-codex-gate.sh --inventory  # hash the CLI's model-side state, exit
+#   serve-codex-gate.sh --prepare-home LOGIN_HOME CAMPAIGN_HOME
 #   serve-codex-gate.sh --help
 #
-# Auth: the Codex CLI's own login is used — run `codex login` once for this
-# user (ChatGPT sign-in). The gate never handles credentials itself.
+# Auth: the Codex CLI's own login is used. For an isolated campaign, run login
+# in a fresh home, then use --prepare-home to copy only its OAuth credential.
 
 set -euo pipefail
 
@@ -21,7 +22,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 VENV="$HERE/.venv"
 
 print_help() {
-	sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 case "${1:-}" in
@@ -48,6 +49,5 @@ fi
 # Billing guard: an inherited API key can override ChatGPT auth in the CLI.
 unset OPENAI_API_KEY
 
-# Remaining arguments (--inventory [HOME]) go to the gate; the server mode
-# takes none.
+# Remaining maintenance arguments go to the gate; the server mode takes none.
 exec "$VENV/bin/python" "$HERE/codex_gate.py" "$@"


### PR DESCRIPTION
## Motivation
A fresh Codex device login creates operational state that correctly fails the gateway strict home allowlist. Reusing or manually copying an older auth file risks rotated-token failures during a campaign.

## Changes
- add --prepare-home LOGIN_HOME CAMPAIGN_HOME
- validate private ownership, exact modes, entry types, and a non-empty regular OAuth file
- reject symlinks, inherited configuration, nested or existing destinations
- atomically copy only auth.json into a new private campaign home
- document the credential lifecycle and evidence boundary

## Validation
- ./tests/host/codex_gate_test.sh: PASS
- Python bytecode compilation: PASS
- git diff --check: PASS

The full host suite was not used as a signal in the clean macOS worktree because its emulator build products are absent.