### PR TITLE
fix(codex-gate): classify transient model capacity

### DIFF
--- a/docs/CODEX-GATE.md
+++ b/docs/CODEX-GATE.md
@@ -79,6 +79,15 @@ All endpoints bind `127.0.0.1` only.
 | `/v1/models` | GET | Advertised model ids — what llmsrv's `/mnt/llm/models` and the Settings picker show. Set with `CODEX_GATE_MODELS`; whatever a request names is passed straight to `codex -m`, so the list is a convenience, not a whitelist. |
 | `/health` | GET | Liveness + gauges. |
 
+Trusted CLI failures are never returned as assistant prose when the caller can
+act on them safely. Account exhaustion is a structured HTTP 429
+`usage_limit`; transient model saturation is a structured HTTP 503
+`model_capacity`. Streaming requests receive the same error object as an SSE
+`data:` record followed by `[DONE]`. Both carry `retryable: true`; callers may
+retry only under their own bounded policy and must preserve the original
+request. Text merely resembling either error in a successful model reply is
+ordinary untrusted assistant output.
+
 `/health` response:
 
 ```json

--- a/tests/host/codex_gate_test.sh
+++ b/tests/host/codex_gate_test.sh
@@ -230,6 +230,62 @@ if echo "$stream_error" | grep -q '"content"'; then
 fi
 pass "streaming usage-limit error is not assistant content"
 
+# A transient capacity failure is also structured at the trusted CLI boundary.
+# It must not become an ordinary successful assistant reply, which would make
+# callers unable to distinguish it safely from model-authored prose.
+CAPACITY_PORT=$((PORT+3))
+CODEX_GATE_MOCK=1 \
+CODEX_GATE_MOCK_ERROR='Selected model is at capacity. Please try a different model.' \
+CODEX_GATE_MOCK_ERROR_COUNT=2 CODEX_GATE_PORT=$CAPACITY_PORT \
+    python3 "$GATE" >/dev/null 2>&1 &
+CAPACITY_PID=$!
+trap 'kill $GATE_PID $ERROR_PID $CAPACITY_PID 2>/dev/null || true; rm -f "$ERROR_BODY"' EXIT
+i=0
+while ! curl -sf -m 1 "http://127.0.0.1:$CAPACITY_PORT/health" >/dev/null 2>&1; do
+    i=$((i+1))
+    [ $i -lt 30 ] || fail "capacity gate did not come up on :$CAPACITY_PORT"
+    sleep 0.2
+done
+status="$(curl -s -o "$ERROR_BODY" -w '%{http_code}' \
+    "http://127.0.0.1:$CAPACITY_PORT/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"default","messages":[{"role":"user","content":"hello"}]}')"
+[ "$status" = 503 ] || fail "capacity injection returned HTTP $status"
+grep -q '"type": "model_capacity"' "$ERROR_BODY" || \
+    fail "capacity injection lost structured type"
+grep -q '"retryable": true' "$ERROR_BODY" || \
+    fail "capacity injection is not marked retryable"
+if grep -q 'Please try a different model' "$ERROR_BODY"; then
+    fail "raw provider capacity text escaped into the response"
+fi
+stream_capacity="$(curl -sf --no-buffer \
+    "http://127.0.0.1:$CAPACITY_PORT/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"default","stream":true,"messages":[{"role":"user","content":"hello"}]}')"
+echo "$stream_capacity" | grep -q '"type": "model_capacity"' || \
+    fail "streaming capacity failure lost structured error ($stream_capacity)"
+if echo "$stream_capacity" | grep -q '"content"'; then
+    fail "streaming capacity failure was emitted as assistant content"
+fi
+kill "$CAPACITY_PID" 2>/dev/null || true
+wait "$CAPACITY_PID" 2>/dev/null || true
+pass "model-capacity failures are structured and retryable"
+
+python3 - "$ROOT" <<'PY' || fail "capacity classifier"
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location(
+    "codex_gate", sys.argv[1] + "/tools/codex-gate/codex_gate.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+assert m.capacity_metadata(
+    "Selected model is at capacity. Please try a different model.") == {
+        "reason": "model_capacity", "retryable": True}
+assert m.capacity_metadata("worker pool is at capacity") is None
+assert m.capacity_metadata("model returned a capacity report") is None
+PY
+pass "capacity classifier is narrow"
+
 # 9. The prompt-level tool protocol parses into OpenAI tool_calls
 python3 - "$ROOT" <<'PY' || fail "tool-reply parser"
 import sys, importlib.util

--- a/tools/codex-gate/codex_gate.py
+++ b/tools/codex-gate/codex_gate.py
@@ -576,6 +576,12 @@ class UsageLimitError(CodexError):
         self.metadata = metadata or {}
 
 
+class ModelCapacityError(CodexError):
+    def __init__(self, message, metadata=None):
+        super().__init__(message)
+        self.metadata = metadata or {}
+
+
 def quota_metadata(message, now=None):
     """Return safe retry metadata for a Codex account limit, or None.
 
@@ -615,6 +621,19 @@ def quota_metadata(message, now=None):
     return metadata
 
 
+def capacity_metadata(message):
+    """Return safe retry metadata for a transient model-capacity failure.
+
+    Classification happens only on an error reported by the trusted Codex CLI
+    process. Assistant output is never passed here, so model prose cannot ask
+    callers to replay a request.
+    """
+    lower = message.lower()
+    if not re.search(r"\b(selected\s+)?model\s+is\s+at\s+capacity\b", lower):
+        return None
+    return {"reason": "model_capacity", "retryable": True}
+
+
 def quota_error_body(error):
     metadata = dict(getattr(error, "metadata", {}) or {})
     metadata.setdefault("reason", "usage_limit")
@@ -623,6 +642,18 @@ def quota_error_body(error):
         "message": "codex-gate: account usage limit reached",
         "type": "usage_limit",
         "code": "usage_limit",
+        **metadata,
+    }}
+
+
+def capacity_error_body(error):
+    metadata = dict(getattr(error, "metadata", {}) or {})
+    metadata.setdefault("reason", "model_capacity")
+    metadata.setdefault("retryable", True)
+    return {"error": {
+        "message": "codex-gate: selected model is temporarily at capacity",
+        "type": "model_capacity",
+        "code": "model_capacity",
         **metadata,
     }}
 
@@ -1002,6 +1033,10 @@ async def chat_completions(request):
         log.error("turn failed: %s", e)
         metadata = quota_metadata(str(e))
         quota = UsageLimitError(str(e), metadata) if metadata else None
+        capacity = None
+        if quota is None:
+            metadata = capacity_metadata(str(e))
+            capacity = ModelCapacityError(str(e), metadata) if metadata else None
         if stream_response is not None:
             if quota is not None:
                 await stream_response.write(
@@ -1009,10 +1044,18 @@ async def chat_completions(request):
                     b"\n\ndata: [DONE]\n\n")
                 await stream_response.write_eof()
                 return stream_response
+            if capacity is not None:
+                await stream_response.write(
+                    b"data: " + json.dumps(capacity_error_body(capacity)).encode() +
+                    b"\n\ndata: [DONE]\n\n")
+                await stream_response.write_eof()
+                return stream_response
             return await respond(request, model, "ERROR: codex-gate: %s" % e,
                                  [], 0, True, stream_response)
         if quota is not None:
             return web.json_response(quota_error_body(quota), status=429)
+        if capacity is not None:
+            return web.json_response(capacity_error_body(capacity), status=503)
         return web.json_response(
             {"error": {"message": "codex-gate: %s" % e, "type": "gate_error"}},
             status=502)


### PR DESCRIPTION
## Summary

Codex CLI can report `Selected model is at capacity` as a trusted process error. The gateway currently turns that streaming failure into ordinary assistant content, so an OpenAI-compatible caller cannot distinguish transient infrastructure failure from model-authored prose and must discard the run.

Return a structured, retryable `model_capacity` error at the existing HTTP gateway boundary. This is general gateway correctness and does not add campaign-specific behavior to InferNode; retry policy remains entirely caller-owned.

## Changes

- classify only the narrow trusted CLI model-capacity error shape
- return HTTP 503 for non-streaming requests and a top-level SSE error record for streaming requests
- redact raw provider text from the client-facing error
- document the structured error contract
- cover HTTP, SSE, redaction, and classifier false positives in mock mode

## Testing

- [x] `tests/host/codex_gate_test.sh`
- [x] New model-free tests added
- [x] Tested on macOS host with Python/aiohttp
- [ ] `/tests/runner.dis -v` (not applicable: no Limbo or emulator change)

## Checklist

- [x] Code follows the existing style of the files modified
- [x] No `.dis` build artifacts committed
- [x] Documentation updated
- [x] No secrets, API keys, credentials, endpoints, or campaign evidence included

Design-principles checklist: this changes the error semantics of an existing host-side HTTP adapter. It adds no 9P interface, namespace authority, Inferno-side script, credentialed action, download, service, or tool, so the remaining design-principles items are not applicable.
