### PR TITLE
fix(emu): preserve mount boundaries across parent walks (INFR-470)

### DIFF
--- a/emu/port/chan.c
+++ b/emu/port/chan.c
@@ -294,6 +294,35 @@ cnamepush(Cname *n, Chan *mp)
 	n->mlen++;
 }
 
+/*
+ * Record a mount crossed at the current path element.  walk() can discover a
+ * mount either while walking a batch of names or at the start of the next
+ * iteration.  The latter consumes no name, so it belongs in the most recent
+ * slot rather than a new one.  A later crossing at the same element replaces
+ * the earlier one: ".." must undo the mount most recently entered.
+ */
+static Cname*
+cnamecross(Cname *n, Chan *mp)
+{
+	Cname *new;
+	int i;
+
+	if(mp == nil || n->mlen == 0)
+		return n;
+	if(n->r.ref > 1){
+		new = newcname(n->s);
+		mtptcopy(new, n);
+		cnameclose(n);
+		n = new;
+	}
+	i = n->mlen - 1;
+	if(n->mtpt[i] != nil)
+		cclose(n->mtpt[i]);
+	n->mtpt[i] = mp;
+	incref(&mp->r);
+	return n;
+}
+
 void
 cnameclose(Cname *n)
 {
@@ -338,8 +367,17 @@ addelem(Cname *n, char *s)
 		n->s[n->len++] = '/';
 	memmove(n->s+n->len, s, i+1);
 	n->len += i;
-	if(isdotdot(s))
+	if(isdotdot(s)){
 		cleancname(n);
+		/* Drop the child before undomount() examines the parent slot. */
+		if(n->mlen > 1){
+			n->mlen--;
+			if(n->mtpt[n->mlen] != nil){
+				cclose(n->mtpt[n->mlen]);
+				n->mtpt[n->mlen] = nil;
+			}
+		}
+	}
 	return n;
 }
 
@@ -709,9 +747,13 @@ if(m->from == nil){
 }
 
 int
-domount(Chan **cp, Mhead **mp)
+domount(Chan **cp, Mhead **mp, Cname **name)
 {
-	return findmount(cp, mp, (*cp)->type, (*cp)->dev, (*cp)->qid);
+	if(!findmount(cp, mp, (*cp)->type, (*cp)->dev, (*cp)->qid))
+		return 0;
+	if(name != nil)
+		*name = cnamecross(*name, (*mp)->from);
+	return 1;
 }
 
 static int
@@ -779,9 +821,8 @@ undomount(Chan *c, Cname *name)
 		return nc;
 	}
 
-	name->mlen--;
-	nc = name->mtpt[name->mlen];
-	name->mtpt[name->mlen] = nil;
+	nc = name->mtpt[name->mlen-1];
+	name->mtpt[name->mlen-1] = nil;
 	if(nc == nil)
 		return c;	/* no mount crossed at this element — the device's parent is correct */
 	cclose(c);
@@ -870,8 +911,9 @@ walk(Chan **cp, char **names, int nnames, int nomount, int *nerror)
 		}
 
 		if(!dotdot && !nomount && !didmount)
-			if(domount(&c, &mh))
+			if(domount(&c, &mh, &cname)){
 				mflag = mheadflag(mh);
+			}
 
 		type = c->type;
 		dev = c->dev;
