### PR TITLE
fix(codex-gate): return quota control to callers (INFR-466)

### DIFF
--- a/docs/CODEX-GATE.md
+++ b/docs/CODEX-GATE.md
@@ -62,10 +62,9 @@ and no `CODEX_GATE_HOLD_TIMEOUT`; the
 price is that no CLI session spans a tool round-trip — each request is one
 `codex exec` with the transcript replayed. `/health` still reports
 `held_turns` for surface parity with claude-gate; it is always 0. This does
-not mean `CODEX_HOME` is stateless: the CLI writes operational files there
-even when each invocation uses `--ephemeral`. An in-flight HTTP request,
-including a quota-paused one, is also not durable across a gateway restart;
-the caller must retry it.
+not mean `CODEX_HOME` is stateless: the CLI may write operational files there
+even when each invocation uses `--ephemeral`. An in-flight HTTP request is not
+durable across a gateway restart; the caller must retry it.
 
 A reply that isn't the agreed JSON object is treated as plain content rather
 than an error — degraded, never fatal.
@@ -88,10 +87,7 @@ All endpoints bind `127.0.0.1` only.
  "hardened": true, "codex_version": "codex-cli 0.149.0",
  "sandbox": "read-only", "exec_flags": ["--sandbox", "read-only", "..."],
  "disabled_features": ["plugins", "..."], "features_sha256": "…",
- "adapter_instructions_sha256": "…",
- "codex_home_baseline": {"files": 1, "bytes": 4156, "sha256": "…"},
- "codex_home_current": {"files": 72, "persistent_cli_state_files": 71,
-                         "persistent_cli_state": true, "sha256": "…"}}
+ "adapter_instructions_sha256": "…"}
 ```
 
 - `status` — `"ok"` if the daemon is serving. Non-mock startup first runs
@@ -103,17 +99,12 @@ All endpoints bind `127.0.0.1` only.
 - `held_turns` — always 0 here (see above); present so monitoring can treat
   both gates alike.
 - `turn_timeout_seconds` / `idle_timeout_seconds` — the total and no-output
-  deadlines applied to each Codex process. Escape-room preflight rejects a
-  gateway whose idle deadline is disabled or exceeds the campaign maximum.
+  deadlines applied to each Codex process.
 - `stateless` / `session_stateless` — the HTTP and CLI session contract only.
   They make no claim that the isolated Codex home remains empty.
 - `hardened`, `codex_version`, `exec_flags`, `disabled_features`,
-  `features_sha256`, `adapter_instructions_sha256`, `codex_home_baseline` —
-  the pinned CLI surface (see below). The external
-  [escape-room harness](https://github.com/infernode-os/infernode-escape-room)
-  copies these into a campaign's `manifest.json` and a scenario file can
-  require them, so a containment result names the gateway configuration it was
-  measured under.
+  `features_sha256`, `adapter_instructions_sha256` — the pinned CLI surface
+  available to operators and monitoring (see below).
 
 ## Lifecycle & startup
 
@@ -154,10 +145,7 @@ Config (env, read at start):
 | `CODEX_GATE_IDLE_TIMEOUT` | `300` | seconds a `codex exec` may produce no stdout/stderr before its process group is killed; `0` disables this deadline |
 | `CODEX_GATE_HEARTBEAT` | `30` | seconds between protocol-valid SSE comments while `codex exec` is still running; keep below the caller's no-progress timeout |
 | `CODEX_GATE_CONCURRENCY` | `4` | max simultaneous codex processes |
-| `CODEX_GATE_QUOTA_MAX_WAIT` | `21600` | maximum seconds to preserve and retry a usage-limit-paused request; `0` returns a structured 429 immediately |
-| `CODEX_GATE_QUOTA_BACKOFF` | `30` | initial retry delay when Codex provides no reset time |
-| `CODEX_GATE_QUOTA_MAX_BACKOFF` | `900` | maximum fallback retry delay |
-| `CODEX_GATE_QUOTA_RESET_GRACE` | `30` | grace after a minute-precision reset time before retrying |
+| `CODEX_GATE_QUOTA_RESET_GRACE` | `30` | grace added to a minute-precision reset time reported to callers |
 | `CODEX_GATE_SANDBOX` | `read-only` | `--sandbox` value |
 | `CODEX_GATE_WORKDIR` | `~/.cache/codex-gate/workdir` | `--cd` value |
 | `CODEX_GATE_CODEX_HOME` | *(unset)* | `CODEX_HOME` for the child, to isolate `~/.codex` (you must copy `auth.json` in yourself) |
@@ -167,20 +155,13 @@ Config (env, read at start):
 | `CODEX_GATE_DISABLE_FEATURES` | *(unset)* | comma list replacing the pinned disable set |
 | `CODEX_GATE_HOME_ALLOW` | `auth.json,auth.json.lock,version.json,installation_id` | what the isolated Codex home may contain at startup |
 | `CODEX_GATE_MOCK`, `CODEX_GATE_DEBUG` | — | test backend, verbose logs |
-| `CODEX_GATE_MOCK_ERROR_SYSTEM_MATCH` | *(empty)* | mock-only fault selector; inject the configured mock error only when the system prompt contains this exact text |
 
 ## Pinned CLI surface
 
-The Codex CLI is an agent harness with a life of its own. During the
-escape-room campaign it populated a fresh 0700 `CODEX_HOME` — created with
-nothing in it but `auth.json` — with 144 plugin-cache files (~26 MiB,
-including the remote curated catalog), 60 system-skill files and a shell
-snapshot. Nothing escaped: the CLI ran `--sandbox read-only`, with its native
-shell disabled, in an empty working directory, on a machine with no access to
-the system under test. But the model was carrying tools and instructions that
-no run record named, and the next run would carry different ones.
-
-So the gate pins the surface rather than inheriting it (INFR-413). Every
+The Codex CLI is an agent harness with a life of its own. It can discover
+plugins, skills, configuration, and host tools that are outside this adapter's
+virtual-tool protocol. The gate therefore pins the surface rather than
+inheriting installed defaults (INFR-413). Every
 `codex exec` gets:
 
 - `--ephemeral`, so no resumable Codex session spans requests; the CLI may
@@ -199,23 +180,12 @@ instead of quietly running without it. At startup the gate asks
 both validates every pinned name against the installed build and produces the
 hash reported on `/health`.
 
-If `CODEX_GATE_CODEX_HOME` is set, the gate inventories it **before**
-authenticating through it and refuses to serve when it holds anything outside
+If `CODEX_GATE_CODEX_HOME` is set, the gate checks it **before** authenticating
+through it and refuses to serve when it holds anything outside
 the allowlist — a `config.toml`, an `AGENTS.md`, an `mcp.json`, a `plugins/`
 or `skills/` directory — or when the directory itself is group- or
 world-accessible. The check runs once at startup because the CLI fills the
-directory in itself as soon as the first request arrives.
-
-After a campaign, account for what it created:
-
-```sh
-tools/codex-gate/serve-codex-gate.sh --inventory    # or: --inventory PATH
-```
-
-That prints every file under the Codex home with its size, mode and SHA-256,
-separate credential and persistent-state counts, and one digest over the whole
-listing. `/health` exposes the same current summary without file names, and
-the campaign runner saves its final value as `gateway-final.json`.
+directory itself as soon as the first request arrives.
 
 ## Setup (pointing InferNode at it)
 
@@ -256,27 +226,12 @@ codex` report on it.
 ## Billing — read this once
 
 Headless CLI usage draws on the account the CLI is logged into. On a ChatGPT
