### PR TITLE
test(veltro): make live-shadow regression portable

### DIFF
--- a/tests/host/tools9p_write_exec_view_test.sh
+++ b/tests/host/tools9p_write_exec_view_test.sh
@@ -45,7 +45,9 @@ rm -r /tmp/veltro/probe-sdk /tmp/veltro/cow >[2] /dev/null
 mkdir -p /tmp/veltro/probe-sdk/dis
 cp /dis/limbo.dis /tmp/veltro/probe-sdk/dis/limbo.dis
 cp -r /module /tmp/veltro/probe-sdk/module
-tools9p -a 1 -p /tmp/veltro/probe-sdk:rw write list read exec & sleep 2
+tools9p -a 1 -p /tmp/veltro/probe-sdk:rw write list read exec &
+tools9p -m /tool.hold -a 2 -p /tmp/veltro/probe-sdk:rw exec &
+sleep 2
 echo '/tmp/veltro/probe-sdk/qualification-probe.b
 implement Probe;
 include "sys.m";
@@ -73,7 +75,7 @@ echo '@@COMPILE'
 echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/qualification-probe.dis /tmp/veltro/probe-sdk/qualification-probe.b' > /tool/exec/ctl
 cat /tool/exec/ctl
 echo '@@RUN'
-echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl &
+echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool.hold/exec/ctl &
 sleep 1
 echo '@@CONCURRENT_BOUNDARY'
 echo '/tmp/veltro/probe-sdk/../../..' > /tool/list/ctl
@@ -85,7 +87,7 @@ cat /tool/list/ctl
 echo '/tmp/veltro/probe-sdk/../../../.veltro-ns' > /tool/list/ctl
 cat /tool/list/ctl
 echo '@@CONCURRENT_DONE'
-sleep 8
+sleep 6
 echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl
 cat /tool/exec/ctl
 echo '@@DRIVEDONE'

--- a/tests/host/tools9p_write_exec_view_test.sh
+++ b/tests/host/tools9p_write_exec_view_test.sh
@@ -57,8 +57,19 @@ Probe: module { init: fn(nil: ref Draw->Context, nil: list of string); };
 init(nil: ref Draw->Context, nil: list of string)
 {
 	sys = load Sys Sys->PATH;
-	sys->sleep(5000);
 	sys->print("INFR434_PROBE_OK");
+}' > /tool/write/ctl
+cat /tool/write/ctl
+echo '/tmp/veltro/probe-sdk/shadow-hold-probe.b
+implement ShadowHoldProbe;
+include "sys.m";
+	sys: Sys;
+include "draw.m";
+ShadowHoldProbe: module { init: fn(nil: ref Draw->Context, nil: list of string); };
+init(nil: ref Draw->Context, nil: list of string)
+{
+	sys = load Sys Sys->PATH;
+	sys->sleep(60000);
 }' > /tool/write/ctl
 cat /tool/write/ctl
 echo '@@LIST'
@@ -74,8 +85,10 @@ echo '@@BOUNDARY_DONE'
 echo '@@COMPILE'
 echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/qualification-probe.dis /tmp/veltro/probe-sdk/qualification-probe.b' > /tool/exec/ctl
 cat /tool/exec/ctl
+echo '/tmp/veltro/probe-sdk/dis/limbo.dis -I /tmp/veltro/probe-sdk/module -o /tmp/veltro/probe-sdk/shadow-hold-probe.dis /tmp/veltro/probe-sdk/shadow-hold-probe.b' > /tool/exec/ctl
+cat /tool/exec/ctl
 echo '@@RUN'
-echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool.hold/exec/ctl &
+echo '/tmp/veltro/probe-sdk/shadow-hold-probe.dis' > /tool.hold/exec/ctl &
 sleep 1
 echo '@@CONCURRENT_BOUNDARY'
 echo '/tmp/veltro/probe-sdk/../../..' > /tool/list/ctl
@@ -87,7 +100,6 @@ cat /tool/list/ctl
 echo '/tmp/veltro/probe-sdk/../../../.veltro-ns' > /tool/list/ctl
 cat /tool/list/ctl
 echo '@@CONCURRENT_DONE'
-sleep 6
 echo '/tmp/veltro/probe-sdk/qualification-probe.dis' > /tool/exec/ctl
 cat /tool/exec/ctl
 echo '@@DRIVEDONE'


### PR DESCRIPTION
## Summary

Fix the Linux deadlock in the concurrent live-shadow test merged in PR #601. The test now uses a dedicated long-lived module and a separate `tools9p` mount to hold one real worker shadow live while the primary mount probes the namespace and performs the existing fast compile/run qualification.

This changes test infrastructure only. Namespace policy and runtime enforcement are unchanged.

## Testing

- [x] `sh -n tests/host/tools9p_write_exec_view_test.sh`
- [x] `tests/host/tools9p_write_exec_view_test.sh` on Linux amd64: PASS
- [x] Concurrent probes observed only the restricted root; `.veltro-ns` remained absent
- [x] Final write/compile/execute marker completed

## Checklist

- [x] No `.dis` artifacts committed
- [x] No campaign evidence, credentials, endpoints, or local configuration included
- [x] No product capability change