### PR TITLE
test(veltro): pin baseline namespace boundaries

### DIFF
--- a/appl/veltro/SECURITY.md
+++ b/appl/veltro/SECURITY.md
@@ -361,6 +361,15 @@ The subagent's system prompt comes from `/lib/veltro/agents/{type}.txt`, loaded 
 | Speech preserved | `/n/speech` auto-detected and included in `/n` allowlist |
 | 9P self-mount safe | Root restriction skips `stat()` to avoid deadlock on `/tool` |
 
+The baseline paths above are retained capabilities, not declarations that an
+entire subtree is harmless. `/dev/cons` is an input/output channel, `/prog`
+reveals the current tool process, and `/lib/veltro` contains agent-visible
+prompts and configuration. Installation secrets must never be placed in that
+tree; credentials belong in factotum. The deterministic security suite pins the
+exact `/dev`, `/dis`, `/prog`, and `/lib` top-level views, the granted tool
+module set, protected-key exclusion, and read-only attenuation. Escape-room
+campaign results supplement those checks but do not prove these paths safe.
+
 ## Shell and Exec Access
 
 The `exec` tool and `shellcmds` field both affect what appears in `/dis`:
@@ -510,7 +519,8 @@ Tests cover:
 - `restrictns()` full policy (/dis, /dev, /n, /lib, /tmp, /)
 - `restrictns()` shell access via shellcmds
 - `/prog` is empty for exec both with and without shellcmds
-- `restrictns()` concurrent (race safety)
+- baseline `/dev`, `/dis`, `/prog`, and `/lib` surface and read-only attenuation
+- concurrent live-shadow containment while restricted namespaces coexist
 - `verifyns()` violation detection
 - Audit logging
 - Missing items handled gracefully

--- a/tests/host/tools9p_write_exec_view_test.sh
+++ b/tests/host/tools9p_write_exec_view_test.sh
@@ -55,6 +55,7 @@ Probe: module { init: fn(nil: ref Draw->Context, nil: list of string); };
 init(nil: ref Draw->Context, nil: list of string)
 {
 	sys = load Sys Sys->PATH;
+	sys->sleep(5000);
 	sys->print("INFR434_PROBE_OK");
 }' > /tool/write/ctl
 cat /tool/write/ctl
@@ -72,6 +73,19 @@ echo '@@COMPILE'
 echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/qualification-probe.dis /tmp/veltro/probe-sdk/qualification-probe.b' > /tool/exec/ctl
 cat /tool/exec/ctl
 echo '@@RUN'
+echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl &
+sleep 1
+echo '@@CONCURRENT_BOUNDARY'
+echo '/tmp/veltro/probe-sdk/../../..' > /tool/list/ctl
+cat /tool/list/ctl
+echo '/tmp/veltro/probe-sdk/../../../.veltro-ns' > /tool/list/ctl
+cat /tool/list/ctl
+echo '/tmp/veltro/probe-sdk/../../..' > /tool/list/ctl
+cat /tool/list/ctl
+echo '/tmp/veltro/probe-sdk/../../../.veltro-ns' > /tool/list/ctl
+cat /tool/list/ctl
+echo '@@CONCURRENT_DONE'
+sleep 8
 echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl
 cat /tool/exec/ctl
 echo '@@DRIVEDONE'
@@ -84,10 +98,11 @@ case "$rc" in 0|124|137) ;; *) echo "FAIL: driver exited with status $rc"; sed -
 out="$(grep -vE '^JIT|sdl3_pre|mounted on' "$LOG")"
 
 boundary="$(printf '%s\n' "$out" | sed -n '/^@@BOUNDARY_ROOT$/,/^@@BOUNDARY_DONE$/p')"
-if printf '%s\n' "$boundary" |
+concurrent_boundary="$(printf '%s\n' "$out" | sed -n '/^@@CONCURRENT_BOUNDARY$/,/^@@CONCURRENT_DONE$/p')"
+if printf '%s\n%s\n' "$boundary" "$concurrent_boundary" |
 	grep -Eq '^d[[:space:]]+- (\.veltro-ns|shadow)$'; then
-	echo "FAIL: probe-sdk parent traversal exposed Veltro shadow backing"
-	printf '%s\n' "$boundary"
+	echo "FAIL: serial or concurrent traversal exposed Veltro shadow backing"
+	printf '%s\n%s\n' "$boundary" "$concurrent_boundary"
 	exit 1
 fi
 