-plan that means the plan's Codex usage allowance; when it is exhausted the
-gate keeps the affected HTTP request open, releases its Codex process slot,
-and retries without advancing the caller's transcript. `/health` reports
-`state=paused_quota` plus safe retry timing while this is happening. The gate
-does not meter usage. All consumers of one gate share one allowance and one
-auth identity.
-
-This is not `codex exec resume`. `llmsrv` and Veltro own the durable transcript,
-tool results, and activity tree; the gate still starts a fresh ephemeral
-`codex exec` for every attempt. A retry replays the same unchanged request.
-Set `CODEX_GATE_QUOTA_MAX_WAIT=0` when an operator prefers an immediate,
-machine-readable HTTP 429 instead of waiting.
-
-After resetting account quota manually, send `SIGHUP` to the gateway process.
-It immediately retries every quota-paused request with its original, unchanged
-HTTP body; a still-exhausted account returns the request to bounded backoff.
-For a systemd user service:
-
-```sh
-systemctl --user kill --kill-whom=main -s HUP codex-gate
-```
+plan that means the plan's Codex usage allowance. When it is exhausted the gate
+returns a machine-readable HTTP 429 with `type=usage_limit`, `retryable=true`,
+and safe reset timing when the CLI supplied it. The gate does not meter usage
+or retain and retry requests. Callers that need durable retry own that policy
+and their transcript state. All consumers of one gate share one allowance and
+one auth identity.
 
 **OPENAI_API_KEY can silently outrank ChatGPT auth in the CLI**, billing the
 API instead of the plan. The serve script unsets it, and the gate refuses to
@@ -331,9 +286,9 @@ deliberately).
 
 `codex_gate_test.sh` bills nothing. When a `codex` CLI is on `PATH` it also
 checks every pinned feature name against that build — `codex features list`
