### PR TITLE
fix(lucibridge): bound native tool calls

### DIFF
--- a/appl/cmd/lucibridge.b
+++ b/appl/cmd/lucibridge.b
@@ -71,6 +71,11 @@ MAX_TOOL_FAILURES: con 3;
 lb_failstreak_tool := "";
 lb_failstreak_count := 0;
 
+# A native tool is a 9P request and may block on a faulty backend or special
+# file. Keep the bridge responsive so it can record the failed result and
+# drive the activity to a signed terminal state.
+TOOL_TIMEOUT: con 60000;
+
 # Tool tracking: raw string from /tool/tools; updated when tool set changes
 currenttoolsraw := "";
 toolmount := "/tool";	# "/tool" for activity 0, "/tool.N" for child N
@@ -658,6 +663,34 @@ toolresultstatus(name, content: string): string
 	   (name == "limbo" && agentlib->contains(lower, "status: failed")))
 		return "error";
 	return "success";
+}
+
+calltoolworker(name, args: string, resultch: chan of string)
+{
+	resultch <-= agentlib->calltool(name, args);
+}
+
+tooltimer(timeoutch: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	timeoutch <-= 1;
+}
+
+calltoolbounded(name, args: string): string
+{
+	# Buffered channels let whichever sender loses the alt complete rather than
+	# leaving a timer or a late tool response blocked on its one-shot send.
+	resultch := chan[1] of string;
+	timeoutch := chan[1] of int;
+	spawn calltoolworker(name, args, resultch);
+	spawn tooltimer(timeoutch, TOOL_TIMEOUT);
+	alt {
+	result := <-resultch =>
+		return result;
+	<-timeoutch =>
+		return sys->sprint("error: tool '%s' timed out after %d seconds",
+			name, TOOL_TIMEOUT / 1000);
+	}
 }
 
 # lucibridge is a trusted process outside the activity namespace. The read
@@ -1860,7 +1893,7 @@ agentturn(input: string)
 				}
 				setstatus(nm);
 				log("tool " + name + ": calling with " + string len eargs + " bytes");
-				result := agentlib->calltool(name, eargs);
+				result := calltoolbounded(name, eargs);
 				prov("toolres", sys->sprint("activity=%d agent=%s step=%d tool=%s status=%s",
 					actid, sessionid, step + 1, name, toolresultstatus(nm, result)), array of byte result);
 				agentlib->deduprecord(nm, eargs, result, step);

--- a/tests/host/lucibridge_tool_timeout_test.sh
+++ b/tests/host/lucibridge_tool_timeout_test.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Source pin complementing the behavioral timeout cases in lucibridge_test.b.
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+SRC="$ROOT/appl/cmd/lucibridge.b"
+
+grep -q 'result := calltoolbounded(name, eargs);' "$SRC"
+grep -q 'resultch := chan\[1\] of string;' "$SRC"
+grep -q 'timeoutch := chan\[1\] of int;' "$SRC"
+
+if grep -q 'result := agentlib->calltool(name, eargs);' "$SRC"; then
+	echo "lucibridge_tool_timeout_test: FAIL (agent loop bypasses timeout)" >&2
+	exit 1
+fi
+
+echo "lucibridge_tool_timeout_test: PASS"

--- a/tests/lucibridge_test.b
+++ b/tests/lucibridge_test.b
@@ -21,6 +21,7 @@ implement LucibridgeTest;
 #   - lookuppathperm: permission lookup from path list
 #   - strcontains: list membership check
 #   - toolresultstatus: only direct execution failures taint provenance
+#   - calltoolbounded: a hung tool returns a bounded error
 #   - scratchpaths: trusted backing path and activity-visible path agree
 #
 
@@ -137,6 +138,30 @@ toolresultstatus(name, content: string): string
 	   (name == "limbo" && contains(lower, "status: failed")))
 		return "error";
 	return "success";
+}
+
+tooltimer(timeoutch: chan of int, ms: int)
+{
+	sys->sleep(ms);
+	timeoutch <-= 1;
+}
+
+waittool(name: string, resultch: chan of string, timeoutms: int): string
+{
+	timeoutch := chan[1] of int;
+	spawn tooltimer(timeoutch, timeoutms);
+	alt {
+	result := <-resultch =>
+		return result;
+	<-timeoutch =>
+		return sys->sprint("error: tool '%s' timed out after %dms", name, timeoutms);
+	}
+}
+
+delayedresult(resultch: chan of string, delayms: int, result: string)
+{
+	sys->sleep(delayms);
+	resultch <-= result;
 }
 
 scratchpaths(aid, step: int): (string, string)
@@ -750,6 +775,25 @@ testToolresultstatusEmbeddedExit(t: ref T)
 		"error", "direct limbo failure is an error");
 }
 
+testToolCallReturnsBeforeTimeout(t: ref T)
+{
+	resultch := chan[1] of string;
+	spawn delayedresult(resultch, 1, "ok");
+	t.assertseq(waittool("read", resultch, 1000), "ok",
+		"completed tool result wins before timeout");
+}
+
+testToolCallTimeoutIsError(t: ref T)
+{
+	resultch := chan[1] of string;
+	spawn delayedresult(resultch, 100, "late");
+	result := waittool("grep", resultch, 10);
+	t.assertseq(result, "error: tool 'grep' timed out after 10ms",
+		"hung tool returns bounded error");
+	t.assertseq(toolresultstatus("grep", result), "error",
+		"timeout is recorded as an error result");
+}
+
 testScratchpathsActivityView(t: ref T)
 {
 	(backing, visible) := scratchpaths(17, 3);
@@ -855,6 +899,8 @@ init(nil: ref Draw->Context, args: list of string)
 
 	# provenance and activity scratch regressions
 	run("ToolresultstatusEmbeddedExit", testToolresultstatusEmbeddedExit);
+	run("ToolCallReturnsBeforeTimeout", testToolCallReturnsBeforeTimeout);
+	run("ToolCallTimeoutIsError", testToolCallTimeoutIsError);
 	run("ScratchpathsActivityView", testScratchpathsActivityView);
 
 	if(testing->summary(passed, failed, skipped) > 0)


### PR DESCRIPTION
## Summary

A stalled native 9P tool call currently blocks the Lucifer activity loop indefinitely. The signed audit chain then ends at `toolcall`/`nsrestrict`, without `toolres` or `agentdone`. Bound Lucibridge tool calls at the same 60-second limit already used by Veltro so the failure becomes an explicit error result and the activity can terminate audibly.

## Changes

- run native tool calls through a 60-second timeout
- use buffered one-shot channels so the losing timer or late response sender can exit
- add behavioral success/timeout tests and a production call-site regression pin

## Testing

- [x] `lucibridge_test.dis -v`: 55 passed
- [x] `tests/host/lucibridge_tool_timeout_test.sh`
- [x] `tools/verify-dis-build.sh`: all 964 manifest modules produced
- [x] `tools/verify-sh-exec.sh`: 117 tracked shell tests executable
- [x] Tested on macOS arm64

## Checklist

- [x] Code follows the existing style
- [x] No `.dis` build artifacts committed
- [x] No documentation change required; no file interface changed
- [x] No secrets, API keys, or credentials included

Design principles: no new service, capability, namespace path, protocol, or external dependency is introduced. The change preserves the existing 9P tool boundary and makes its failure auditable.