@@ -1286,7 +1328,7 @@ namec(char *aname, int amode, int omode, ulong perm)
 	switch(amode){
 	case Aaccess:
 		m = nil;
-		if(!nomount && domount(&c, &m)){
+		if(!nomount && domount(&c, &m, nil)){
 			c = cunique(c);
 			c->mflag = mheadflag(m);
 		}
@@ -1295,7 +1337,7 @@ namec(char *aname, int amode, int omode, ulong perm)
 
 	case Abind:
 		m = nil;
-		if(!nomount && domount(&c, &m)){
+		if(!nomount && domount(&c, &m, nil)){
 			c = cunique(c);
 			c->mflag = mheadflag(m);
 		}
@@ -1312,7 +1354,7 @@ namec(char *aname, int amode, int omode, ulong perm)
 		incref(&cname->r);
 		m = nil;
 		if(!nomount)
-			domount(&c, &m);
+			domount(&c, &m, &cname);
 
 		/* our own copy to open or remove */
 		c = cunique(c);

--- a/emu/port/fns.h
+++ b/emu/port/fns.h
@@ -58,7 +58,7 @@ Walkqid*	devwalk(Chan*, Chan*, char**, int, Dirtab*, int, Devgen*);
 void		disfault(void*, char*);
 void		disinit(void*);
 void		cnamepush(Cname*, Chan*);
-int		domount(Chan**, Mhead**);
+int		domount(Chan**, Mhead**, Cname**);
 void	drawqlock(void);
 void	drawqunlock(void);
 Fgrp*	dupfgrp(Fgrp*);

--- a/tests/host/tools9p_write_exec_view_test.sh
+++ b/tests/host/tools9p_write_exec_view_test.sh
@@ -61,6 +61,13 @@ cat /tool/write/ctl
 echo '@@LIST'
 echo '/tmp/veltro/probe-sdk' > /tool/list/ctl
 cat /tool/list/ctl
+echo '@@BOUNDARY_ROOT'
+echo '/tmp/veltro/probe-sdk/../../..' > /tool/list/ctl
+cat /tool/list/ctl
+echo '@@BOUNDARY_INTERNAL'
+echo '/tmp/veltro/probe-sdk/../../../.veltro-ns' > /tool/list/ctl
+cat /tool/list/ctl
+echo '@@BOUNDARY_DONE'
 echo '@@COMPILE'
 echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/qualification-probe.dis /tmp/veltro/probe-sdk/qualification-probe.b' > /tool/exec/ctl
 cat /tool/exec/ctl
@@ -75,6 +82,14 @@ rc=$?
 case "$rc" in 0|124|137) ;; *) echo "FAIL: driver exited with status $rc"; sed -n '1,40p' "$LOG"; exit 1 ;; esac
 
 out="$(grep -vE '^JIT|sdl3_pre|mounted on' "$LOG")"
+
+boundary="$(printf '%s\n' "$out" | sed -n '/^@@BOUNDARY_ROOT$/,/^@@BOUNDARY_DONE$/p')"
+if printf '%s\n' "$boundary" |
+	grep -Eq '^d[[:space:]]+- (\.veltro-ns|shadow)$'; then
+	echo "FAIL: probe-sdk parent traversal exposed Veltro shadow backing"
+	printf '%s\n' "$boundary"
+	exit 1
+fi
 
 # list must see the written file
 if ! echo "$out" | grep -q 'qualification-probe.b'; then

--- a/tests/veltro_security_test.b
+++ b/tests/veltro_security_test.b
@@ -698,6 +698,7 @@ TRAVERSAL_TMP_CANARY: con "/tmp/veltro-traversal-canary";
 TRAVERSAL_ROOT_CANARY: con "/veltro-traversal-canary-root";
 TRAVERSAL_TMP_ESCAPE: con "/tmp/veltro-traversal-escape";
 TRAVERSAL_ROOT_ESCAPE: con "/veltro-traversal-escape-root";
+TRAVERSAL_PROBE: con "/tmp/veltro/probe-sdk";
 
 testNamespaceTraversalContainment(t: ref T)
 {
@@ -727,6 +728,8 @@ cleanuptraversal()
 	sys->remove(TRAVERSAL_ROOT_CANARY);
 	sys->remove(TRAVERSAL_TMP_ESCAPE);
 	sys->remove(TRAVERSAL_ROOT_ESCAPE);
+	sys->remove(TRAVERSAL_PROBE + "/marker");
+	sys->remove(TRAVERSAL_PROBE);
 }
 
 # Directory entry names at a path, for probes that care about how much is
@@ -745,6 +748,14 @@ lsnames(path: string): list of string
 			names = d[i].name :: names;
 	}
 	return names;