-evaluates local configuration only — so a renamed flag is caught before a
-campaign runs with the feature quietly back on. Without a CLI that one check
-is skipped and the rest still runs.
+evaluates local configuration only — so a renamed flag cannot quietly turn a
+disabled feature back on. Without a CLI that one check is skipped and the rest
+still runs.
 
 Live end-to-end (needs a logged-in CLI; uses your plan's allowance): start
 the gate, then inside emu `llmsrv -b openai -u http://127.0.0.1:11436/v1`

--- a/tests/host/codex_gate_test.sh
+++ b/tests/host/codex_gate_test.sh
@@ -195,7 +195,6 @@ pass "cancelled streams reap codex exec"
 ERROR_PORT=$((PORT+1))
 CODEX_GATE_MOCK=1 \
 CODEX_GATE_MOCK_ERROR='usage limit reached; retry after reset' \
-CODEX_GATE_QUOTA_MAX_WAIT=0 \
 CODEX_GATE_PORT=$ERROR_PORT python3 "$GATE" >/dev/null 2>&1 &
 ERROR_PID=$!
 ERROR_BODY="$(mktemp "${TMPDIR:-/tmp}/codex-gate-error.XXXXXX")"
@@ -230,122 +229,6 @@ if echo "$stream_error" | grep -q '"content"'; then
     fail "streaming quota failure was emitted as assistant content"
 fi
 pass "streaming usage-limit error is not assistant content"
-
-# 8. A transient limit pauses and retries the exact request. While sleeping,
-#    /health exposes machine-readable state; the successful response contains
-#    no quota text and requires no client-side transcript mutation.
-RECOVER_PORT=$((PORT+3))
-RECOVER_BODY="$(mktemp "${TMPDIR:-/tmp}/codex-gate-recover.XXXXXX")"
-CODEX_GATE_MOCK=1 \
-CODEX_GATE_MOCK_ERROR='usage limit reached; try again in 1 second' \
-CODEX_GATE_MOCK_ERROR_COUNT=1 \
-CODEX_GATE_QUOTA_BACKOFF=0.05 \
-CODEX_GATE_QUOTA_MAX_WAIT=5 \
-CODEX_GATE_PORT=$RECOVER_PORT python3 "$GATE" >/dev/null 2>&1 &
-RECOVER_PID=$!
-trap 'kill $GATE_PID $ERROR_PID $RECOVER_PID 2>/dev/null || true; rm -f "$ERROR_BODY" "$RECOVER_BODY"' EXIT
-i=0
-while ! curl -sf -m 1 "http://127.0.0.1:$RECOVER_PORT/health" >/dev/null 2>&1; do
-    i=$((i+1))
-    [ $i -lt 30 ] || fail "recovery gate did not come up on :$RECOVER_PORT"
-    sleep 0.2
-done
-curl -sf "http://127.0.0.1:$RECOVER_PORT/v1/chat/completions" \
-    -H 'Content-Type: application/json' \
-    -d '{"model":"default","messages":[{"role":"user","content":"resume me"}]}' \
-    >"$RECOVER_BODY" &
-RECOVER_CURL_PID=$!
-sleep 0.2
-out="$(curl -sf "http://127.0.0.1:$RECOVER_PORT/health")"
-echo "$out" | grep -q '"state": "paused_quota"' || \
-    fail "gateway did not expose quota pause ($out)"
-echo "$out" | grep -q '"paused_turns": 1' || \
-    fail "gateway did not count paused turn ($out)"
-wait "$RECOVER_CURL_PID"
-grep -q 'MOCK_REPLY: resume me' "$RECOVER_BODY" || \
-    fail "paused request did not resume"
-if grep -qi 'usage limit' "$RECOVER_BODY"; then
-    fail "quota text was returned as model output"
-fi
-out="$(curl -sf "http://127.0.0.1:$RECOVER_PORT/health")"
-echo "$out" | grep -q '"state": "ready"' || fail "gateway did not return to ready"
-echo "$out" | grep -q '"state": "resumed"' || fail "gateway lost resume evidence"
-pass "usage-limit pause resumes the same request"
-
-python3 - "$ROOT" <<'PY' || fail "bounded quota exhaustion"
-import asyncio
-import importlib.util
-import sys
-
-spec = importlib.util.spec_from_file_location(
-    "codex_gate", sys.argv[1] + "/tools/codex-gate/codex_gate.py")
-m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
-m.QUOTA_MAX_WAIT = 0.12
-m.QUOTA_BACKOFF = 0.05
-m.QUOTA_MAX_BACKOFF = 0.05
-calls = 0
-
-async def fail():
-    global calls
-    calls += 1
-    raise m.CodexError("usage limit reached")
-
-async def check():
-    try:
-        await m.run_with_quota_recovery(fail)
-    except m.UsageLimitError:
-        pass
-    else:
-        raise AssertionError("unbounded quota retry returned")
-    assert calls >= 2, calls
-    assert m._last_quota_pause["state"] == "exhausted", m._last_quota_pause
-    assert m._last_quota_pause["duration_seconds"] >= 0.12, m._last_quota_pause
-    assert not m._quota_pauses, m._quota_pauses
-
-    # An operator who has reset quota can wake the same held request instead
-    # of waiting for stale provider reset metadata to expire.
-    m.QUOTA_MAX_WAIT = 5
-    m.QUOTA_BACKOFF = 5
-    m.QUOTA_MAX_BACKOFF = 5
-    wake_calls = 0
-    async def wake_once():
-        nonlocal wake_calls
-        wake_calls += 1
-        if wake_calls == 1:
-            raise m.CodexError("usage limit reached")
-        return "resumed"
-    held = asyncio.create_task(m.run_with_quota_recovery(wake_once))
-    for _ in range(100):
-        if m._quota_pauses:
-            break
-        await asyncio.sleep(0.01)
-    assert m.request_quota_retry() == 1
-    assert await asyncio.wait_for(held, 1) == "resumed"
-    assert wake_calls == 2, wake_calls
-    assert m._last_quota_pause["state"] == "resumed", m._last_quota_pause
-    assert not m._quota_pauses and not m._quota_wakes
-
-    # The campaign control can target a delegated child without spending the
-    # one-shot fault on its parent request.
-    selector = "You are a task execution agent working autonomously."
-    m.MOCK_ERROR = "usage limit reached"
-    m.MOCK_ERROR_COUNT = 1
-    m.MOCK_ERROR_SYSTEM_MATCH = selector
-    m._mock_errors_remaining = 1
-    parent = await m.mock_turn("default", "parent", "create child", [], [])
-    assert parent[0].startswith("MOCK_REPLY:"), parent
-    try:
-        await m.mock_turn("default", selector, "child brief", [], [])
-    except m.CodexError as error:
-        assert "usage limit" in str(error)
-    else:
-        raise AssertionError("selected child mock did not fail")
-    resumed = await m.mock_turn("default", selector, "child brief", [], [])
-    assert resumed[0] == "MOCK_REPLY: child brief", resumed
-
-asyncio.run(check())
-PY
-pass "quota retries are bounded and can target a delegated child"
 
 # 9. The prompt-level tool protocol parses into OpenAI tool_calls
 python3 - "$ROOT" <<'PY' || fail "tool-reply parser"
@@ -389,10 +272,9 @@ assert "-m" not in argv, argv
 PY
 pass "codex exec argv is sandboxed and stdin-fed"
 
-# A CLI that starts a turn and then stops producing events must not consume the
-# rest of a child campaign deadline. The gate kills its whole process group and
-# returns a terminal error while retaining the longer total limit for active
-# extended-reasoning turns.
+# A CLI that starts a turn and then stops producing events must not occupy a
+# process slot indefinitely. The gate kills its whole process group and returns
+# a terminal error while retaining the longer total limit for active turns.
 python3 - "$ROOT" <<'PY' || fail "idle Codex process was not reaped"
 import asyncio
 import importlib.util
@@ -483,10 +365,7 @@ else:
 PY
 pass "startup readiness requires a ChatGPT OAuth login"
 
-# 11. The CLI's own plugin/skill/MCP surface is pinned, not inherited.
-#     Codex CLI 0.149.0 filled a fresh CODEX_HOME (auth.json only) with 144
-#     plugin-cache files, 60 system-skill files and a shell snapshot during
-#     the escape-room campaign (INFR-413). None of it was recorded anywhere.
+# 11. The CLI's own plugin, skill, and MCP surface is pinned, not inherited.
 python3 - "$ROOT" <<'PY' || fail "gateway hardening"
 import importlib.util
 import json
@@ -511,8 +390,8 @@ for feature in ("plugins", "apps", "skill_search", "memories",
                 "shell_snapshot", "shell_tool", "hooks", "multi_agent"):
     assert feature in disabled, (feature, disabled)
 assert disabled == list(m.disabled_features()), (disabled, m.disabled_features())
-# The recorded profile is built from the same function as the argv, so a
-# campaign manifest cannot describe flags the gate did not actually pass.
+# The reported profile is built from the same function as the argv, so it
+# cannot describe flags the gate did not actually pass.
 flags = m.profile_flags()
 assert flags == argv[2:2 + len(flags)], (flags, argv)
 
@@ -553,21 +432,6 @@ with tempfile.TemporaryDirectory() as td:
     assert any("credentials" in v for v in violations), violations
     os.chmod(home, 0o700)
 
-    # The post-campaign inventory accounts for what the CLI created itself.
-    os.makedirs(os.path.join(home, "plugins", "cache"))
-    open(os.path.join(home, "plugins", "cache", "catalog.json"), "w").write("[]")
-    inventory = m.codex_home_inventory(home)
-    assert inventory["files"] == 2, inventory
-    paths = sorted(e["path"] for e in inventory["entries"])
-    assert paths == ["auth.json", "plugins/cache/catalog.json"], paths
-    assert all(len(e["sha256"]) == 64 for e in inventory["entries"]), inventory
-    assert inventory["credential_files"] == 1, inventory
-    assert inventory["persistent_cli_state_files"] == 1, inventory
-    assert inventory["persistent_cli_state"] is True, inventory
-    before = inventory["sha256"]
-    open(os.path.join(home, "plugins", "cache", "catalog.json"), "w").write("[1]")
-    assert m.codex_home_inventory(home)["sha256"] != before
-
 # `codex features list` output → the effective state the manifest records.
 features = m.parse_features(
     "plugins                     stable             false\n"
@@ -575,7 +439,7 @@ features = m.parse_features(
     "web_search                  stable             true\n")
 assert features == {"plugins": False, "shell_tool": False, "web_search": True}, features
 PY
-pass "hardening flags, home preflight and state inventory"
+pass "hardening flags and home preflight"
 
 # 12. The pinned feature names must exist in the installed CLI. This is the
 #     forward-compatibility gate: a renamed flag would otherwise silently stop
@@ -607,15 +471,13 @@ else
     echo "skip: codex CLI not on PATH — pinned feature names not validated"
 fi
 
-# 13. /health carries the pinned profile, so a campaign manifest records the
-#     configuration the trial actually ran under.
+# 13. /health carries the pinned profile for operational verification.
 out="$(curl -sf "$BASE/health")"
 echo "$out" | grep -q '"hardened": true' || fail "health: no hardening flag ($out)"
 echo "$out" | grep -q '"disabled_features"' || fail "health: no feature list ($out)"
 echo "$out" | grep -q '"shell_tool"' || fail "health: shell_tool not pinned ($out)"
 echo "$out" | grep -q '"exec_flags"' || fail "health: no exec flags ($out)"
 echo "$out" | grep -q '"adapter_instructions_sha256"' || fail "health: adapter contract unhashed ($out)"
-echo "$out" | grep -q '"quota_recovery": true' || fail "health: quota recovery not advertised ($out)"
 echo "$out" | grep -q '"session_stateless": true' || fail "health: session statelessness not explicit ($out)"
 pass "health reports the pinned CLI profile"
 

--- a/tools/codex-gate/codex_gate.py
+++ b/tools/codex-gate/codex_gate.py
@@ -33,8 +33,8 @@
 #
 # Consequence worth knowing: CLI SESSIONS are stateless. There is no live CLI
 # session across a tool round-trip — each request is one `codex exec`.
-# In-flight HTTP requests, including quota-paused requests, are not durable
-# across a gateway restart and must be retried by the caller. /health reports
+# In-flight HTTP requests are not durable across a gateway restart and must
+# be retried by the caller. /health reports
 # held_turns for surface parity with claude-gate; it is always 0.
 #
 # Endpoints (bind 127.0.0.1 only — no auth of its own):
@@ -48,8 +48,6 @@
 #   CODEX_GATE_MOCK       "1" = deterministic mock backend (tests; no CLI)
 #   CODEX_GATE_MOCK_ERROR non-empty = fail every mock turn with this message
 #   CODEX_GATE_MOCK_ERROR_COUNT fail this many mock calls (-1 = every call)
-#   CODEX_GATE_MOCK_ERROR_SYSTEM_MATCH only fail mock turns whose system prompt
-#                                      contains this string
 #   CODEX_GATE_BIN        codex binary (default "codex", found on PATH)
 #   CODEX_GATE_MODEL      default model; empty = let the CLI use its own
 #   CODEX_GATE_MODELS     comma-separated list advertised on /v1/models
@@ -57,12 +55,7 @@
 #   CODEX_GATE_IDLE_TIMEOUT seconds with no CLI output before abort (default 300)
 #   CODEX_GATE_HEARTBEAT  seconds between SSE keepalives (default 30)
 #   CODEX_GATE_CONCURRENCY  max simultaneous codex processes (default 4)
-#   CODEX_GATE_QUOTA_MAX_WAIT max seconds to preserve/retry a quota-paused turn
-#                             (default 21600; 0 = return structured 429)
-#   CODEX_GATE_QUOTA_BACKOFF initial retry delay without reset metadata (30)
-#   CODEX_GATE_QUOTA_MAX_BACKOFF maximum fallback retry delay (900)
 #   CODEX_GATE_QUOTA_RESET_GRACE seconds after a minute-precision reset (30)
-#   SIGHUP                    retry quota-paused requests immediately
 #   CODEX_GATE_SANDBOX    --sandbox value (default read-only)
 #   CODEX_GATE_WORKDIR    --cd value (default ~/.cache/codex-gate/workdir)
 #   CODEX_GATE_CODEX_HOME CODEX_HOME for the child (isolates ~/.codex; you
@@ -73,9 +66,6 @@
 #   CODEX_GATE_HARDEN     "0" = do not pin the CLI feature surface (see below)
 #   CODEX_GATE_DISABLE_FEATURES  comma list replacing the pinned disable set
 #   CODEX_GATE_HOME_ALLOW comma list of entries allowed in CODEX_GATE_CODEX_HOME
-#
-# Also: `codex_gate.py --inventory [CODEX_HOME]` prints a hashed inventory of
-# the model-side state the CLI created, and exits.  Run it after a campaign.
 #
 # Billing guard: OPENAI_API_KEY in the environment can make the CLI bill the
 # API instead of the ChatGPT plan.  serve-codex-gate.sh unsets it; we also
@@ -91,7 +81,6 @@ import re
 import shlex
 import signal
 import subprocess
-import sys
 import tempfile
 import time
 import uuid
@@ -105,8 +94,6 @@ PORT = int(os.environ.get("CODEX_GATE_PORT", "11436"))
 MOCK = os.environ.get("CODEX_GATE_MOCK", "") == "1"
 MOCK_ERROR = os.environ.get("CODEX_GATE_MOCK_ERROR", "")
 MOCK_ERROR_COUNT = int(os.environ.get("CODEX_GATE_MOCK_ERROR_COUNT", "-1"))
-MOCK_ERROR_SYSTEM_MATCH = os.environ.get(
-    "CODEX_GATE_MOCK_ERROR_SYSTEM_MATCH", "")
 CODEX_BIN = os.environ.get("CODEX_GATE_BIN", "codex")
 DEFAULT_MODEL = os.environ.get("CODEX_GATE_MODEL", "")
 EXEC_TIMEOUT = max(0.05, float(os.environ.get("CODEX_GATE_TIMEOUT", "900")))
@@ -114,20 +101,10 @@ IDLE_TIMEOUT = max(0.0, float(os.environ.get("CODEX_GATE_IDLE_TIMEOUT", "300")))
 HEARTBEAT = max(0.05, float(os.environ.get("CODEX_GATE_HEARTBEAT", "30")))
 CONCURRENCY = int(os.environ.get("CODEX_GATE_CONCURRENCY", "4"))
 SANDBOX = os.environ.get("CODEX_GATE_SANDBOX", "read-only")
-QUOTA_MAX_WAIT = max(0.0, float(os.environ.get(
-    "CODEX_GATE_QUOTA_MAX_WAIT", "21600")))
-QUOTA_BACKOFF = max(0.05, float(os.environ.get(
-    "CODEX_GATE_QUOTA_BACKOFF", "30")))
-QUOTA_MAX_BACKOFF = max(QUOTA_BACKOFF, float(os.environ.get(
-    "CODEX_GATE_QUOTA_MAX_BACKOFF", "900")))
 QUOTA_RESET_GRACE = max(0.0, float(os.environ.get(
     "CODEX_GATE_QUOTA_RESET_GRACE", "30")))
 
 _mock_errors_remaining = MOCK_ERROR_COUNT
-_quota_pauses = {}
-_quota_wakes = {}
-_last_quota_pause = None
-_home_inventory_cache = None
 
 # Models advertised on /v1/models — what llmsrv's `/mnt/llm/models` and the
 # Settings picker show.  Codex's model lineup moves faster than this file
@@ -171,15 +148,10 @@ PROMPT_ARGV = os.environ.get("CODEX_GATE_PROMPT_ARGV", "") == "1"
 
 # ── pinned CLI feature surface (INFR-413) ──────────────────────────
 #
-# During the escape-room campaign, Codex CLI 0.149.0 populated a fresh 0700
-# CODEX_HOME that held only auth.json with 144 plugin-cache files (~26 MiB,
-# the remote curated catalog included), 60 system-skill files, and a shell
-# snapshot.  Nothing escaped — the CLI ran --sandbox read-only, with its
-# native shell disabled, in an empty working directory on a VM with no target
-# filesystem — but the model was carrying tools and instructions nobody
-# recorded, and the next campaign would carry different ones.  So the gateway
-# pins the surface instead of inheriting whatever the installed CLI defaults
-# to, and reports what it pinned on /health for the campaign manifest.
+# The Codex CLI can discover plugins, skills, configuration, and host tools of
+# its own. This protocol adapter pins that surface rather than inheriting
+# whatever an installed CLI enables by default, and reports the effective
+# configuration on /health.
 #
 # `--disable X` is `-c features.X=false`.  An unknown name is a hard error
 # from the CLI, and that is the point: a build that renames one must fail
@@ -242,7 +214,7 @@ def profile_flags():
     """The invariant, security-relevant part of every `codex exec`.
 
     build_argv() and the /health profile are both built from this, so the
-    flags a campaign records cannot drift from the flags it ran under.
+    reported configuration cannot drift from the flags actually passed.
     """
     flags = ["--sandbox", SANDBOX, "--strict-config"]
     for feature in disabled_features():
@@ -268,62 +240,6 @@ def codex_home_violations(home, allow):
         kind = "directory" if os.path.isdir(os.path.join(home, name)) else "file"
         violations.append("unexpected %s %r" % (kind, name))
     return violations
-
-
-def file_sha256(path):
-    digest = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def codex_home_inventory(home):
-    """Every file under a Codex home, hashed.
-
-    The CLI populates this directory itself while a campaign runs, so an
-    inventory taken afterwards is the only account of what model-side state
-    the trials actually carried.  The top-level `sha256` covers the whole
-    listing, so two campaigns can be compared by one value.
-    """
-    entries = []
-    total = 0
-    for dirpath, dirnames, filenames in os.walk(home):
-        dirnames.sort()
-        for name in sorted(filenames):
-            path = os.path.join(dirpath, name)
-            rel = os.path.relpath(path, home)
-            try:
-                stat = os.stat(path)
-                entries.append({"path": rel, "size": stat.st_size,
-                                "mode": oct(stat.st_mode & 0o777),
-                                "sha256": file_sha256(path)})
-                total += stat.st_size
-            except OSError as e:
-                entries.append({"path": rel, "error": str(e)})
-    listing = "\n".join("%s %s" % (e["path"], e.get("sha256", "unreadable"))
-                        for e in entries)
-    credential_names = {"auth.json", "auth.json.lock"}
-    credential_files = sum(
-        1 for entry in entries if entry["path"].split(os.sep, 1)[0]
-        in credential_names)
-    return {"home": home, "files": len(entries), "bytes": total,
-            "credential_files": credential_files,
-            "persistent_cli_state_files": len(entries) - credential_files,
-            "persistent_cli_state": len(entries) > credential_files,
-            "sha256": hashlib.sha256(listing.encode()).hexdigest(),
-            "entries": entries}
-
-
-def codex_home_summary(home):
-    """Cached inventory summary, invalidated whenever a Codex child exits."""
-    global _home_inventory_cache
-    if _home_inventory_cache is None:
-        _home_inventory_cache = {
-            k: v for k, v in codex_home_inventory(home).items()
-            if k != "entries"
-        }
-    return dict(_home_inventory_cache)
 
 
 def codex_version():
@@ -357,8 +273,8 @@ def effective_features(disabled):
     """Ask the installed CLI what its feature set is under our flags.
 
     Two jobs at once: it validates every pinned name against this build (the
-    CLI errors on one it does not know) and it produces the hashable record
-    the campaign manifest needs.  It evaluates the same CODEX_HOME the child
+    CLI errors on one it does not know) and it produces a hashable record for
+    operators. It evaluates the same CODEX_HOME the child
     will use, so a config.toml smuggled in there would show up here too.
     """
     argv = [CODEX_BIN, "features", "list"]
@@ -382,8 +298,8 @@ def effective_features(disabled):
     return features, hashlib.sha256(canonical.encode()).hexdigest()
 
 
-# Filled in at startup by gate_profile(); reported on /health so a campaign
-# manifest records the CLI version and effective configuration it ran against.
+# Filled in at startup by gate_profile(); reported on /health so operators can
+# verify the CLI version and effective configuration in use.
 PROFILE = {}
 
 
@@ -404,10 +320,6 @@ def gate_profile():
     features, digest = effective_features(disabled_features())
     profile["features_sha256"] = digest
     profile["features_enabled"] = sorted(k for k, on in features.items() if on)
-    home = os.environ.get("CODEX_GATE_CODEX_HOME")
-    if home:
-        profile["codex_home_baseline"] = {
-            k: v for k, v in codex_home_inventory(home).items() if k != "entries"}
     return profile
 
 _sem = None     # asyncio.Semaphore, created on startup
@@ -715,101 +627,6 @@ def quota_error_body(error):
     }}
 
 
