### PR TITLE
chore: ignore runtime namespace residue and host-tool bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,23 @@ test-output.txt
 .claude/settings.local.json
 .claude/worktrees/
 
+# Runtime namespace residue. Running `emu -r$PWD` makes the repo root the
+# Inferno root, so 9P services mounted during a session leave their file
+# names behind on the host as empty stubs (/llm/ctl, /n/wallet/accounts,
+# /phone/sms, ...). They are recreated by the next boot. Ignore the
+# service trees, not the mount points themselves: n/ is tracked via
+# n/.gitkeep because a bind target has to exist.
+/llm/
+/phone/
+/n/*
+!/n/.gitkeep
+# scap(1) writes this beside the image it captured.
+/scap.status
+
+# Python bytecode from the host-side tooling (codex-gate, harness scripts).
+__pycache__/
+*.pyc
+
 # Veltro API keys (secrets)
 lib/veltro/keys/
 


### PR DESCRIPTION
## Summary

`git status` in a working tree that has actually *run* InferNode was full of
untracked noise, which buries real changes. Running `emu -r$PWD` makes the repo
root the Inferno root, so every 9P service mounted during a session leaves its
file names behind on the host as empty stubs:

```
?? llm/          (status, ctl)
?? n/git/        (ctl)
?? n/wallet/     (alice/ctl, accounts, new/session, ctl)
?? n/web/        (clone)
?? n/wikia/      (status, ctl)
?? phone/        (sms)
?? scap.status
?? tools/codex-gate/__pycache__/
?? tests/agent-harness/__pycache__/
```

None of it is authored content: the stubs are recreated by the next boot, and a
fresh clone has none of them yet boots fine.

## Changes

- Ignore `/llm/`, `/phone/`, `/n/*` and `/scap.status`.
- **Ignore the service trees, not the mount points.** `n/` stays tracked via
  `n/.gitkeep`, because a bind target has to exist — hence `/n/*` plus a
  `!/n/.gitkeep` negation. `n/local/` already had its own rule; `/n/*`
  generalises it.
- Ignore `__pycache__/` and `*.pyc` from the host-side Python tooling
  (codex-gate, the out-of-tree harness). Worth noting: a stale
  `tests/agent-harness/__pycache__/` was the *only* thing left in a directory
  #585 deliberately removed from the tree — and that path is exactly what the
  CI ring-fence job guards against.

## Testing

The footgun with a change like this is silently shadowing a tracked file, so I
measured it rather than assuming:

```
tracked-but-ignored files, without these rules: 33
tracked-but-ignored files, with    these rules: 33
```

Identical — all 33 are pre-existing `emu/*/emu.c`-style generated files from
older rules. No path matching the new patterns appears in that set, and
`git check-ignore n/.gitkeep` correctly reports it as *not* ignored.

- [x] Tests pass (`/tests/runner.dis -v`) — n/a, no code touched
- [ ] New tests added (if applicable) — n/a
- [x] Tested on: macOS arm64 — `git status` now shows only real changes

## Checklist

- [x] Code follows the existing style of the file(s) modified
- [x] No `.dis` build artifacts committed from `appl/` or `tests/`
- [x] Documentation updated (if applicable) — the inline comment explains why
      the mount point is kept while its contents are ignored
- [x] No secrets, API keys, or credentials included

Design principles — none apply; ignore rules only. Note the rules are
deliberately anchored (`/llm/`, not `llm/`) so they match the namespace roots
at the repo root and cannot silently swallow a future `appl/.../phone/`
directory.

Generated with [Devin](https://devin.ai)