+}
+
+hasname(names: list of string, want: string): int
+{
+	for(; names != nil; names = tl names)
+		if(hd names == want)
+			return 1;
+	return 0;
 }
 
 # Containment must hold for code that is not a Veltro tool. Rooted filesystem
@@ -810,10 +821,12 @@ traversalWorker(result: chan of string)
 	sys->pctl(Sys->FORKNS, nil);
 	createfile(TRAVERSAL_TMP_CANARY);
 	createfile(TRAVERSAL_ROOT_CANARY);
+	mkdirp(TRAVERSAL_PROBE);
+	createfile(TRAVERSAL_PROBE + "/marker");
 
 	caps := ref NsConstruct->Capabilities(
-		"read" :: "write" :: nil, nil, nil, nil, 0 :: 1 :: 2 :: nil,
-		nil, 0, 0, 41003, nil
+		"read" :: "write" :: nil, TRAVERSAL_PROBE :: nil, nil, nil,
+		0 :: 1 :: 2 :: nil, nil, 0, 0, 41003, TRAVERSAL_PROBE :: nil
 	, nil);
 	err := nsconstruct->restrictns(caps);
 	if(err != nil) {
@@ -831,6 +844,8 @@ traversalWorker(result: chan of string)
 		"/tmp/veltro/scratch/../../veltro-traversal-canary",
 		"/tmp/veltro/scratch/../../../veltro-traversal-canary-root",
 		"/tmp/veltro/scratch/../../../../veltro-traversal-canary-root",
+		"/tmp/veltro/probe-sdk/../../veltro-traversal-canary",
+		"/tmp/veltro/probe-sdk/../../../veltro-traversal-canary-root",
 		"/tmp/veltro/../../veltro-traversal-canary",
 		"/dis/lib/../../veltro-traversal-canary-root",
 		"/dis/veltro/../../veltro-traversal-canary-root",
@@ -842,6 +857,9 @@ traversalWorker(result: chan of string)
 			report += sys->sprint("  READ  %s reached a canary outside the namespace\n",
 				reads[i]);
 	}
+	if(hasname(lsnames("/tmp/veltro/probe-sdk/../../.."), ".veltro-ns") ||
+	   hasname(lsnames("/tmp/veltro/probe-sdk/../../../.veltro-ns"), "shadow"))
+		report += "  READ  probe-sdk parent traversal exposed .veltro-ns/shadow\n";
 
 	# Relative resolution after chdir. Plan 9 4e keeps the mount-point stack on
 	# the channel, so a relative walk from the working directory must clamp the
@@ -869,6 +887,7 @@ traversalWorker(result: chan of string)
 	# granted writable view by any traversal.
 	writes := array[] of {
 		"/tmp/veltro/scratch/../../veltro-traversal-escape",
+		"/tmp/veltro/probe-sdk/../../veltro-traversal-escape",
 		"/dis/lib/../../veltro-traversal-escape-root",
 		"/lib/veltro/../../veltro-traversal-escape-root",
 	};


### PR DESCRIPTION
## Security impact

Completes pathname-stack semantics so parent traversal cannot expose Veltro private shadow backing. The prior port omitted final-element mount crossings performed by `open` and removed the wrong stack slot during `..` resolution.

## Changes

- attach `domount` crossings to the current `Cname`
- discard the child slot before undoing a parent mount
- cover the real tools9p writable-overlay namespace
- extend the Veltro traversal matrix for explicit writable grants

## Verification

- regression fails against the pre-fix emulator
- tools9p writable-view integration: PASS
- Veltro security: 37 passed, 1 skipped
- mount clone walk: PASS
- path-heavy emulator suites: PASS
- macOS headless emulator build: PASS

Refs: INFR-470