-async def run_with_quota_recovery(factory):
-    """Retry one stateless turn without advancing the caller transcript."""
-    global _last_quota_pause
-    turn_id = uuid.uuid4().hex
-    started = None
-    started_at = None
-    retries = 0
-    wake = asyncio.Event()
-    _quota_wakes[turn_id] = wake
-    try:
-        while True:
-            try:
-                if turn_id in _quota_pauses:
-                    _quota_pauses[turn_id]["state"] = "resuming"
-                result = await factory()
-                if started is not None:
-                    finished = dict(_quota_pauses.get(turn_id, {}))
-                    finished.update({
-                        "state": "resumed",
-                        "resumed_at": datetime.datetime.now().astimezone().isoformat(),
-                        "duration_seconds": round(time.monotonic() - started, 3),
-                    })
-                    _last_quota_pause = finished
-                return result
-            except CodexError as error:
-                metadata = quota_metadata(str(error))
-                if metadata is None:
-                    raise
-                qerror = UsageLimitError(str(error), metadata)
-                if QUOTA_MAX_WAIT <= 0:
-                    raise qerror
-                now_mono = time.monotonic()
-                if started is None:
-                    started = now_mono
-                    started_at = datetime.datetime.now().astimezone().isoformat()
-                remaining = QUOTA_MAX_WAIT - (now_mono - started)
-                if remaining <= 0:
-                    exhausted = dict(_quota_pauses.get(turn_id, {}))
-                    exhausted.update({
-                        "state": "exhausted",
-                        "ended_at": datetime.datetime.now().astimezone().isoformat(),
-                        "duration_seconds": round(now_mono - started, 3),
-                    })
-                    _last_quota_pause = exhausted
-                    raise qerror
-                delay = metadata.get("retry_after")
-                if delay is None:
-                    delay = min(QUOTA_BACKOFF * (2 ** min(retries, 20)),
-                                QUOTA_MAX_BACKOFF)
-                delay = min(max(0.05, float(delay)), remaining)
-                retry_at = datetime.datetime.now().astimezone() + \
-                    datetime.timedelta(seconds=delay)
-                state = {
-                    "state": "paused_quota",
-                    "reason": "usage_limit",
-                    "paused_at": started_at,
-                    "retry_at": retry_at.isoformat(),
-                    "retry": retries + 1,
-                }
-                _quota_pauses[turn_id] = state
-                _last_quota_pause = dict(state)
-                log.warning("usage limit; pausing turn %.1fs (retry %d)",
-                            delay, retries + 1)
-                try:
-                    await asyncio.wait_for(wake.wait(), timeout=delay)
-                    wake.clear()
-                    log.warning("operator requested immediate quota retry")
-                except asyncio.TimeoutError:
-                    pass
-                retries += 1
-    finally:
-        _quota_pauses.pop(turn_id, None)
-        _quota_wakes.pop(turn_id, None)
-
-
-def request_quota_retry():
-    """Wake quota-paused requests so they recheck the account immediately."""
-    now = datetime.datetime.now().astimezone().isoformat()
-    woken = 0
-    for turn_id, wake in list(_quota_wakes.items()):
-        pause = _quota_pauses.get(turn_id)
-        if pause is None or pause.get("state") != "paused_quota":
-            continue
-        pause["state"] = "resuming"
-        pause["retry_at"] = now
-        pause["operator_retry_at"] = now
-        wake.set()
-        woken += 1
-    if woken:
-        log.warning("SIGHUP: retrying %d quota-paused turn(s)", woken)
-    else:
-        log.info("SIGHUP: no quota-paused turns to retry")
-    return woken
-
-
 def child_env():
     env = dict(os.environ)
     env.pop("OPENAI_API_KEY", None)      # never bill the API by accident
