### PR TITLE
ci(scorecard): read protection with the default token, not an expiring PAT

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,8 +32,12 @@ jobs:
         results_format: sarif
         # Publish results to the repository's Security tab
         publish_results: true
-        # Fine-grained PAT with admin:read to check branch protection
-        repo_token: ${{ secrets.SCORECARD_TOKEN }}
+        # No repo_token: it defaults to ${{ github.token }}, which suffices here.
+        # A PAT is only required to read *classic* branch protection. master is
+        # protected by the `protect-master` ruleset instead, and rulesets are
+        # readable with the default token — so the PAT this used to pass
+        # (SCORECARD_TOKEN) was vestigial after that migration, and once it
+        # expired it failed the whole job with "401 Bad credentials".
 
     - name: Upload Scorecard SARIF
       uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v3


### PR DESCRIPTION
## Summary

The OSSF Scorecard job has failed on **every** push to master since its PAT
expired. The error is not a scoring failure, it's an auth failure before the
scan starts:

```
scorecard had an error: repo unreachable:
GET https://api.github.com/repos/infernode-os/infernode: 401 Bad credentials
```

`SCORECARD_TOKEN` was last set 2026-04-12, consistent with a fine-grained PAT
that has since hit its expiry.

## Why remove it rather than rotate it

- `repo_token` is **optional** in `ossf/scorecard-action` and defaults to
  `${{ github.token }}`. Upstream calls the default token "our recommended
  approach".
- A PAT is required only to read **classic** Branch Protection. This repo has
  none — `GET /repos/infernode-os/infernode/branches/master/protection`
  returns `404 Branch not protected`.
- master is protected by the **`protect-master` ruleset** (`pull_request`,
  `required_status_checks`, `deletion`, `non_fast_forward`), and upstream
  documents rulesets as readable with the default `GITHUB_TOKEN` — they
  explicitly recommend migrating to rulesets so no admin PAT is needed.

So the PAT went vestigial the moment this repo moved to a ruleset, and the
stale comment next to it ("Fine-grained PAT with admin:read to check branch
protection") no longer described reality. Rotating it would re-arm the same
outage at the next expiry; removing it ends the class of failure and drops a
credential we don't need.

**This weakens nothing.** The ruleset is untouched. The Branch-Protection
check currently contributes *nothing*, because the run dies at authentication
— reading the ruleset with the default token is strictly more coverage than a
job that 401s.

## Changes

- Drop `repo_token: ${{ secrets.SCORECARD_TOKEN }}` from
  `.github/workflows/scorecard.yml`, falling back to the default
  `${{ github.token }}`.
- Replace the stale comment with why no PAT is required here.

Job permissions are unchanged and still cover what Scorecard needs with the
default token (`contents: read`, `actions: read`, `security-events: write`,
`id-token: write`), and the workflow still has no top-level `env`/`defaults`,
which the publish API rejects.

`SCORECARD_TOKEN` can be deleted from repo secrets once this lands — it is
referenced in exactly one place in the tree, this line.

## Testing

- [x] Tests pass (`/tests/runner.dis -v`) — n/a, CI config only; no product
      code touched
- [ ] New tests added (if applicable) — n/a
- [x] Tested on: YAML parsed and asserted locally (inputs now
      `results_file`, `results_format`, `publish_results`; permissions intact).
      Real verification is the next push to master, since this workflow only
      triggers on `push: master` and the weekly schedule.

## Checklist

- [x] Code follows the existing style of the file(s) modified
- [x] No `.dis` build artifacts committed from `appl/` or `tests/`
- [x] Documentation updated (if applicable) — the inline comment is the doc
- [x] No secrets, API keys, or credentials included

Design principles — none apply; CI configuration only, no interface, service,
or namespace change.

Generated with [Devin](https://devin.ai)