--- a/tests/veltro_security_test.b
+++ b/tests/veltro_security_test.b
@@ -758,6 +758,17 @@ hasname(names: list of string, want: string): int
 	return 0;
 }
 
+samenames(got, want: list of string): int
+{
+	for(g := got; g != nil; g = tl g)
+		if(!hasname(want, hd g))
+			return 0;
+	for(w := want; w != nil; w = tl w)
+		if(!hasname(got, hd w))
+			return 0;
+	return 1;
+}
+
 # Containment must hold for code that is not a Veltro tool. Rooted filesystem
 # grants (ADR 0001) confine the tools; they do nothing for a shell command,
 # which resolves paths itself in the process namespace. This is the coverage
@@ -2357,6 +2368,142 @@ testEnvironmentAllowlist(t: ref T)
 		t.error(r);
 }
 
+
+# ============================================================================
+# Baseline capability surface
+# Pins the intentional residual authority in /dev, /dis, /prog and /lib.
+# A campaign PASS is not this contract: these assertions inspect the namespace
+# deterministically and verify that the retained code/config views are read-only.
+# ============================================================================
+testBaselineCapabilitySurface(t: ref T)
+{
+	result := chan of string;
+	parentpid := sys->pctl(0, nil);
+	spawn baselineCapabilityWorker(result, parentpid);
+	r := <-result;
+	if(r != "")
+		t.error(r);
+}
+
+baselineCapabilityWorker(result: chan of string, parentpid: int)
+{
+	selfpid := sys->pctl(Sys->FORKNS, nil);
+	caps := ref NsConstruct->Capabilities(
+		"read" :: nil, nil, nil, nil, 0 :: 1 :: 2 :: nil,
+		nil, 0, 0, -1, nil
+	, nil);
+	err := nsconstruct->restrictns(caps);
+	if(err != nil) {
+		result <-= sys->sprint("restrictns failed: %s", err);
+		return;
+	}
+
+	if(!samenames(lsnames("/dev"), "cons" :: "null" :: "time" :: nil)) {
+		result <-= "/dev contains authority outside cons, null and time";
+		return;
+	}
+	if(!samenames(lsnames("/dis"), "lib" :: "veltro" :: nil)) {
+		result <-= "/dis contains an ungranted top-level executable or tree";
+		return;
+	}
+	if(!samenames(lsnames("/dis/veltro/tools"), "read.dis" :: nil)) {
+		result <-= "/dis/veltro/tools contains an ungranted tool module";
+		return;
+	}
+	if(!samenames(lsnames("/lib"), "certs" :: "veltro" :: nil)) {
+		result <-= "/lib contains a tree outside certs and veltro";
+		return;
+	}
+	if(!samenames(lsnames("/prog"), string selfpid :: nil)) {
+		result <-= "/prog is not restricted to the current tool process";
+		return;
+	}
+	(parentok, nil) := sys->stat(sys->sprint("/prog/%d/ns", parentpid));
+	if(parentok >= 0) {
+		result <-= "/prog exposes the parent namespace";
+		return;
+	}
+
+	readonly := array[] of {
+		"/dev/time",
+		"/dis/veltro/tools/read.dis",
+		"/lib/veltro/system.txt",
+		sys->sprint("/prog/%d/ctl", selfpid),
+	};
+	for(i := 0; i < len readonly; i++) {
+		fd := sys->open(readonly[i], Sys->OWRITE);
+		if(fd != nil) {
+			result <-= "baseline capability accepted a write open: " + readonly[i];
+			return;
+		}
+	}
+
+	(keyok, nil) := sys->stat("/lib/veltro/keys/ns-secret-canary");
+	if(keyok >= 0) {
+		result <-= "/lib/veltro exposes protected key material";
+		return;
+	}
+	result <-= "";
+}
+
+
+# ============================================================================
+# Concurrent live-shadow containment
+# Every worker holds its completed restricted namespace at a barrier, ensuring
+# other workers' physical shadow trees are live during direct and parent-walk
+# probes. This covers the concurrency condition absent from the INFR-470 serial
+# traversal regression.
+# ============================================================================
+testConcurrentShadowContainment(t: ref T)
+{
+	nworkers := 4;
+	mkdirp(TRAVERSAL_PROBE);
+	createfile(TRAVERSAL_PROBE + "/marker");
+	ready := chan of int;
+	probe := chan[nworkers] of int;
+	results := chan of string;
+	for(i := 0; i < nworkers; i++)
+		spawn concurrentShadowWorker(ready, probe, results, 42000 + i);
+	for(i = 0; i < nworkers; i++)
+		<-ready;
+	for(i = 0; i < nworkers; i++)
+		probe <-= 1;
+	for(i = 0; i < nworkers; i++) {
+		r := <-results;
+		if(r != "")
+			t.error(r);
+	}
+	sys->remove(TRAVERSAL_PROBE + "/marker");
+	sys->remove(TRAVERSAL_PROBE);
+}
+
+concurrentShadowWorker(ready, probe: chan of int, results: chan of string,
+	actid: int)
+{
+	sys->pctl(Sys->FORKNS, nil);
+	caps := ref NsConstruct->Capabilities(
+		"read" :: nil, TRAVERSAL_PROBE :: nil, nil, nil,
+		0 :: 1 :: 2 :: nil, nil, 0, 0, actid, nil
+	, nil);
+	err := nsconstruct->restrictns(caps);
+	if(err != nil) {
+		ready <-= 1;
+		results <-= sys->sprint("restrictns failed: %s", err);
+		return;
+	}
+	ready <-= 1;
+	<-probe;
+
+	if(hasname(lsnames("/tmp"), ".veltro-ns") ||
+	   hasname(lsnames("/tmp/.veltro-ns"), "shadow") ||
+	   hasname(lsnames(TRAVERSAL_PROBE + "/../../.."), ".veltro-ns") ||
+	   hasname(lsnames(TRAVERSAL_PROBE + "/../../../.veltro-ns"), "shadow")) {
+		results <-= "concurrent restricted worker exposed live shadow backing";
+		return;
+	}
+	results <-= "";
+}
+
 environmentAllowlistWorker(result: chan of string)
 {
 	sys->pctl(Sys->FORKNS, nil);
@@ -2545,6 +2692,8 @@ init(nil: ref Draw->Context, args: list of string)
 	run("ExecTraversalContainment", testExecTraversalContainment);
 	run("NetworkCapability", testNetworkCapability);
 	run("EnvironmentAllowlist", testEnvironmentAllowlist);
+	run("BaselineCapabilitySurface", testBaselineCapabilitySurface);
+	run("ConcurrentShadowContainment", testConcurrentShadowContainment);
 	run("ProgAllowlist", testProgAllowlist);
 	run("ExecProgAllowlist", testExecProgAllowlist);
 	run("ExecShellProgAllowlist", testExecShellProgAllowlist);


### PR DESCRIPTION
## Summary

Replace confidence inferred from stochastic escape-room results with deterministic product tests for the retained Veltro namespace surface. This also closes the concurrent-reproduction gap left after the INFR-470 serial pathname regression.

## Changes

- Assert exact minimal-tool views for `/dev`, `/dis`, `/dis/veltro/tools`, `/prog`, and `/lib`.
- Assert read-only attenuation for the clock, granted tool bytecode, Veltro configuration, and the current process control file.
- Hold four restricted namespaces at a barrier and probe direct and parent-walk paths while all physical shadow trees coexist.
- Extend the real `tools9p` integration test with a long-running exec request while repeated list requests probe for `.veltro-ns`.
- Document that baseline paths are retained capabilities, not a blanket safety claim.

Refs INFR-470.

## Testing

- [x] `veltro_security_test.dis -v`: 39 passed, 1 unrelated `/n/local` skip
- [x] `veltro_security_test.dis` repeated 50 times
- [x] `tests/host/tools9p_write_exec_view_test.sh`
- [x] `tests/host/devfs_fsinfo_init_test.sh`
- [x] `tools/verify-dis-build.sh`: all 964 modules
- [x] New tests added
- [x] Tested on: macOS arm64, headless emulator

## Checklist

- [x] Code follows the existing style of the files modified
- [x] No `.dis` build artifacts committed
- [x] Documentation updated
- [x] No secrets, API keys, credentials, or local configuration included

Design principles:

- [x] Access restriction remains namespace shape; this PR adds verification and changes no capability policy
- [x] Inferno-side code remains rc/Limbo idiomatic
- [x] No new service, tool, protocol, external download, or agent-facing effect