@@ -927,7 +744,6 @@ def parse_events(stdout):
 
 async def run_codex(model, prompt, schema):
     """One `codex exec`.  Returns (final_text, usage_tokens)."""
-    global _home_inventory_cache
     tmpdir = tempfile.mkdtemp(prefix="codex-gate-")
     schema_path = os.path.join(tmpdir, "schema.json")
     last_path = os.path.join(tmpdir, "last-message.txt")
@@ -959,10 +775,6 @@ async def run_codex(model, prompt, schema):
         except asyncio.CancelledError:
             await kill_process_group(proc)
             raise
-        finally:
-            # The CLI may have changed its isolated home even on failure.
-            _home_inventory_cache = None
-
         stdout = out.decode("utf-8", "replace")
         stderr = err.decode("utf-8", "replace")
         if proc.returncode != 0:
@@ -1113,9 +925,7 @@ async def mock_turn(model, system_prompt, prompt, tooldefs, trailing_tools):
     gate's stateless shape: tool results arrive in the request, not on a
     held turn.  `MOCK_TOOL_CALL <name> <json>` triggers one tool call."""
     global _mock_errors_remaining
-    selected = not MOCK_ERROR_SYSTEM_MATCH or \
-        MOCK_ERROR_SYSTEM_MATCH in system_prompt
-    if MOCK_ERROR and selected and _mock_errors_remaining != 0:
+    if MOCK_ERROR and _mock_errors_remaining != 0:
         if _mock_errors_remaining > 0:
             _mock_errors_remaining -= 1
         raise CodexError(MOCK_ERROR)
@@ -1162,12 +972,10 @@ async def chat_completions(request):
             {"error": {"message": "no user content in messages"}}, status=400)
 
     trailing = [m for m in history if m.get("role") == "tool"]
-    def turn_factory():
-        if MOCK:
-            return mock_turn(model, system_prompt, prompt, tooldefs, trailing)
-        return codex_turn(model, system_prompt, prompt, tooldefs)
-
-    turn = run_with_quota_recovery(turn_factory)
+    if MOCK:
+        turn = mock_turn(model, system_prompt, prompt, tooldefs, trailing)
+    else:
+        turn = codex_turn(model, system_prompt, prompt, tooldefs)
 
     stream_response = None
     task = None
@@ -1192,7 +1000,8 @@ async def chat_completions(request):
             content, calls, usage = await turn
     except CodexError as e:
         log.error("turn failed: %s", e)
-        quota = e if isinstance(e, UsageLimitError) else None
+        metadata = quota_metadata(str(e))
+        quota = UsageLimitError(str(e), metadata) if metadata else None
         if stream_response is not None:
             if quota is not None:
                 await stream_response.write(
@@ -1235,9 +1044,6 @@ async def models(request):
 
 
 async def health(request):
-    states = {pause.get("state") for pause in _quota_pauses.values()}
-    state = ("paused_quota" if "paused_quota" in states else
-             "resuming" if "resuming" in states else "ready")
     body = {
         "status": "ok",
         "backend": "mock" if MOCK else "codex-cli",
@@ -1248,25 +1054,12 @@ async def health(request):
         # but the CLI may still write operational state there between turns.
         "stateless": True,
         "session_stateless": True,
-        "quota_recovery": QUOTA_MAX_WAIT > 0,
         "turn_timeout_seconds": EXEC_TIMEOUT,
         "idle_timeout_seconds": IDLE_TIMEOUT,
-        "state": state,
-        "quota": {
-            "paused_turns": len(_quota_pauses),
-            "retry_at": min((p["retry_at"] for p in _quota_pauses.values()),
-                            default=None),
-            "last_pause": _last_quota_pause,
-            "max_wait_seconds": QUOTA_MAX_WAIT,
-        },
     }
-    # The pinned CLI surface (INFR-413). A campaign records this verbatim, and
-    # the external escape-room harness refuses to start a trial against a
-    # gateway that is not running the profile the scenario asked for.
+    # The pinned CLI surface lets operators verify that the adapter is not
+    # inheriting an uncontrolled set of native Codex tools or instructions.
     body.update(PROFILE)
-    home = os.environ.get("CODEX_GATE_CODEX_HOME")
-    if home and not MOCK:
-        body["codex_home_current"] = codex_home_summary(home)
     return web.json_response(body)
 
 
@@ -1275,18 +1068,6 @@ def main():
         level=logging.DEBUG if os.environ.get("CODEX_GATE_DEBUG") else logging.INFO,
         format="codex-gate: %(levelname)s %(message)s")
 
-    # `codex_gate.py --inventory [HOME]` — the post-campaign account of the
-    # model-side state the CLI created for itself (INFR-413). Not a server
-    # mode; it prints and exits.
-    argv = sys.argv[1:]
-    if argv and argv[0] == "--inventory":
-        home = (argv[1] if len(argv) > 1 else
-                os.environ.get("CODEX_GATE_CODEX_HOME") or
-                os.environ.get("CODEX_HOME") or
-                os.path.expanduser("~/.codex"))
-        print(json.dumps(codex_home_inventory(home), indent=2))
-        return
-
     if os.environ.get("OPENAI_API_KEY") and not MOCK \
             and os.environ.get("CODEX_GATE_ALLOW_API_KEY") != "1":
         raise SystemExit(
@@ -1294,9 +1075,8 @@ def main():
             "instead of your ChatGPT plan. Unset it (serve-codex-gate.sh "
             "does) or set CODEX_GATE_ALLOW_API_KEY=1 to override.")
 
-    # An isolated Codex home is only isolated if nothing else got in. Checked
-    # before the first request, because the CLI populates the directory itself
-    # once one arrives and the baseline is gone (INFR-413).
+    # An isolated Codex home is only isolated if nothing else got in. Check it
+    # before the first request, because the CLI may populate it once serving.
     home = os.environ.get("CODEX_GATE_CODEX_HOME")
     if home and not MOCK:
         violations = codex_home_violations(home, home_allowlist())
@@ -1334,12 +1114,6 @@ def main():
     async def make_sem(app):
         global _sem
         _sem = asyncio.Semaphore(CONCURRENCY)
-        if hasattr(signal, "SIGHUP"):
-            try:
-                asyncio.get_running_loop().add_signal_handler(
-                    signal.SIGHUP, request_quota_retry)
-            except (NotImplementedError, RuntimeError):
-                log.warning("SIGHUP quota retry is unavailable on this platform")
     app.on_startup.append(make_sem)
 
     log.info("listening on http://%s:%d/v1 (%s backend)",

--- a/tools/codex-gate/serve-codex-gate.sh
+++ b/tools/codex-gate/serve-codex-gate.sh
@@ -9,7 +9,6 @@
 # Usage:
 #   serve-codex-gate.sh              # 127.0.0.1:11436, codex CLI backend
 #   serve-codex-gate.sh --mock       # deterministic mock backend (tests)
-#   serve-codex-gate.sh --inventory  # hash the CLI's model-side state, exit
 #   serve-codex-gate.sh --help
 #
 # Auth: the Codex CLI's own login is used — run `codex login` once for this
@@ -29,8 +28,8 @@ case "${1:-}" in
 	--mock) export CODEX_GATE_MOCK=1; shift ;;
 esac
 
-# The umask matters here: a campaign's gateway writes its own logs and the CLI
-# writes into CODEX_HOME, which holds an OAuth credential (INFR-412/413).
+# CODEX_HOME holds an OAuth credential, so files created by the CLI and the
+# gateway must not be group- or world-readable.
 umask 077
 
 if ! command -v "${CODEX_GATE_BIN:-codex}" >/dev/null 2>&1 && [ "${CODEX_GATE_MOCK:-}" != "1" ]; then
@@ -48,6 +47,4 @@ fi
 # Billing guard: an inherited API key can override ChatGPT auth in the CLI.
 unset OPENAI_API_KEY
 
-# Remaining arguments (--inventory [HOME]) go to the gate; the server mode
-# takes none.
 exec "$VENV/bin/python" "$HERE/codex_gate.py" "$@"


### PR DESCRIPTION
## Summary
- return usage limits immediately as structured HTTP 429 and remove gateway-owned multi-hour retry/SIGHUP state
- remove campaign evidence inventory and targeted child fault injection from the product gateway
- preserve process-group cleanup, idle/total deadlines, startup CODEX_HOME allowlisting, strict feature pinning, and safe quota metadata

## Why
Durable campaign recovery and evidence collection belong to infernode-os/escape-room. The product gateway remains a bounded, stateless protocol adapter.

## Tests
- python3 -m py_compile tools/codex-gate/codex_gate.py
- sh -n tests/host/codex_gate_test.sh
- bash -n tools/codex-gate/serve-codex-gate.sh
- tests/host/codex_gate_test.sh: all deterministic tests green; installed-CLI feature check intentionally skipped in offline mode

## Note
The optional installed-CLI check separately found minipc Codex does not recognize plugin_sharing. That pre-existing version mismatch is not changed or hidden by this PR.
